### PR TITLE
add support for OpenStack IaaS configuration

### DIFF
--- a/acceptance/configure_bosh_test.go
+++ b/acceptance/configure_bosh_test.go
@@ -372,6 +372,73 @@ var _ = Describe("configure-bosh command", func() {
 		})
 	})
 
+	Context("OpenStack", func() {
+		var command *exec.Cmd
+
+		BeforeEach(func() {
+			iaasConfiguration := `{
+				"api_ssl_cert": "os-api-ssl-cert",
+				"disable_dhcp": false,
+				"openstack_domain": "os-domain",
+				"openstack_authentication_url": "https//openstack.com/v2",
+				"ignore_server_availability_zone": true,
+				"openstack_key_pair_name": "os-key-pair",
+				"keystone_version": "v2.0",
+				"openstack_password": "os-password",
+				"openstack_region": "os-region",
+				"openstack_security_group": "os-security-group",
+				"openstack_tenant": "os-tenant",
+				"openstack_username": "os-user",
+				"ssh_private_key": "my-private-ssh-key"
+			}`
+
+			command = exec.Command(pathToMain,
+				"--target", server.URL,
+				"--username", "fake-username",
+				"--password", "fake-password",
+				"--skip-ssl-validation",
+				"configure-bosh",
+				"--iaas-configuration", iaasConfiguration)
+		})
+
+		It("configures the bosh tile with the provided iaas configuration", func() {
+			session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(session).Should(gexec.Exit(0))
+
+			Expect(session.Out).To(gbytes.Say("configuring iaas specific options for bosh tile"))
+			Expect(session.Out).To(gbytes.Say("finished configuring bosh tile"))
+
+			Expect(Forms[0].Get("iaas_configuration[api_ssl_cert]")).To(Equal("os-api-ssl-cert"))
+			Expect(Forms[0].Get("iaas_configuration[disable_dhcp]")).To(Equal("false"))
+			Expect(Forms[0].Get("iaas_configuration[domain]")).To(Equal("os-domain"))
+			Expect(Forms[0].Get("iaas_configuration[identity_endpoint]")).To(Equal("https//openstack.com/v2"))
+			Expect(Forms[0].Get("iaas_configuration[ignore_server_availability_zone]")).To(Equal("true"))
+			Expect(Forms[0].Get("iaas_configuration[key_pair_name]")).To(Equal("os-key-pair"))
+			Expect(Forms[0].Get("iaas_configuration[keystone_version]")).To(Equal("v2.0"))
+			Expect(Forms[0].Get("iaas_configuration[password]")).To(Equal("os-password"))
+			Expect(Forms[0].Get("iaas_configuration[region]")).To(Equal("os-region"))
+			Expect(Forms[0].Get("iaas_configuration[security_group]")).To(Equal("os-security-group"))
+			Expect(Forms[0].Get("iaas_configuration[tenant]")).To(Equal("os-tenant"))
+			Expect(Forms[0].Get("iaas_configuration[username]")).To(Equal("os-user"))
+			Expect(Forms[0].Get("iaas_configuration[ssh_private_key]")).To(Equal("my-private-ssh-key"))
+
+			Expect(Forms[0].Get("authenticity_token")).To(Equal("fake_authenticity"))
+			Expect(Forms[0].Get("_method")).To(Equal("fakemethod"))
+		})
+
+		It("does not configure keys that are not part of input", func() {
+			session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(session).Should(gexec.Exit(0))
+
+			_, ok := Forms[0]["iaas_configuration[subscription_id]"]
+			Expect(ok).To(BeFalse())
+		})
+	})
+
 	Context("vSphere", func() {
 		var command *exec.Cmd
 

--- a/commands/bosh_form_models.go
+++ b/commands/bosh_form_models.go
@@ -54,11 +54,27 @@ type VSphereIaaSConfiguration struct {
 	DiskPathFolder           string `url:"iaas_configuration[bosh_disk_path],omitempty" json:"bosh_disk_path"`
 }
 
+type OpenStackIaaSConfiguration struct {
+	APISSLCertificate            string `url:"iaas_configuration[api_ssl_cert],omitempty" json:"api_ssl_cert"`
+	DisableDHCP                  *bool  `url:"iaas_configuration[disable_dhcp],omitempty" json:"disable_dhcp"`
+	OpenStackDomain              string `url:"iaas_configuration[domain],omitempty" json:"openstack_domain"`
+	OpenStackAuthenticationURL   string `url:"iaas_configuration[identity_endpoint],omitempty" json:"openstack_authentication_url"`
+	IgnoreServerAvailabilityZone *bool  `url:"iaas_configuration[ignore_server_availability_zone],omitempty" json:"ignore_server_availability_zone"`
+	OpenStackKeyPairName         string `url:"iaas_configuration[key_pair_name],omitempty" json:"openstack_key_pair_name"`
+	KeyStoneVersion              string `url:"iaas_configuration[keystone_version],omitempty" json:"keystone_version"`
+	OpenStackPassword            string `url:"iaas_configuration[password],omitempty" json:"openstack_password"`
+	OpenStackRegion              string `url:"iaas_configuration[region],omitempty" json:"openstack_region"`
+	OpenStackSecurityGroup       string `url:"iaas_configuration[security_group],omitempty" json:"openstack_security_group"`
+	OpenStackTenant              string `url:"iaas_configuration[tenant],omitempty" json:"openstack_tenant"`
+	OpenStackUserName            string `url:"iaas_configuration[username],omitempty" json:"openstack_username"`
+}
+
 type CommonIaaSConfiguration struct {
 	SSHPrivateKey string `url:"iaas_configuration[ssh_private_key],omitempty" json:"ssh_private_key"`
 }
 
 type IaaSConfiguration struct {
+	OpenStackIaaSConfiguration
 	GCPIaaSConfiguration
 	AzureIaaSConfiguration
 	AWSIaaSConfiguration

--- a/docs/configure-bosh/README.md
+++ b/docs/configure-bosh/README.md
@@ -8,6 +8,7 @@ The `configure-bosh` command will allow you to setup your BOSH tile on the OpsMa
 * [GCP](gcp.md)
 * [Azure](azure.md)
 * [vSphere](vsphere.md)
+* [OpenStack](openstack.md)
 
 ## Command Usage
 ```

--- a/docs/configure-bosh/openstack.md
+++ b/docs/configure-bosh/openstack.md
@@ -1,0 +1,91 @@
+&larr; [back to `configure-bosh`](README.md)
+
+# OpenStack configure-bosh
+
+#### --iaas-configuration
+**Note for `ssh_private_key`**: You will need to replace newlines with "\n".
+This can be done with the simple `bash` chainsaw `cat key.pem | awk '{print $1 "\\n"}' | tr -d '\n'`.
+
+##### Minimal example
+```json
+{ 
+  "openstack_authentication_url": "http://openstack.example.com:5000/v2",
+  "openstack_username": "admin",
+  "openstack_password": "s3cret",
+  "openstack_tenant": "TENANT",
+  "openstack_region": "RegionOne",
+  "openstack_security_group": "opsmanager",
+  "keystone_version": "v2.0",
+  "ignore_server_availability_zone": true,
+  "ssh_private_key": "my-ssh-key",
+  "key_pair_name": "pcf"
+  }"
+```
+
+#### --director-configuration
+
+##### Minimal example
+```json
+{
+  "ntp_servers_string": "169.254.169.254"
+}
+```
+
+#### --security-configuration
+No additional security configuration is strictly required.
+
+##### Minimal example
+```json
+{
+  "trusted_certificates": "some-trusted-certificates",
+  "vm_password_type": "generate"
+}
+```
+
+#### --az-configuration
+
+##### Minimal example
+```json
+{
+  "availability_zones": [
+    {"name": "nova"}
+  ]
+}
+```
+
+#### --networks-configuration
+
+##### Minimal example
+```json
+{
+  "icmp_checks_enabled": false,
+  "networks": [
+    {
+      "name": "opsman-network",
+      "iaas_identifier": "openstack-network-guid",
+      "service_network": false,
+      "subnets": [
+        {
+          "cidr": "10.0.0.0/24",
+          "reserved_ip_ranges": "10.0.0.0-10.0.0.4",
+          "dns": "8.8.8.8",
+          "gateway": "10.0.0.1",
+          "availability_zones": [
+            "nova"
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
+#### --network-assignment
+
+##### Minimal example
+```json
+{
+  "singleton_availability_zone": "nova",
+  "network": "services"
+}
+```


### PR DESCRIPTION
We've tested this on a Pivotal Field engagement, and it seems tickety-boo against a v2 auth server and Ops Manager 1.9.3.