### PR TITLE
Fixed product metadata extraction filename filter

### DIFF
--- a/extractor/product_unzipper.go
+++ b/extractor/product_unzipper.go
@@ -5,9 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"strings"
-
 	yaml "gopkg.in/yaml.v2"
+	"regexp"
 )
 
 type ProductUnzipper struct{}
@@ -21,7 +20,9 @@ func (u ProductUnzipper) ExtractMetadata(productPath string) (string, string, er
 	defer zipReader.Close()
 
 	for _, file := range zipReader.File {
-		if strings.Contains(file.Name, ".yml") {
+		matched, _ := regexp.MatchString("metadata/.*\\.yml", file.Name)
+
+		if matched {
 			metadataFile, err := file.Open()
 			if err != nil {
 				return "", "", err


### PR DESCRIPTION
The original code was failing when an existing .yml file existed in the archive and appeared in the file list before the needed file `metadata/file.yml`. The wrong file was parsed and some required fields were missing.

For example with this product:
https://network.pivotal.io/products/push-notification-service#/releases/2285

The metadata file is expected to be found at `/metadata/*.yml` according to https://github.com/pivotal-cf/installation/blob/master/web/app/models/tempest/verifiers/internal/product_assets_verifier.rb#L70


Signed-off-by: Felix Reyn <freyn@pivotal.io>