### PR TITLE
Reuse status validation with consistent messaging

### DIFF
--- a/api/available_products_service.go
+++ b/api/available_products_service.go
@@ -108,8 +108,7 @@ func (ap AvailableProductsService) Trash() error {
 		return fmt.Errorf("could not make api request to available_products endpoint: %s", err)
 	}
 
-	err = ValidateStatusOK(resp)
-	if err != nil {
+	if err = ValidateStatusOK(resp); err != nil {
 		return err
 	}
 

--- a/api/available_products_service.go
+++ b/api/available_products_service.go
@@ -108,7 +108,12 @@ func (ap AvailableProductsService) Trash() error {
 		return fmt.Errorf("could not make api request to available_products endpoint: %s", err)
 	}
 
-	return ValidateStatusOK(resp)
+	err = ValidateStatusOK(resp)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (ap AvailableProductsService) List() (AvailableProductsOutput, error) {

--- a/api/available_products_service_test.go
+++ b/api/available_products_service_test.go
@@ -173,7 +173,7 @@ var _ = Describe("AvailableProductsService", func() {
 					}, nil)
 
 					_, err := service.List()
-					Expect(err).To(MatchError(ContainSubstring("could not make api request")))
+					Expect(err).To(MatchError(ContainSubstring("request failed")))
 				})
 			})
 
@@ -224,7 +224,7 @@ var _ = Describe("AvailableProductsService", func() {
 					}, nil)
 
 					err := service.Trash()
-					Expect(err).To(MatchError(ContainSubstring("could not make api request to available_products endpoint: unexpected response")))
+					Expect(err).To(MatchError(ContainSubstring("request failed: unexpected response")))
 				})
 			})
 		})

--- a/api/bosh_form_service.go
+++ b/api/bosh_form_service.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"net/http/httputil"
 	"strings"
 
 	"github.com/PuerkitoBio/goquery"
@@ -48,13 +47,8 @@ func (bs BoshFormService) GetForm(path string) (Form, error) {
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
-		out, err := httputil.DumpResponse(resp, true)
-		if err != nil {
-			return Form{}, fmt.Errorf("request failed: unexpected response: %s", err)
-		}
-
-		return Form{}, fmt.Errorf("request failed: unexpected response:\n%s", out)
+	if err = ValidateStatusOK(resp); err != nil {
+		return Form{}, err
 	}
 
 	document, err := goquery.NewDocumentFromReader(resp.Body)
@@ -90,16 +84,7 @@ func (bs BoshFormService) PostForm(input PostFormInput) error {
 		return fmt.Errorf("failed to POST form: %s", err)
 	}
 
-	if resp.StatusCode != http.StatusOK {
-		out, err := httputil.DumpResponse(resp, true)
-		if err != nil {
-			return fmt.Errorf("request failed: unexpected response: %s", err)
-		}
-
-		return fmt.Errorf("request failed: unexpected response:\n%s", out)
-	}
-
-	return nil
+	return ValidateStatusOK(resp)
 }
 
 func (bs BoshFormService) AvailabilityZones() (map[string]string, error) {
@@ -116,13 +101,8 @@ func (bs BoshFormService) AvailabilityZones() (map[string]string, error) {
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
-		out, err := httputil.DumpResponse(resp, true)
-		if err != nil {
-			return zones, fmt.Errorf("request failed: unexpected response: %s", err)
-		}
-
-		return zones, fmt.Errorf("request failed: unexpected response:\n%s", out)
+	if err = ValidateStatusOK(resp); err != nil {
+		return zones, err
 	}
 
 	document, err := goquery.NewDocumentFromReader(resp.Body)
@@ -177,12 +157,8 @@ func (bs BoshFormService) Networks() (map[string]string, error) {
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
-		out, err := httputil.DumpResponse(resp, true)
-		if err != nil {
-			return networks, fmt.Errorf("request failed: unexpected response: %s", err)
-		}
-		return networks, fmt.Errorf("request failed: unexpected response: %s", out)
+	if err = ValidateStatusOK(resp); err != nil {
+		return networks, err
 	}
 
 	document, err := goquery.NewDocumentFromReader(resp.Body)

--- a/api/bosh_form_service.go
+++ b/api/bosh_form_service.go
@@ -84,7 +84,12 @@ func (bs BoshFormService) PostForm(input PostFormInput) error {
 		return fmt.Errorf("failed to POST form: %s", err)
 	}
 
-	return ValidateStatusOK(resp)
+	err = ValidateStatusOK(resp)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (bs BoshFormService) AvailabilityZones() (map[string]string, error) {

--- a/api/bosh_form_service.go
+++ b/api/bosh_form_service.go
@@ -84,8 +84,7 @@ func (bs BoshFormService) PostForm(input PostFormInput) error {
 		return fmt.Errorf("failed to POST form: %s", err)
 	}
 
-	err = ValidateStatusOK(resp)
-	if err != nil {
+	if err = ValidateStatusOK(resp); err != nil {
 		return err
 	}
 

--- a/api/dashboard_service.go
+++ b/api/dashboard_service.go
@@ -19,13 +19,13 @@ func NewDashboardService(client httpClient) DashboardService {
 	}
 }
 
-func (bs DashboardService) GetInstallForm() (Form, error) {
+func (ds DashboardService) GetInstallForm() (Form, error) {
 	req, err := http.NewRequest("GET", "/", nil)
 	if err != nil {
 		return Form{}, err
 	}
 
-	resp, err := bs.client.Do(req)
+	resp, err := ds.client.Do(req)
 	if err != nil {
 		return Form{}, fmt.Errorf("failed during request: %s", err)
 	}
@@ -62,7 +62,7 @@ func (bs DashboardService) GetInstallForm() (Form, error) {
 	}, nil
 }
 
-func (bs DashboardService) PostInstallForm(input PostFormInput) error {
+func (ds DashboardService) PostInstallForm(input PostFormInput) error {
 	req, err := http.NewRequest("POST", "/installation", strings.NewReader(input.EncodedPayload))
 	if err != nil {
 		return err
@@ -70,10 +70,15 @@ func (bs DashboardService) PostInstallForm(input PostFormInput) error {
 
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
-	resp, err := bs.client.Do(req)
+	resp, err := ds.client.Do(req)
 	if err != nil {
 		return fmt.Errorf("failed to POST form: %s", err)
 	}
 
-	return ValidateStatusOK(resp)
+	err = ValidateStatusOK(resp)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/api/dashboard_service.go
+++ b/api/dashboard_service.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"net/http/httputil"
 	"strings"
 
 	"github.com/PuerkitoBio/goquery"
@@ -32,13 +31,8 @@ func (bs DashboardService) GetInstallForm() (Form, error) {
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
-		out, err := httputil.DumpResponse(resp, true)
-		if err != nil {
-			return Form{}, fmt.Errorf("request failed: unexpected response: %s", err)
-		}
-
-		return Form{}, fmt.Errorf("request failed: unexpected response:\n%s", out)
+	if err = ValidateStatusOK(resp); err != nil {
+		return Form{}, err
 	}
 
 	document, err := goquery.NewDocumentFromReader(resp.Body)
@@ -81,14 +75,5 @@ func (bs DashboardService) PostInstallForm(input PostFormInput) error {
 		return fmt.Errorf("failed to POST form: %s", err)
 	}
 
-	if resp.StatusCode != http.StatusOK {
-		out, err := httputil.DumpResponse(resp, true)
-		if err != nil {
-			return fmt.Errorf("request failed: unexpected response: %s", err)
-		}
-
-		return fmt.Errorf("request failed: unexpected response:\n%s", out)
-	}
-
-	return nil
+	return ValidateStatusOK(resp)
 }

--- a/api/dashboard_service.go
+++ b/api/dashboard_service.go
@@ -75,8 +75,7 @@ func (ds DashboardService) PostInstallForm(input PostFormInput) error {
 		return fmt.Errorf("failed to POST form: %s", err)
 	}
 
-	err = ValidateStatusOK(resp)
-	if err != nil {
+	if err = ValidateStatusOK(resp); err != nil {
 		return err
 	}
 

--- a/api/diagnostic_service.go
+++ b/api/diagnostic_service.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"net/http/httputil"
 )
 
 type DiagnosticService struct {
@@ -52,13 +51,8 @@ func (ds DiagnosticService) Report() (DiagnosticReport, error) {
 		return DiagnosticReport{}, DiagnosticReportUnavailable{}
 	}
 
-	if resp.StatusCode != http.StatusOK {
-		out, err := httputil.DumpResponse(resp, true)
-		if err != nil {
-			return DiagnosticReport{}, fmt.Errorf("request failed: unexpected response: %s", err)
-		}
-
-		return DiagnosticReport{}, fmt.Errorf("request failed: unexpected response:\n%s", out)
+	if err = ValidateStatusOK(resp); err != nil {
+		return DiagnosticReport{}, err
 	}
 
 	body, err := ioutil.ReadAll(resp.Body)

--- a/api/installation_asset_service.go
+++ b/api/installation_asset_service.go
@@ -147,8 +147,7 @@ func (ia InstallationAssetService) Import(input ImportInstallationInput) error {
 
 	defer resp.Body.Close()
 
-	err = ValidateStatusOK(resp)
-	if err != nil {
+	if err = ValidateStatusOK(resp); err != nil {
 		return err
 	}
 

--- a/api/installation_asset_service.go
+++ b/api/installation_asset_service.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"log"
 	"net/http"
-	"net/http/httputil"
 	"os"
 	"time"
 )
@@ -148,16 +147,7 @@ func (ia InstallationAssetService) Import(input ImportInstallationInput) error {
 
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
-		out, err := httputil.DumpResponse(resp, true)
-		if err != nil {
-			return fmt.Errorf("request failed: unexpected response: %s", err)
-		}
-
-		return fmt.Errorf("request failed: unexpected response:\n%s", out)
-	}
-
-	return nil
+	return ValidateStatusOK(resp)
 }
 
 func (ia InstallationAssetService) Delete() (InstallationsServiceOutput, error) {
@@ -178,13 +168,8 @@ func (ia InstallationAssetService) Delete() (InstallationsServiceOutput, error) 
 		return InstallationsServiceOutput{}, nil
 	}
 
-	if resp.StatusCode != http.StatusOK {
-		out, err := httputil.DumpResponse(resp, true)
-		if err != nil {
-			return InstallationsServiceOutput{}, fmt.Errorf("request failed: unexpected response: %s", err)
-		}
-
-		return InstallationsServiceOutput{}, fmt.Errorf("request failed: unexpected response:\n%s", out)
+	if err = ValidateStatusOK(resp); err != nil {
+		return InstallationsServiceOutput{}, err
 	}
 
 	var installation struct {

--- a/api/installation_asset_service.go
+++ b/api/installation_asset_service.go
@@ -147,7 +147,12 @@ func (ia InstallationAssetService) Import(input ImportInstallationInput) error {
 
 	defer resp.Body.Close()
 
-	return ValidateStatusOK(resp)
+	err = ValidateStatusOK(resp)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (ia InstallationAssetService) Delete() (InstallationsServiceOutput, error) {

--- a/api/installations_service.go
+++ b/api/installations_service.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"net/http/httputil"
 	"strings"
 )
 
@@ -43,13 +42,8 @@ func (is InstallationsService) RunningInstallation() (InstallationsServiceOutput
 
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
-		out, err := httputil.DumpResponse(resp, true)
-		if err != nil {
-			return InstallationsServiceOutput{}, fmt.Errorf("request failed: unexpected response: %s", err)
-		}
-
-		return InstallationsServiceOutput{}, fmt.Errorf("request failed: unexpected response:\n%s", out)
+	if err = ValidateStatusOK(resp); err != nil {
+		return InstallationsServiceOutput{}, err
 	}
 
 	var responseStruct struct {
@@ -84,13 +78,8 @@ func (is InstallationsService) Trigger(ignoreWarnings bool) (InstallationsServic
 
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
-		out, err := httputil.DumpResponse(resp, true)
-		if err != nil {
-			return InstallationsServiceOutput{}, fmt.Errorf("request failed: unexpected response: %s", err)
-		}
-
-		return InstallationsServiceOutput{}, fmt.Errorf("request failed: unexpected response:\n%s", out)
+	if err = ValidateStatusOK(resp); err != nil {
+		return InstallationsServiceOutput{}, err
 	}
 
 	var installation struct {
@@ -121,13 +110,8 @@ func (is InstallationsService) Status(id int) (InstallationsServiceOutput, error
 
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
-		out, err := httputil.DumpResponse(resp, true)
-		if err != nil {
-			return InstallationsServiceOutput{}, fmt.Errorf("request failed: unexpected response: %s", err)
-		}
-
-		return InstallationsServiceOutput{}, fmt.Errorf("request failed: unexpected response:\n%s", out)
+	if err = ValidateStatusOK(resp); err != nil {
+		return InstallationsServiceOutput{}, err
 	}
 
 	var output struct {
@@ -156,13 +140,8 @@ func (is InstallationsService) Logs(id int) (InstallationsServiceOutput, error) 
 
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
-		out, err := httputil.DumpResponse(resp, true)
-		if err != nil {
-			return InstallationsServiceOutput{}, fmt.Errorf("request failed: unexpected response: %s", err)
-		}
-
-		return InstallationsServiceOutput{}, fmt.Errorf("request failed: unexpected response:\n%s", out)
+	if err = ValidateStatusOK(resp); err != nil {
+		return InstallationsServiceOutput{}, err
 	}
 
 	var output struct {

--- a/api/jobs_service.go
+++ b/api/jobs_service.go
@@ -125,5 +125,10 @@ func (j JobsService) ConfigureJob(productGUID, jobGUID string, jobProperties Job
 
 	defer resp.Body.Close()
 
-	return ValidateStatusOK(resp)
+	err = ValidateStatusOK(resp)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/api/jobs_service.go
+++ b/api/jobs_service.go
@@ -125,8 +125,7 @@ func (j JobsService) ConfigureJob(productGUID, jobGUID string, jobProperties Job
 
 	defer resp.Body.Close()
 
-	err = ValidateStatusOK(resp)
-	if err != nil {
+	if err = ValidateStatusOK(resp); err != nil {
 		return err
 	}
 

--- a/api/jobs_service.go
+++ b/api/jobs_service.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"net/http/httputil"
 )
 
 type JobsService struct {
@@ -53,13 +52,8 @@ func (j JobsService) Jobs(productGUID string) (map[string]string, error) {
 
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
-		out, err := httputil.DumpResponse(resp, true)
-		if err != nil {
-			return nil, fmt.Errorf("request failed: unexpected response: %s", err)
-		}
-
-		return nil, fmt.Errorf("request failed: unexpected response:\n%s", out)
+	if err = ValidateStatusOK(resp); err != nil {
+		return nil, err
 	}
 
 	var jobsOutput struct {
@@ -92,13 +86,8 @@ func (j JobsService) GetExistingJobConfig(productGUID, jobGUID string) (JobPrope
 
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
-		out, err := httputil.DumpResponse(resp, true)
-		if err != nil {
-			return JobProperties{}, fmt.Errorf("request failed: unexpected response: %s", err)
-		}
-
-		return JobProperties{}, fmt.Errorf("request failed: unexpected response:\n%s", out)
+	if err = ValidateStatusOK(resp); err != nil {
+		return JobProperties{}, err
 	}
 
 	content, err := ioutil.ReadAll(resp.Body)
@@ -136,14 +125,5 @@ func (j JobsService) ConfigureJob(productGUID, jobGUID string, jobProperties Job
 
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
-		out, err := httputil.DumpResponse(resp, true)
-		if err != nil {
-			return fmt.Errorf("request failed: unexpected response: %s", err)
-		}
-
-		return fmt.Errorf("request failed: unexpected response:\n%s", out)
-	}
-
-	return nil
+	return ValidateStatusOK(resp)
 }

--- a/api/security_service.go
+++ b/api/security_service.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"net/http/httputil"
 )
 
 type SecurityService struct {
@@ -26,21 +25,17 @@ func (s SecurityService) FetchRootCACert() (string, error) {
 		return "", fmt.Errorf("failed constructing request: %s", err)
 	}
 
-	response, err := s.client.Do(request)
+	resp, err := s.client.Do(request)
 	if err != nil {
 		return "", fmt.Errorf("failed to submit request: %s", err)
 	}
-	defer response.Body.Close()
+	defer resp.Body.Close()
 
-	if response.StatusCode != http.StatusOK {
-		out, err := httputil.DumpResponse(response, true)
-		if err != nil {
-			return "", fmt.Errorf("request failed: unexpected response: %s", err)
-		}
-		return "", fmt.Errorf("could not make api request: unexpected response.\n%s", out)
+	if err = ValidateStatusOK(resp); err != nil {
+		return "", err
 	}
 
-	output, err := ioutil.ReadAll(response.Body)
+	output, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return "", err
 	}

--- a/api/security_service_test.go
+++ b/api/security_service_test.go
@@ -54,7 +54,7 @@ var _ = Describe("SecurityService", func() {
 				}, nil)
 
 				_, err := service.FetchRootCACert()
-				Expect(err).To(MatchError(ContainSubstring("could not make api request: unexpected response")))
+				Expect(err).To(MatchError(ContainSubstring("request failed: unexpected response")))
 			})
 
 			It("returns error if response fails to unmarshal", func() {

--- a/api/setup_service.go
+++ b/api/setup_service.go
@@ -73,8 +73,7 @@ func (ss SetupService) Setup(input SetupInput) (SetupOutput, error) {
 
 	defer response.Body.Close()
 
-	err = ValidateStatusOK(response)
-	if err != nil {
+	if err = ValidateStatusOK(response); err != nil {
 		return SetupOutput{}, err
 	}
 

--- a/api/setup_service.go
+++ b/api/setup_service.go
@@ -73,7 +73,12 @@ func (ss SetupService) Setup(input SetupInput) (SetupOutput, error) {
 
 	defer response.Body.Close()
 
-	return SetupOutput{}, ValidateStatusOK(response)
+	err = ValidateStatusOK(response)
+	if err != nil {
+		return SetupOutput{}, err
+	}
+
+	return SetupOutput{}, nil
 }
 
 const (

--- a/api/setup_service.go
+++ b/api/setup_service.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"net/http/httputil"
 	"net/url"
 	"strconv"
 	"strings"
@@ -74,16 +73,7 @@ func (ss SetupService) Setup(input SetupInput) (SetupOutput, error) {
 
 	defer response.Body.Close()
 
-	if response.StatusCode != http.StatusOK {
-		out, err := httputil.DumpResponse(response, true)
-		if err != nil {
-			return SetupOutput{}, fmt.Errorf("request failed: unexpected response: %s", err)
-		}
-
-		return SetupOutput{}, fmt.Errorf("request failed: unexpected response:\n%s", out)
-	}
-
-	return SetupOutput{}, nil
+	return SetupOutput{}, ValidateStatusOK(response)
 }
 
 const (

--- a/api/staged_products_service.go
+++ b/api/staged_products_service.go
@@ -113,7 +113,12 @@ func (p StagedProductsService) Stage(input StageProductInput) error {
 	}
 	defer stResp.Body.Close()
 
-	return ValidateStatusOK(stResp)
+	err = ValidateStatusOK(stResp)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (p StagedProductsService) StagedProducts() (StagedProductsOutput, error) {
@@ -161,7 +166,10 @@ func (p StagedProductsService) Configure(input ProductsConfigurationInput) error
 		}
 		defer resp.Body.Close()
 
-		return ValidateStatusOK(resp)
+		err = ValidateStatusOK(resp)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/api/staged_products_service.go
+++ b/api/staged_products_service.go
@@ -113,8 +113,7 @@ func (p StagedProductsService) Stage(input StageProductInput) error {
 	}
 	defer stResp.Body.Close()
 
-	err = ValidateStatusOK(stResp)
-	if err != nil {
+	if err = ValidateStatusOK(stResp); err != nil {
 		return err
 	}
 
@@ -166,8 +165,7 @@ func (p StagedProductsService) Configure(input ProductsConfigurationInput) error
 		}
 		defer resp.Body.Close()
 
-		err = ValidateStatusOK(resp)
-		if err != nil {
+		if err = ValidateStatusOK(resp); err != nil {
 			return err
 		}
 	}

--- a/api/staged_products_service_test.go
+++ b/api/staged_products_service_test.go
@@ -269,7 +269,7 @@ var _ = Describe("ProductsService", func() {
 						ProductName:    "some-product",
 						ProductVersion: "some-version",
 					})
-					Expect(err).To(MatchError(ContainSubstring("could not make api request to deployed products endpoint: unexpected response")))
+					Expect(err).To(MatchError(ContainSubstring("request failed: unexpected response")))
 				})
 			})
 
@@ -388,7 +388,7 @@ var _ = Describe("ProductsService", func() {
 						ProductName:    "foo",
 						ProductVersion: "bar",
 					})
-					Expect(err).To(MatchError(ContainSubstring("could not make POST api request to staged products endpoint: unexpected response.")))
+					Expect(err).To(MatchError(ContainSubstring("request failed: unexpected response")))
 				})
 			})
 		})
@@ -477,7 +477,7 @@ var _ = Describe("ProductsService", func() {
 					service := api.NewStagedProductsService(client)
 
 					_, err := service.StagedProducts()
-					Expect(err).To(MatchError(ContainSubstring("could not make api request to staged products endpoint: unexpected response")))
+					Expect(err).To(MatchError(ContainSubstring("request failed: unexpected response")))
 				})
 			})
 
@@ -610,7 +610,7 @@ var _ = Describe("ProductsService", func() {
 						GUID:          "foo",
 						Configuration: `{}`,
 					})
-					Expect(err).To(MatchError(ContainSubstring("could not make api request to staged product properties endpoint: unexpected response")))
+					Expect(err).To(MatchError(ContainSubstring("request failed: unexpected response")))
 				})
 			})
 		})

--- a/api/stemcell_service.go
+++ b/api/stemcell_service.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/http/httputil"
 )
 
 type StemcellUploadInput struct {
@@ -50,14 +49,5 @@ func (us UploadStemcellService) Upload(input StemcellUploadInput) (StemcellUploa
 
 	us.progress.End()
 
-	if resp.StatusCode != http.StatusOK {
-		out, err := httputil.DumpResponse(resp, true)
-		if err != nil {
-			return StemcellUploadOutput{}, fmt.Errorf("request failed: unexpected response: %s", err)
-		}
-
-		return StemcellUploadOutput{}, fmt.Errorf("request failed: unexpected response:\n%s", out)
-	}
-
-	return StemcellUploadOutput{}, nil
+	return StemcellUploadOutput{}, ValidateStatusOK(resp)
 }

--- a/api/validation.go
+++ b/api/validation.go
@@ -1,0 +1,19 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httputil"
+)
+
+func ValidateStatusOK(resp *http.Response) error {
+	if resp.StatusCode != http.StatusOK {
+		out, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return fmt.Errorf("request failed: unexpected response: %s", err)
+		}
+
+		return fmt.Errorf("request failed: unexpected response:\n%s", out)
+	}
+	return nil
+}


### PR DESCRIPTION
The same HTTP status code check with similar error messaging occurred over 20 times in different service object. 