### PR TITLE
More logging

### DIFF
--- a/acceptance/upload_product_test.go
+++ b/acceptance/upload_product_test.go
@@ -84,10 +84,10 @@ var _ = Describe("upload-product command", func() {
 		session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
 		Expect(err).NotTo(HaveOccurred())
 
-		Eventually(session).Should(gexec.Exit(0))
-		Eventually(session.Out).Should(gbytes.Say("processing product"))
-		Eventually(session.Out).Should(gbytes.Say("beginning product upload to Ops Manager"))
-		Eventually(session.Out).Should(gbytes.Say("finished upload"))
+		Eventually(session, 5).Should(gexec.Exit(0))
+		Eventually(session.Out, 5).Should(gbytes.Say("processing product"))
+		Eventually(session.Out, 5).Should(gbytes.Say("beginning product upload to Ops Manager"))
+		Eventually(session.Out, 5).Should(gbytes.Say("finished upload"))
 
 		Expect(product).To(Equal(filepath.Base(content.Name())))
 	})
@@ -120,8 +120,8 @@ var _ = Describe("upload-product command", func() {
 				session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
 				Expect(err).NotTo(HaveOccurred())
 
-				Eventually(session).Should(gexec.Exit(1))
-				Eventually(session.Out).Should(gbytes.Say("failed to load product: file provided has no content"))
+				Eventually(session, 5).Should(gexec.Exit(1))
+				Eventually(session.Out, 5).Should(gbytes.Say("failed to load product: file provided has no content"))
 			})
 		})
 
@@ -144,8 +144,8 @@ var _ = Describe("upload-product command", func() {
 				session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
 				Expect(err).NotTo(HaveOccurred())
 
-				Eventually(session).Should(gexec.Exit(1))
-				Eventually(session.Out).Should(gbytes.Say(`no such file or directory`))
+				Eventually(session, 5).Should(gexec.Exit(1))
+				Eventually(session.Out, 5).Should(gbytes.Say(`no such file or directory`))
 			})
 		})
 	})

--- a/api/installation_asset_service.go
+++ b/api/installation_asset_service.go
@@ -113,19 +113,10 @@ func (ia InstallationAssetService) Import(input ImportInstallationInput) error {
 
 	ia.progress.Kickoff()
 	respChan := make(chan error)
-	progressDone := ia.trackProgress()
 	go func() {
 		for {
-			var pbDone bool
-			select {
-			case _ = <-progressDone:
+			if ia.progress.GetCurrent() == ia.progress.GetTotal() {
 				ia.progress.End()
-				pbDone = true
-			default:
-				time.Sleep(1 * time.Second)
-			}
-
-			if pbDone {
 				break
 			}
 		}
@@ -202,17 +193,4 @@ func (ia InstallationAssetService) Delete() (InstallationsServiceOutput, error) 
 	}
 
 	return InstallationsServiceOutput{ID: installation.Install.ID}, nil
-}
-
-func (ia InstallationAssetService) trackProgress() chan string {
-	progressChan := make(chan string)
-	go func() {
-		for {
-			if ia.progress.GetCurrent() == ia.progress.GetTotal() {
-				progressChan <- "done"
-				break
-			}
-		}
-	}()
-	return progressChan
 }

--- a/api/installation_asset_service.go
+++ b/api/installation_asset_service.go
@@ -113,6 +113,7 @@ func (ia InstallationAssetService) Import(input ImportInstallationInput) error {
 
 	ia.progress.Kickoff()
 	respChan := make(chan error)
+	progressDone := ia.trackProgress()
 	go func() {
 		var elapsedTime int
 		var liveLog logger
@@ -121,14 +122,13 @@ func (ia InstallationAssetService) Import(input ImportInstallationInput) error {
 			case _ = <-respChan:
 				ia.liveWriter.Stop()
 				return
+			case _ = <-progressDone:
+				ia.progress.End()
+				ia.liveWriter.Start()
+				liveLog = log.New(ia.liveWriter, "", 0)
 			default:
 				time.Sleep(1 * time.Second)
-				if ia.progress.GetCurrent() == ia.progress.GetTotal() { // so that we only start logging time elapsed after the progress bar is done
-					ia.progress.End()
-					if elapsedTime == 0 {
-						ia.liveWriter.Start()
-						liveLog = log.New(ia.liveWriter, "", 0)
-					}
+				if liveLog != nil {
 					elapsedTime++
 					liveLog.Printf("%ds elapsed, waiting for response from Ops Manager...\r", elapsedTime)
 				}
@@ -191,4 +191,17 @@ func (ia InstallationAssetService) Delete() (InstallationsServiceOutput, error) 
 	}
 
 	return InstallationsServiceOutput{ID: installation.Install.ID}, nil
+}
+
+func (ia InstallationAssetService) trackProgress() chan string {
+	progressChan := make(chan string)
+	go func() {
+		for {
+			if ia.progress.GetCurrent() == ia.progress.GetTotal() {
+				progressChan <- "done"
+				break
+			}
+		}
+	}()
+	return progressChan
 }

--- a/api/installation_asset_service_test.go
+++ b/api/installation_asset_service_test.go
@@ -157,7 +157,6 @@ var _ = Describe("InstallationAssetService", func() {
 
 		It("makes a request to import the installation to the Ops Manager", func() {
 			client.DoStub = func(req *http.Request) (*http.Response, error) {
-				time.Sleep(1 * time.Second)
 				return &http.Response{StatusCode: http.StatusOK,
 					Body: ioutil.NopCloser(strings.NewReader("{}")),
 				}, nil
@@ -190,6 +189,7 @@ var _ = Describe("InstallationAssetService", func() {
 			Expect(string(newReaderContent)).To(Equal("some installation"))
 			Expect(bar.SetTotalArgsForCall(0)).To(BeNumerically("==", 10))
 			Expect(bar.KickoffCallCount()).To(Equal(1))
+			By("ending the progress bar")
 			Expect(bar.EndCallCount()).To(Equal(1))
 		})
 

--- a/api/products_service.go
+++ b/api/products_service.go
@@ -89,21 +89,14 @@ func (p ProductsService) Upload(input UploadProductInput) (UploadProductOutput, 
 
 	p.progress.Kickoff()
 	respChan := make(chan error)
-	progressDone := p.trackProgress()
 	go func() {
 		for {
-			var pbDone bool
-			select {
-			case _ = <-progressDone:
+			if p.progress.GetCurrent() == p.progress.GetTotal() {
 				p.progress.End()
-				pbDone = true
-			default:
-				time.Sleep(1 * time.Second)
-			}
-
-			if pbDone {
 				break
 			}
+
+			time.Sleep(1 * time.Second)
 		}
 
 		var elapsedTime int
@@ -141,19 +134,6 @@ func (p ProductsService) Upload(input UploadProductInput) (UploadProductOutput, 
 	}
 
 	return UploadProductOutput{}, nil
-}
-
-func (p ProductsService) trackProgress() chan string {
-	progressChan := make(chan string)
-	go func() {
-		for {
-			if p.progress.GetCurrent() == p.progress.GetTotal() {
-				progressChan <- "done"
-				break
-			}
-		}
-	}()
-	return progressChan
 }
 
 func (p ProductsService) Stage(input StageProductInput) error {

--- a/api/products_service.go
+++ b/api/products_service.go
@@ -6,8 +6,10 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"log"
 	"net/http"
 	"net/http/httputil"
+	"time"
 )
 
 type UploadProductInput struct {
@@ -39,8 +41,9 @@ type ProductsConfigurationInput struct {
 }
 
 type ProductsService struct {
-	client   httpClient
-	progress progress
+	client     httpClient
+	progress   progress
+	liveWriter liveWriter
 }
 
 type ProductInfo struct {
@@ -64,10 +67,11 @@ type ConfigurationRequest struct {
 	Configuration string
 }
 
-func NewProductsService(client httpClient, progress progress) ProductsService {
+func NewProductsService(client httpClient, progress progress, liveWriter liveWriter) ProductsService {
 	return ProductsService{
-		client:   client,
-		progress: progress,
+		client:     client,
+		progress:   progress,
+		liveWriter: liveWriter,
 	}
 }
 
@@ -84,8 +88,32 @@ func (p ProductsService) Upload(input UploadProductInput) (UploadProductOutput, 
 	req.ContentLength = input.ContentLength
 
 	p.progress.Kickoff()
+	respChan := make(chan error)
+	go func() {
+		var elapsedTime int
+		var liveLog logger
+		for {
+			select {
+			case _ = <-respChan:
+				p.liveWriter.Stop()
+				return
+			default:
+				time.Sleep(1 * time.Second)
+				if p.progress.GetCurrent() == p.progress.GetTotal() { // so that we only start logging time elapsed after the progress bar is done
+					p.progress.End()
+					if elapsedTime == 0 {
+						p.liveWriter.Start()
+						liveLog = log.New(p.liveWriter, "", 0)
+					}
+					elapsedTime++
+					liveLog.Printf("%ds elapsed, waiting for response from Ops Manager...\r", elapsedTime)
+				}
+			}
+		}
+	}()
 
 	resp, err := p.client.Do(req)
+	respChan <- err
 	if err != nil {
 		return UploadProductOutput{}, fmt.Errorf("could not make api request to available_products endpoint: %s", err)
 	}

--- a/api/products_service.go
+++ b/api/products_service.go
@@ -120,8 +120,6 @@ func (p ProductsService) Upload(input UploadProductInput) (UploadProductOutput, 
 
 	defer resp.Body.Close()
 
-	p.progress.End()
-
 	if resp.StatusCode != http.StatusOK {
 		out, err := httputil.DumpResponse(resp, true)
 		if err != nil {

--- a/api/products_service_test.go
+++ b/api/products_service_test.go
@@ -31,10 +31,12 @@ var _ = Describe("ProductsService", func() {
 		})
 
 		It("makes a request to upload the product to the Ops Manager", func() {
-			client.DoReturns(&http.Response{
-				StatusCode: http.StatusOK,
-				Body:       ioutil.NopCloser(strings.NewReader("{}")),
-			}, nil)
+			client.DoStub = func(req *http.Request) (*http.Response, error) {
+				time.Sleep(1 * time.Second)
+				return &http.Response{StatusCode: http.StatusOK,
+					Body: ioutil.NopCloser(strings.NewReader("{}")),
+				}, nil
+			}
 
 			bar.NewBarReaderReturns(strings.NewReader("some other content"))
 			service := api.NewProductsService(client, bar, liveWriter)

--- a/api/products_service_test.go
+++ b/api/products_service_test.go
@@ -32,7 +32,6 @@ var _ = Describe("ProductsService", func() {
 
 		It("makes a request to upload the product to the Ops Manager", func() {
 			client.DoStub = func(req *http.Request) (*http.Response, error) {
-				time.Sleep(1 * time.Second)
 				return &http.Response{StatusCode: http.StatusOK,
 					Body: ioutil.NopCloser(strings.NewReader("{}")),
 				}, nil

--- a/api/products_service_test.go
+++ b/api/products_service_test.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/pivotal-cf/om/api"
 	"github.com/pivotal-cf/om/api/fakes"
@@ -18,12 +19,14 @@ import (
 var _ = Describe("ProductsService", func() {
 	Describe("Upload", func() {
 		var (
-			client *fakes.HttpClient
-			bar    *fakes.Progress
+			client     *fakes.HttpClient
+			bar        *fakes.Progress
+			liveWriter *fakes.LiveWriter
 		)
 
 		BeforeEach(func() {
 			client = &fakes.HttpClient{}
+			liveWriter = &fakes.LiveWriter{}
 			bar = &fakes.Progress{}
 		})
 
@@ -34,7 +37,7 @@ var _ = Describe("ProductsService", func() {
 			}, nil)
 
 			bar.NewBarReaderReturns(strings.NewReader("some other content"))
-			service := api.NewProductsService(client, bar)
+			service := api.NewProductsService(client, bar, liveWriter)
 
 			output, err := service.Upload(api.UploadProductInput{
 				ContentLength: 10,
@@ -64,11 +67,46 @@ var _ = Describe("ProductsService", func() {
 			Expect(bar.EndCallCount()).To(Equal(1))
 		})
 
+		It("logs while waiting for a response from the Ops Manager", func() {
+			client.DoStub = func(req *http.Request) (*http.Response, error) {
+				if req.URL.Path == "/api/v0/available_products" {
+					time.Sleep(5 * time.Second)
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Body:       ioutil.NopCloser(strings.NewReader("some-installation")),
+					}, nil
+				}
+				return nil, nil
+			}
+
+			bar.NewBarReaderReturns(strings.NewReader("some-fake-installation"))
+			service := api.NewProductsService(client, bar, liveWriter)
+
+			_, err := service.Upload(api.UploadProductInput{
+				ContentLength: 10,
+				Product:       strings.NewReader("some content"),
+				ContentType:   "some content-type",
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("starting the live log writer")
+			Expect(liveWriter.StartCallCount()).To(Equal(1))
+
+			By("writing to the live log writer")
+			Expect(liveWriter.WriteCallCount()).To(Equal(5))
+			for i := 0; i < 5; i++ {
+				Expect(string(liveWriter.WriteArgsForCall(i))).To(ContainSubstring(fmt.Sprintf("%ds elapsed", i+1)))
+			}
+
+			By("flushing the live log writer")
+			Expect(liveWriter.StopCallCount()).To(Equal(1))
+		})
+
 		Context("when an error occurs", func() {
 			Context("when the client errors before the request", func() {
 				It("returns an error", func() {
 					client.DoReturns(&http.Response{}, errors.New("some client error"))
-					service := api.NewProductsService(client, bar)
+					service := api.NewProductsService(client, bar, liveWriter)
 
 					_, err := service.Upload(api.UploadProductInput{})
 					Expect(err).To(MatchError("could not make api request to available_products endpoint: some client error"))
@@ -81,7 +119,7 @@ var _ = Describe("ProductsService", func() {
 						StatusCode: http.StatusInternalServerError,
 						Body:       ioutil.NopCloser(strings.NewReader("{}")),
 					}, nil)
-					service := api.NewProductsService(client, bar)
+					service := api.NewProductsService(client, bar, liveWriter)
 
 					_, err := service.Upload(api.UploadProductInput{})
 					Expect(err).To(MatchError(ContainSubstring("request failed: unexpected response")))
@@ -127,7 +165,7 @@ var _ = Describe("ProductsService", func() {
 		})
 
 		It("makes a request to stage the product to the Ops Manager", func() {
-			service := api.NewProductsService(client, nil)
+			service := api.NewProductsService(client, nil, nil)
 
 			err := service.Stage(api.StageProductInput{
 				ProductName:    "some-product",
@@ -201,7 +239,7 @@ var _ = Describe("ProductsService", func() {
 			})
 
 			It("makes a request to stage the product to the Ops Manager", func() {
-				service := api.NewProductsService(client, nil)
+				service := api.NewProductsService(client, nil, nil)
 
 				err := service.Stage(api.StageProductInput{
 					ProductName:    "some-product",
@@ -234,7 +272,7 @@ var _ = Describe("ProductsService", func() {
 
 		Context("when the requested product is not available", func() {
 			It("returns an error", func() {
-				service := api.NewProductsService(client, nil)
+				service := api.NewProductsService(client, nil, nil)
 
 				err := service.Stage(api.StageProductInput{
 					ProductName:    "some-unavailable-product",
@@ -246,7 +284,7 @@ var _ = Describe("ProductsService", func() {
 
 		Context("when the requested product version is not available", func() {
 			It("returns an error", func() {
-				service := api.NewProductsService(client, nil)
+				service := api.NewProductsService(client, nil, nil)
 
 				err := service.Stage(api.StageProductInput{
 					ProductName:    "some-product",
@@ -260,7 +298,7 @@ var _ = Describe("ProductsService", func() {
 			Context("when the available products endpoint returns an error", func() {
 				It("returns an error", func() {
 					client.DoReturns(&http.Response{}, errors.New("some client error"))
-					service := api.NewProductsService(client, nil)
+					service := api.NewProductsService(client, nil, nil)
 
 					err := service.Stage(api.StageProductInput{})
 					Expect(err).To(MatchError("could not make api request to available_products endpoint: some client error"))
@@ -273,7 +311,7 @@ var _ = Describe("ProductsService", func() {
 						StatusCode: http.StatusInternalServerError,
 						Body:       ioutil.NopCloser(strings.NewReader("{}")),
 					}, nil)
-					service := api.NewProductsService(client, nil)
+					service := api.NewProductsService(client, nil, nil)
 
 					err := service.Stage(api.StageProductInput{})
 					Expect(err).To(MatchError(ContainSubstring("could not make api request to available_products endpoint: unexpected response")))
@@ -286,7 +324,7 @@ var _ = Describe("ProductsService", func() {
 						StatusCode: http.StatusOK,
 						Body:       ioutil.NopCloser(strings.NewReader("%%%")),
 					}, nil)
-					service := api.NewProductsService(client, nil)
+					service := api.NewProductsService(client, nil, nil)
 
 					err := service.Stage(api.StageProductInput{})
 					Expect(err).To(MatchError(ContainSubstring("invalid character")))
@@ -325,7 +363,7 @@ var _ = Describe("ProductsService", func() {
 				})
 
 				It("returns an error", func() {
-					service := api.NewProductsService(client, nil)
+					service := api.NewProductsService(client, nil, nil)
 
 					err := service.Stage(api.StageProductInput{
 						ProductName:    "some-product",
@@ -369,7 +407,7 @@ var _ = Describe("ProductsService", func() {
 				})
 
 				It("returns an error", func() {
-					service := api.NewProductsService(client, nil)
+					service := api.NewProductsService(client, nil, nil)
 
 					err := service.Stage(api.StageProductInput{
 						ProductName:    "some-product",
@@ -413,7 +451,7 @@ var _ = Describe("ProductsService", func() {
 				})
 
 				It("returns an error", func() {
-					service := api.NewProductsService(client, nil)
+					service := api.NewProductsService(client, nil, nil)
 
 					err := service.Stage(api.StageProductInput{
 						ProductName:    "some-product",
@@ -443,7 +481,7 @@ var _ = Describe("ProductsService", func() {
 				})
 
 				It("returns an error", func() {
-					service := api.NewProductsService(client, nil)
+					service := api.NewProductsService(client, nil, nil)
 
 					err := service.Stage(api.StageProductInput{
 						ProductName:    "foo",
@@ -476,7 +514,7 @@ var _ = Describe("ProductsService", func() {
 				})
 
 				It("returns an error", func() {
-					service := api.NewProductsService(client, nil)
+					service := api.NewProductsService(client, nil, nil)
 					err := service.Stage(api.StageProductInput{
 						ProductName:    "foo",
 						ProductVersion: "bar",
@@ -519,7 +557,7 @@ var _ = Describe("ProductsService", func() {
 		})
 
 		It("retrieves a list of staged products from the Ops Manager", func() {
-			service := api.NewProductsService(client, nil)
+			service := api.NewProductsService(client, nil, nil)
 
 			output, err := service.StagedProducts()
 			Expect(err).NotTo(HaveOccurred())
@@ -550,7 +588,7 @@ var _ = Describe("ProductsService", func() {
 				})
 
 				It("returns an error", func() {
-					service := api.NewProductsService(client, nil)
+					service := api.NewProductsService(client, nil, nil)
 
 					_, err := service.StagedProducts()
 					Expect(err).To(MatchError("could not make api request to staged products endpoint: nope"))
@@ -566,7 +604,7 @@ var _ = Describe("ProductsService", func() {
 				})
 
 				It("returns an error", func() {
-					service := api.NewProductsService(client, nil)
+					service := api.NewProductsService(client, nil, nil)
 
 					_, err := service.StagedProducts()
 					Expect(err).To(MatchError(ContainSubstring("could not make api request to staged products endpoint: unexpected response")))
@@ -582,7 +620,7 @@ var _ = Describe("ProductsService", func() {
 				})
 
 				It("returns an error", func() {
-					service := api.NewProductsService(client, nil)
+					service := api.NewProductsService(client, nil, nil)
 
 					_, err := service.StagedProducts()
 					Expect(err).To(MatchError(ContainSubstring("could not unmarshal staged products response:")))
@@ -617,7 +655,7 @@ var _ = Describe("ProductsService", func() {
 		})
 
 		It("configures the properties for the given staged product in the Ops Manager", func() {
-			service := api.NewProductsService(client, nil)
+			service := api.NewProductsService(client, nil, nil)
 
 			err := service.Configure(api.ProductsConfigurationInput{
 				GUID: "some-product-guid",
@@ -644,7 +682,7 @@ var _ = Describe("ProductsService", func() {
 		})
 
 		It("configures the network for the given staged product in the Ops Manager", func() {
-			service := api.NewProductsService(client, nil)
+			service := api.NewProductsService(client, nil, nil)
 
 			err := service.Configure(api.ProductsConfigurationInput{
 				GUID: "some-product-guid",
@@ -677,7 +715,7 @@ var _ = Describe("ProductsService", func() {
 				})
 
 				It("returns an error", func() {
-					service := api.NewProductsService(client, nil)
+					service := api.NewProductsService(client, nil, nil)
 
 					err := service.Configure(api.ProductsConfigurationInput{
 						GUID:          "foo",
@@ -696,7 +734,7 @@ var _ = Describe("ProductsService", func() {
 				})
 
 				It("returns an error", func() {
-					service := api.NewProductsService(client, nil)
+					service := api.NewProductsService(client, nil, nil)
 
 					err := service.Configure(api.ProductsConfigurationInput{
 						GUID:          "foo",

--- a/main.go
+++ b/main.go
@@ -74,7 +74,7 @@ func main() {
 
 	setupService := api.NewSetupService(unauthenticatedClient)
 	uploadStemcellService := api.NewUploadStemcellService(authedClient, progress.NewBar())
-	productsService := api.NewProductsService(authedClient, progress.NewBar())
+	productsService := api.NewProductsService(authedClient, progress.NewBar(), liveWriter)
 	diagnosticService := api.NewDiagnosticService(authedClient)
 	importInstallationService := api.NewInstallationAssetService(unauthenticatedClient, progress.NewBar(), liveWriter)
 	exportInstallationService := api.NewInstallationAssetService(authedClient, progress.NewBar(), liveWriter)


### PR DESCRIPTION
Refactored live logging code to be less complex in terms of the level of branching back and forth between select-cases and ifs. Basically wrote a function to track the progress bar and write to a channel once the bar is done, and made the logging code wait on that channel to start logging (in case of tasks where the live logging happens after the progress bar is done, like import-installation and upload-product). The logging code for export-installation is unchanged.

Logically, this is much better than my previous solution, and in future the progress tracking code can theoretically be integrated into progress.go (so the code that uses the progress bar need only call Kickoff()). 