### PR TITLE
Log job name before getting existing job config

### DIFF
--- a/commands/configure_product.go
+++ b/commands/configure_product.go
@@ -123,6 +123,7 @@ func (cp ConfigureProduct) Execute(args []string) error {
 
 		cp.logger.Printf("applying resource configuration for the following jobs:")
 		for _, name := range names {
+			cp.logger.Printf("\t%s", name)
 			jobProperties, err := cp.jobsService.GetExistingJobConfig(productGUID, jobs[name])
 			if err != nil {
 				return fmt.Errorf("could not fetch existing job configuration: %s", err)
@@ -134,7 +135,6 @@ func (cp ConfigureProduct) Execute(args []string) error {
 			}
 
 			if !reflect.DeepEqual(jobProperties, api.JobProperties{}) {
-				cp.logger.Printf("\t%s", name)
 				err = cp.jobsService.ConfigureJob(productGUID, jobs[name], jobProperties)
 				if err != nil {
 					return fmt.Errorf("failed to configure resources: %s", err)


### PR DESCRIPTION
Currently `configure-product` output prints the name after it gets the existing job config. This can be confusing if you give a job name that doesn't exist and assume that the job that failed is the one that is printed.

e.g I saw this in my pipeline

```
applying resource configuration for the following jobs:
	backup-prepare
could not execute "configure-product": could not fetch existing job configuration: request failed: unexpected response:
```

om succeeded in configuring `backup-prepare`, but failed to configure `ccdb`, which was removed in pcf 1.12. Not quick to find out what was failing.