### PR TITLE
Enable om curl to support opsmanager 1.7

### DIFF
--- a/api/request_service.go
+++ b/api/request_service.go
@@ -7,9 +7,10 @@ import (
 )
 
 type RequestServiceInvokeInput struct {
-	Path   string
-	Method string
-	Data   io.Reader
+	Path        string
+	Method      string
+	Data        io.Reader
+	ContentType string
 }
 
 type RequestServiceInvokeOutput struct {
@@ -32,7 +33,7 @@ func (rs RequestService) Invoke(input RequestServiceInvokeInput) (RequestService
 		return RequestServiceInvokeOutput{}, fmt.Errorf("failed constructing request: %s", err)
 	}
 
-	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("Content-Type", input.ContentType)
 	response, err := rs.client.Do(request)
 	if err != nil {
 		return RequestServiceInvokeOutput{}, fmt.Errorf("failed submitting request: %s", err)

--- a/api/request_service_test.go
+++ b/api/request_service_test.go
@@ -35,9 +35,10 @@ var _ = Describe("RequestService", func() {
 			}, nil)
 
 			output, err := service.Invoke(api.RequestServiceInvokeInput{
-				Method: "PUT",
-				Path:   "/api/v0/api/endpoint",
-				Data:   strings.NewReader("some-request-body"),
+				Method:      "PUT",
+				Path:        "/api/v0/api/endpoint",
+				Data:        strings.NewReader("some-request-body"),
+				ContentType: "application/json",
 			})
 			Expect(err).NotTo(HaveOccurred())
 

--- a/commands/curl.go
+++ b/commands/curl.go
@@ -24,10 +24,11 @@ type Curl struct {
 	stdout         logger
 	stderr         logger
 	Options        struct {
-		Path   string `short:"p" long:"path"    description:"path to api endpoint"`
-		Method string `short:"x" long:"request" description:"http verb" default:"GET"`
-		Data   string `short:"d" long:"data"    description:"api request payload"`
-		Silent bool   `short:"s" long:"silent"  description:"only write response headers to stderr if response status is 4XX or 5XX"`
+		Path        string `short:"p" long:"path"    description:"path to api endpoint"`
+		Method      string `short:"x" long:"request" description:"http verb" default:"GET"`
+		Data        string `short:"d" long:"data"    description:"api request payload"`
+		Silent      bool   `short:"s" long:"silent"  description:"only write response headers to stderr if response status is 4XX or 5XX"`
+		ContentType string `short:"c" long:"content-type" description:"content type of payload" default:"application/json"`
 	}
 }
 
@@ -46,9 +47,10 @@ func (c Curl) Execute(args []string) error {
 	}
 
 	input := api.RequestServiceInvokeInput{
-		Path:   c.Options.Path,
-		Method: c.Options.Method,
-		Data:   strings.NewReader(c.Options.Data),
+		Path:        c.Options.Path,
+		Method:      c.Options.Method,
+		Data:        strings.NewReader(c.Options.Data),
+		ContentType: c.Options.ContentType,
 	}
 
 	output, err := c.requestService.Invoke(input)


### PR DESCRIPTION
Ops manager 1.7 expects certain endpoints to send data encoded as `application/x-www-form-urlencode` (eg /api/v0/installations). This PR adds a new flag to the `om curl` command, `--content-type` that allows the user to override the content type header in order to send non-json encoded requests. By default it will still send requests as `application/json`

Signed-off-by: Ashish Sehra <ashish.sehra@armakuni.com>