### PR TITLE
add a config flag for configure-director command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+.idea/
+
+# Created by https://www.gitignore.io/api/go
+### Go ###
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, build with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out


### PR DESCRIPTION
The configure-director command takes quite a few arguments that are JSON strings.
This can make it difficult to use from the command line.
The --config/-c option allows an equivalant YAML file to be used in place of the other flags.
It will return the same errors message as if the flags were invoked directly.

[Closes #139]