### PR TITLE
Adding support for configurable timeouts on requests

### DIFF
--- a/acceptance/export_installation_test.go
+++ b/acceptance/export_installation_test.go
@@ -105,5 +105,24 @@ var _ = Describe("export-installation command", func() {
 				Eventually(session.Out, 5).Should(gbytes.Say("request failed: cannot write to output file: open"))
 			})
 		})
+		Context("when the request takes longer than specified timeout", func() {
+			It("returns an error", func() {
+				command := exec.Command(pathToMain,
+					"--target", server.URL,
+					"--username", "some-username",
+					"--password", "some-password",
+					"--skip-ssl-validation",
+					"--request-timeout", "1",
+					"export-installation",
+					"--output-file", outputFileName,
+				)
+
+				session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
+				Expect(err).NotTo(HaveOccurred())
+
+				Eventually(session, 3).Should(gexec.Exit(1))
+				Eventually(session.Out, 3).Should(gbytes.Say(`.*request canceled \(Client\.Timeout exceeded while awaiting headers\)`))
+			})
+		})
 	})
 })

--- a/acceptance/help_test.go
+++ b/acceptance/help_test.go
@@ -19,6 +19,7 @@ Usage: om [options] <command> [<args>]
   -u, --username             string  admin username for the Ops Manager VM (not required for unauthenticated commands)
   -p, --password             string  admin password for the Ops Manager VM (not required for unauthenticated commands)
   -k, --skip-ssl-validation  bool    skip ssl certificate validation during http requests (default: false)
+  -r, --request-timeout      int     timeout in seconds for HTTP requests to Ops Manager (default: 1800)
 
 Commands:
   apply-changes             triggers an install on the Ops Manager targeted
@@ -45,6 +46,7 @@ Usage: om [options] configure-authentication [<args>]
   -u, --username             string  admin username for the Ops Manager VM (not required for unauthenticated commands)
   -p, --password             string  admin password for the Ops Manager VM (not required for unauthenticated commands)
   -k, --skip-ssl-validation  bool    skip ssl certificate validation during http requests (default: false)
+  -r, --request-timeout      int     timeout in seconds for HTTP requests to Ops Manager (default: 1800)
 
 Command Arguments:
   -u, --username                string  admin username

--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/pivotal-cf/om/formcontent"
 	"github.com/pivotal-cf/om/network"
 	"github.com/pivotal-cf/om/progress"
+	"time"
 )
 
 var version = "unknown"
@@ -33,6 +34,7 @@ func main() {
 		Username          string `short:"u" long:"username"            description:"admin username for the Ops Manager VM (not required for unauthenticated commands)"`
 		Password          string `short:"p" long:"password"            description:"admin password for the Ops Manager VM (not required for unauthenticated commands)"`
 		SkipSSLValidation bool   `short:"k" long:"skip-ssl-validation" description:"skip ssl certificate validation during http requests" default:"false"`
+		RequestTimeout    int	 `short:"r" long:"request-timeout"     description:"timeout in seconds for HTTP requests to Ops Manager" default:"1800"`
 	}
 
 	args, err := flags.Parse(&global, os.Args[1:])
@@ -62,9 +64,11 @@ func main() {
 		command = "help"
 	}
 
-	unauthenticatedClient := network.NewUnauthenticatedClient(global.Target, global.SkipSSLValidation)
+	requestTimeout := time.Duration(global.RequestTimeout) * time.Second
 
-	authedClient, err := network.NewOAuthClient(global.Target, global.Username, global.Password, global.SkipSSLValidation)
+	unauthenticatedClient := network.NewUnauthenticatedClient(global.Target, global.SkipSSLValidation, requestTimeout)
+
+	authedClient, err := network.NewOAuthClient(global.Target, global.Username, global.Password, global.SkipSSLValidation, requestTimeout)
 	if err != nil {
 		stdout.Fatal(err)
 	}

--- a/network/oauth_client.go
+++ b/network/oauth_client.go
@@ -19,9 +19,10 @@ type OAuthClient struct {
 	password    string
 	target      string
 	client      *http.Client
+	timeout     time.Duration
 }
 
-func NewOAuthClient(target, username, password string, insecureSkipVerify bool) (OAuthClient, error) {
+func NewOAuthClient(target, username, password string, insecureSkipVerify bool, requestTimeout time.Duration) (OAuthClient, error) {
 	conf := &oauth2.Config{
 		ClientID:     "opsman",
 		ClientSecret: "",
@@ -39,9 +40,7 @@ func NewOAuthClient(target, username, password string, insecureSkipVerify bool) 
 				Timeout:   5 * time.Second,
 				KeepAlive: 30 * time.Second,
 			}).Dial,
-			ResponseHeaderTimeout: 15 * time.Minute,
 		},
-		Timeout: 30 * time.Minute,
 	}
 
 	insecureContext := context.Background()
@@ -54,6 +53,7 @@ func NewOAuthClient(target, username, password string, insecureSkipVerify bool) 
 		password:    password,
 		target:      target,
 		client:      nil,
+		timeout:     requestTimeout,
 	}, nil
 }
 
@@ -64,6 +64,7 @@ func (oc OAuthClient) Do(request *http.Request) (*http.Response, error) {
 	}
 
 	client := oc.oauthConfig.Client(oc.context, token)
+	client.Timeout =  oc.timeout
 
 	targetURL, err := url.Parse(oc.target)
 	if err != nil {
@@ -83,6 +84,7 @@ func (oc OAuthClient) RoundTrip(request *http.Request) (*http.Response, error) {
 	}
 
 	client := oc.oauthConfig.Client(oc.context, token)
+	client.Timeout =  oc.timeout
 
 	targetURL, err := url.Parse(oc.target)
 	if err != nil {

--- a/network/oauth_client.go
+++ b/network/oauth_client.go
@@ -34,7 +34,7 @@ func NewOAuthClient(target, username, password string, insecureSkipVerify bool, 
 	httpclient := &http.Client{
 		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{
-				InsecureSkipVerify: true,
+				InsecureSkipVerify: insecureSkipVerify,
 			},
 			Dial: (&net.Dialer{
 				Timeout:   5 * time.Second,

--- a/network/oauth_client_test.go
+++ b/network/oauth_client_test.go
@@ -13,6 +13,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"time"
 )
 
 var _ = Describe("OAuthClient", func() {
@@ -50,7 +51,7 @@ var _ = Describe("OAuthClient", func() {
 
 	Describe("Do", func() {
 		It("makes a request with authentication", func() {
-			client, err := network.NewOAuthClient(server.URL, "opsman-username", "opsman-password", true)
+			client, err := network.NewOAuthClient(server.URL, "opsman-username", "opsman-password", true, time.Duration(30)*time.Second)
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(callCount).To(Equal(0))
@@ -86,7 +87,7 @@ var _ = Describe("OAuthClient", func() {
 		Context("when an error occurs", func() {
 			Context("when the initial token cannot be retrieved", func() {
 				It("returns an error", func() {
-					client, err := network.NewOAuthClient("%%%", "username", "password", false)
+					client, err := network.NewOAuthClient("%%%", "username", "password", false, time.Duration(30)*time.Second)
 					Expect(err).NotTo(HaveOccurred())
 
 					req, err := http.NewRequest("GET", "/some/path", strings.NewReader("request-body"))
@@ -101,7 +102,7 @@ var _ = Describe("OAuthClient", func() {
 
 	Describe("RoundTrip", func() {
 		It("makes a request with authentication", func() {
-			client, err := network.NewOAuthClient(server.URL, "opsman-username", "opsman-password", true)
+			client, err := network.NewOAuthClient(server.URL, "opsman-username", "opsman-password", true, time.Duration(30)*time.Second)
 			Expect(err).NotTo(HaveOccurred())
 
 			req, err := http.NewRequest("GET", "/some/path", strings.NewReader("request-body"))
@@ -136,7 +137,7 @@ var _ = Describe("OAuthClient", func() {
 	Context("when an error occurs", func() {
 		Context("when the initial token cannot be retrieved", func() {
 			It("returns an error", func() {
-				client, err := network.NewOAuthClient("%%%", "username", "password", false)
+				client, err := network.NewOAuthClient("%%%", "username", "password", false, time.Duration(30)*time.Second)
 				Expect(err).NotTo(HaveOccurred())
 
 				req, err := http.NewRequest("GET", "/some/path", strings.NewReader("request-body"))

--- a/network/unauthenticated_client.go
+++ b/network/unauthenticated_client.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"time"
 )
 
 type UnauthenticatedClient struct {
@@ -12,7 +13,7 @@ type UnauthenticatedClient struct {
 	client *http.Client
 }
 
-func NewUnauthenticatedClient(target string, insecureSkipVerify bool) UnauthenticatedClient {
+func NewUnauthenticatedClient(target string, insecureSkipVerify bool, requestTimeout time.Duration) UnauthenticatedClient {
 	return UnauthenticatedClient{
 		target: target,
 		client: &http.Client{
@@ -21,6 +22,7 @@ func NewUnauthenticatedClient(target string, insecureSkipVerify bool) Unauthenti
 					InsecureSkipVerify: insecureSkipVerify,
 				},
 			},
+			Timeout: requestTimeout,
 		},
 	}
 }

--- a/network/unauthenticated_client_test.go
+++ b/network/unauthenticated_client_test.go
@@ -13,6 +13,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"time"
 )
 
 var _ = Describe("UnauthenticatedClient", func() {
@@ -28,7 +29,7 @@ var _ = Describe("UnauthenticatedClient", func() {
 				w.Write([]byte("response"))
 			}))
 
-			client := network.NewUnauthenticatedClient(server.URL, true)
+			client := network.NewUnauthenticatedClient(server.URL, true, time.Duration(30)*time.Second)
 
 			request, err := http.NewRequest("GET", "/path?query", strings.NewReader("request"))
 			Expect(err).NotTo(HaveOccurred())
@@ -57,7 +58,7 @@ var _ = Describe("UnauthenticatedClient", func() {
 		Context("failure cases", func() {
 			Context("when the target url cannot be parsed", func() {
 				It("returns an error", func() {
-					client := network.NewUnauthenticatedClient("%%%", false)
+					client := network.NewUnauthenticatedClient("%%%", false, time.Duration(30)*time.Second)
 					_, err := client.Do(&http.Request{})
 					Expect(err).To(MatchError("could not parse target url: parse %%%: invalid URL escape \"%%%\""))
 				})
@@ -78,7 +79,7 @@ var _ = Describe("UnauthenticatedClient", func() {
 				w.Write([]byte("response"))
 			}))
 
-			client := network.NewUnauthenticatedClient(server.URL, true)
+			client := network.NewUnauthenticatedClient(server.URL, true, time.Duration(30)*time.Second)
 
 			request, err := http.NewRequest("GET", "/path?query", strings.NewReader("request"))
 			Expect(err).NotTo(HaveOccurred())
@@ -108,7 +109,7 @@ var _ = Describe("UnauthenticatedClient", func() {
 		Context("failure cases", func() {
 			Context("when the target url cannot be parsed", func() {
 				It("returns an error", func() {
-					client := network.NewUnauthenticatedClient("%%%", false)
+					client := network.NewUnauthenticatedClient("%%%", false, time.Duration(30)*time.Second)
 					_, err := client.RoundTrip(&http.Request{})
 					Expect(err).To(MatchError("could not parse target url: parse %%%: invalid URL escape \"%%%\""))
 				})


### PR DESCRIPTION
Moved the timeouts from oauth_client.NewOAuthClient.httpclient because the Timeout variable at http.Client level won't take effect due to the way oauth2 constructs the client. And didn't want to set 'ResponseHeaderTimeout' in Transport layer because it doesn't seem to be the expected behaviour of the option provided in cli.