### PR TITLE
Provide empty errands param to delete-installation

### DIFF
--- a/api/installation_asset_service.go
+++ b/api/installation_asset_service.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -156,7 +157,7 @@ func (ia InstallationAssetService) Import(input ImportInstallationInput) error {
 }
 
 func (ia InstallationAssetService) Delete() (InstallationsServiceOutput, error) {
-	req, err := http.NewRequest("DELETE", "/api/v0/installation_asset_collection", nil)
+	req, err := http.NewRequest("DELETE", "/api/v0/installation_asset_collection", bytes.NewBuffer([]byte(`{"errands": {}}`)))
 	if err != nil {
 		return InstallationsServiceOutput{}, err
 	}

--- a/api/installation_asset_service_test.go
+++ b/api/installation_asset_service_test.go
@@ -301,6 +301,11 @@ var _ = Describe("InstallationAssetService", func() {
 			Expect(request.Method).To(Equal("DELETE"))
 			Expect(request.URL.Path).To(Equal("/api/v0/installation_asset_collection"))
 			Expect(request.Header.Get("Content-Type")).To(Equal("application/json"))
+
+			body, err := ioutil.ReadAll(request.Body)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(string(body)).To(Equal(`{"errands": {}}`))
 		})
 
 		It("gracefully quits when there is no installation to delete", func() {


### PR DESCRIPTION
OpsManager 1.10 expects an errands param, which is an array of errands to be
run before delete. Passing in an empty value as we don't want to run any
errands before destroying. This should stay consistent with current
behaviour.