### PR TITLE
add guard for network-assignment on configure-director

### DIFF
--- a/acceptance/configure_director_test.go
+++ b/acceptance/configure_director_test.go
@@ -179,6 +179,9 @@ var _ = Describe("configure-director command", func() {
 
 				w.Write([]byte(`{}`))
 
+			case "/api/v0/deployed/director/credentials":
+				w.WriteHeader(http.StatusNotFound)
+
 			default:
 				out, err := httputil.DumpRequest(req, true)
 				Expect(err).NotTo(HaveOccurred())

--- a/api/director_service.go
+++ b/api/director_service.go
@@ -79,6 +79,11 @@ func (a Api) UpdateStagedDirectorNetworks(input json.RawMessage) error {
 }
 
 func (a Api) UpdateStagedDirectorNetworkAndAZ(input NetworkAndAZConfiguration) error {
+	_, err := a.sendAPIRequest("GET", "/api/v0/deployed/director/credentials", nil)
+	if err == nil {
+		a.logger.Println("unable to set network assignment for director as it has already been deployed")
+		return err
+	}
 	jsonData, err := json.Marshal(&input)
 	if err != nil {
 		return fmt.Errorf("could not marshal json: %s", err)


### PR DESCRIPTION
This guard allows network-assignment to be called multiple times without issuing an error. This helps with idempotence when calling `configure-director`.

Signed-off-by: Huan Wang <huwang@pivotal.io>