### PR TITLE
Making InternetConnected for resources optional. Fails if this is provided to a tile being deployed to vsphere

### DIFF
--- a/api/jobs_service.go
+++ b/api/jobs_service.go
@@ -16,7 +16,7 @@ type JobProperties struct {
 	Instances         int          `json:"instances"`
 	PersistentDisk    *Disk        `json:"persistent_disk,omitempty"`
 	InstanceType      InstanceType `json:"instance_type"`
-	InternetConnected bool         `json:"internet_connected"`
+	InternetConnected bool         `json:"internet_connected,omitempty"`
 	LBNames           []string     `json:"elb_names"`
 }
 


### PR DESCRIPTION
Making `InternetConnected` for resources optional. Fails if this is provided to a tile being deployed to vsphere

Following is the error that's sent from the server if the InternetConnected flag is set on resources

```
{"errors":{"internet_connected":["unsupported for this infrastructure"]}}
```

After adding the `omitempty` option to the `InternetConnected`, everything worked as expected against vsphere deployment