### PR TITLE
Add Content-Type application/json to requests

### DIFF
--- a/api/request_service.go
+++ b/api/request_service.go
@@ -32,6 +32,7 @@ func (rs RequestService) Invoke(input RequestServiceInvokeInput) (RequestService
 		return RequestServiceInvokeOutput{}, fmt.Errorf("failed constructing request: %s", err)
 	}
 
+	request.Header.Set("Content-Type", "application/json")
 	response, err := rs.client.Do(request)
 	if err != nil {
 		return RequestServiceInvokeOutput{}, fmt.Errorf("failed submitting request: %s", err)

--- a/api/request_service_test.go
+++ b/api/request_service_test.go
@@ -44,6 +44,9 @@ var _ = Describe("RequestService", func() {
 			request := client.DoArgsForCall(0)
 			Expect(request.Method).To(Equal("PUT"))
 			Expect(request.URL.Path).To(Equal("/api/v0/api/endpoint"))
+			Expect(request.Header).To(Equal(http.Header{
+				"Content-Type": []string{"application/json"},
+			}))
 
 			body, err := ioutil.ReadAll(request.Body)
 			Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
@alex-slynko observed that one can't pass JSON playload to the curl command.

The suggested fix, adds a Content-Type: application/json to all outgoing request. This fixed our issue.