### PR TITLE
Adding full example for product-resources

### DIFF
--- a/docs/configure-product/README.md
+++ b/docs/configure-product/README.md
@@ -152,6 +152,17 @@ For the current configuration of your product, you can `curl` the API to retriev
 
 ### Configuring the `--product-resources`
 
+```json
+{
+  "job-name": {
+    "instances": "automatic",
+    "instance_type": {"id": "automatic"},
+    "persistent_disk": {"size_mb": "automatic"}
+  }
+}
+```
+
+
 #### Example JSON:
 ```json
 {


### PR DESCRIPTION
It took me a lot of googling to find a mention of the full syntax for instance_type and persistent_disk for this section.   Strange the names of the parameters differ so much from the source of the web ui.  I didn't look at a metadatafile though, hopefully it matches there?