### PR TITLE
Adding the saml authentication support for configure-authentication

### DIFF
--- a/acceptance/configure_authentication_test.go
+++ b/acceptance/configure_authentication_test.go
@@ -13,23 +13,13 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/pivotal-cf/om/api"
 )
 
 var _ = Describe("configure-authentication command", func() {
 	It("configures the admin user account on OpsManager", func() {
 		var auth struct {
-			Setup struct {
-				IdentityProvider       string `json:"identity_provider"`
-				Username               string `json:"admin_user_name"`
-				Password               string `json:"admin_password"`
-				PasswordConfirmation   string `json:"admin_password_confirmation"`
-				Passphrase             string `json:"decryption_passphrase"`
-				PassphraseConfirmation string `json:"decryption_passphrase_confirmation"`
-				EULAAccepted           string `json:"eula_accepted"`
-				HTTPProxy              string `json:"http_proxy"`
-				HTTPSProxy             string `json:"https_proxy"`
-				NoProxy                string `json:"no_proxy"`
-			} `json:"setup"`
+			Setup api.SetupInput `json:"setup"`
 		}
 		var ensureAvailabilityCallCount int
 
@@ -80,14 +70,14 @@ var _ = Describe("configure-authentication command", func() {
 		Eventually(session, "5s").Should(gexec.Exit(0))
 
 		Expect(auth.Setup.IdentityProvider).To(Equal("internal"))
-		Expect(auth.Setup.Username).To(Equal("username"))
-		Expect(auth.Setup.Password).To(Equal("password"))
-		Expect(auth.Setup.PasswordConfirmation).To(Equal("password"))
-		Expect(auth.Setup.Passphrase).To(Equal("passphrase"))
-		Expect(auth.Setup.PassphraseConfirmation).To(Equal("passphrase"))
-		Expect(auth.Setup.EULAAccepted).To(Equal("true"))
-		Expect(auth.Setup.HTTPProxy).To(Equal("http://http-proxy.com"))
-		Expect(auth.Setup.HTTPSProxy).To(Equal("http://https-proxy.com"))
+		Expect(auth.Setup.AdminUserName).To(Equal("username"))
+		Expect(auth.Setup.AdminPassword).To(Equal("password"))
+		Expect(auth.Setup.AdminPasswordConfirmation).To(Equal("password"))
+		Expect(auth.Setup.DecryptionPassphrase).To(Equal("passphrase"))
+		Expect(auth.Setup.DecryptionPassphraseConfirmation).To(Equal("passphrase"))
+		Expect(auth.Setup.EULAAccepted).To(Equal(true))
+		Expect(auth.Setup.HTTPProxyURL).To(Equal("http://http-proxy.com"))
+		Expect(auth.Setup.HTTPSProxyURL).To(Equal("http://https-proxy.com"))
 		Expect(auth.Setup.NoProxy).To(Equal("10.10.10.10,11.11.11.11"))
 
 		Expect(ensureAvailabilityCallCount).To(Equal(3))

--- a/acceptance/configure_authentication_test.go
+++ b/acceptance/configure_authentication_test.go
@@ -75,7 +75,7 @@ var _ = Describe("configure-authentication command", func() {
 		Expect(auth.Setup.AdminPasswordConfirmation).To(Equal("password"))
 		Expect(auth.Setup.DecryptionPassphrase).To(Equal("passphrase"))
 		Expect(auth.Setup.DecryptionPassphraseConfirmation).To(Equal("passphrase"))
-		Expect(auth.Setup.EULAAccepted).To(Equal(true))
+		Expect(auth.Setup.EULAAccepted).To(Equal("true"))
 		Expect(auth.Setup.HTTPProxyURL).To(Equal("http://http-proxy.com"))
 		Expect(auth.Setup.HTTPSProxyURL).To(Equal("http://https-proxy.com"))
 		Expect(auth.Setup.NoProxy).To(Equal("10.10.10.10,11.11.11.11"))

--- a/acceptance/help_test.go
+++ b/acceptance/help_test.go
@@ -91,8 +91,12 @@ Command Arguments:
   --http-proxy-url              string             proxy for outbound HTTP network traffic
   --https-proxy-url             string             proxy for outbound HTTPS network traffic
   --no-proxy                    string             comma-separated list of hosts that do not go through the proxy
-  --password, -p                string (required)  admin password
-  --username, -u                string (required)  admin username
+  --password, -p                string             Internal Authentication: admin password
+  --saml-bosh-idp-metadata      string             SAML Authentication: XML, or URL to XML, for the IDP that BOSH should use
+  --saml-idp-metadata           string             SAML Authentication: XML, or URL to XML, for the IDP that Ops Manager should use
+  --saml-rbac-admin-group       string             SAML Authentication: If SAML is specified, please provide the admin group for your SAML
+  --saml-rbac-groups-attribute  string             SAML Authentication: If SAML is specified, please provide the groups attribute for your SAML
+  --username, -u                string             Internal Authentication: admin username
 `
 
 var _ = Describe("help", func() {

--- a/api/setup_service.go
+++ b/api/setup_service.go
@@ -17,7 +17,7 @@ type SetupInput struct {
 	AdminPasswordConfirmation        string `json:"admin_password_confirmation,omitempty"`
 	DecryptionPassphrase             string `json:"decryption_passphrase"`
 	DecryptionPassphraseConfirmation string `json:"decryption_passphrase_confirmation"`
-	EULAAccepted                     bool   `json:"eula_accepted"`
+	EULAAccepted                     string `json:"eula_accepted"`
 	HTTPProxyURL                     string `json:"http_proxy,omitempty"`
 	HTTPSProxyURL                    string `json:"https_proxy,omitempty"`
 	NoProxy                          string `json:"no_proxy,omitempty"`

--- a/api/setup_service.go
+++ b/api/setup_service.go
@@ -7,53 +7,26 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
-	"strconv"
 	"strings"
 )
 
 type SetupInput struct {
-	IdentityProvider                 string
-	AdminUserName                    string
-	AdminPassword                    string
-	AdminPasswordConfirmation        string
-	DecryptionPassphrase             string
-	DecryptionPassphraseConfirmation string
-	EULAAccepted                     bool
-	HTTPProxyURL                     string
-	HTTPSProxyURL                    string
-	NoProxy                          string
+	IdentityProvider                 string `json:"identity_provider"`
+	AdminUserName                    string `json:"admin_user_name,omitempty"`
+	AdminPassword                    string `json:"admin_password,omitempty"`
+	AdminPasswordConfirmation        string `json:"admin_password_confirmation,omitempty"`
+	DecryptionPassphrase             string `json:"decryption_passphrase"`
+	DecryptionPassphraseConfirmation string `json:"decryption_passphrase_confirmation"`
+	EULAAccepted                     bool   `json:"eula_accepted"`
+	HTTPProxyURL                     string `json:"http_proxy,omitempty"`
+	HTTPSProxyURL                    string `json:"https_proxy,omitempty"`
+	NoProxy                          string `json:"no_proxy,omitempty"`
 }
 
 type SetupOutput struct{}
 
 func (a Api) Setup(input SetupInput) (SetupOutput, error) {
-	var setup struct {
-		Setup struct {
-			IdentityProvider                 string `json:"identity_provider"`
-			AdminUserName                    string `json:"admin_user_name"`
-			AdminPassword                    string `json:"admin_password"`
-			AdminPasswordConfirmation        string `json:"admin_password_confirmation"`
-			DecryptionPassphrase             string `json:"decryption_passphrase"`
-			DecryptionPassphraseConfirmation string `json:"decryption_passphrase_confirmation"`
-			EULAAccepted                     string `json:"eula_accepted"`
-			HTTPProxyURL                     string `json:"http_proxy,omitempty"`
-			HTTPSProxyURL                    string `json:"https_proxy,omitempty"`
-			NoProxy                          string `json:"no_proxy,omitempty"`
-		} `json:"setup"`
-	}
-
-	setup.Setup.IdentityProvider = input.IdentityProvider
-	setup.Setup.AdminUserName = input.AdminUserName
-	setup.Setup.AdminPassword = input.AdminPassword
-	setup.Setup.AdminPasswordConfirmation = input.AdminPasswordConfirmation
-	setup.Setup.DecryptionPassphrase = input.DecryptionPassphrase
-	setup.Setup.DecryptionPassphraseConfirmation = input.DecryptionPassphraseConfirmation
-	setup.Setup.HTTPProxyURL = input.HTTPProxyURL
-	setup.Setup.HTTPSProxyURL = input.HTTPSProxyURL
-	setup.Setup.NoProxy = input.NoProxy
-	setup.Setup.EULAAccepted = strconv.FormatBool(input.EULAAccepted)
-
-	payload, err := json.Marshal(setup)
+	payload, err := json.Marshal(input)
 	if err != nil {
 		return SetupOutput{}, err
 	}

--- a/api/setup_service.go
+++ b/api/setup_service.go
@@ -21,12 +21,20 @@ type SetupInput struct {
 	HTTPProxyURL                     string `json:"http_proxy,omitempty"`
 	HTTPSProxyURL                    string `json:"https_proxy,omitempty"`
 	NoProxy                          string `json:"no_proxy,omitempty"`
+	IDPMetadata                      string `json:"idp_metadata,omitempty"`
+	BoshIDPMetadata                  string `json:"bosh_idp_metadata,omitempty"`
+	RBACAdminGroup                   string `json:"rbac_saml_admin_group,omitempty"`
+	RBACGroupsAttribute              string `json:"rbac_saml_groups_attribute,omitempty"`
 }
 
 type SetupOutput struct{}
 
+type setup struct {
+	SetupInput `json:"setup"`
+}
+
 func (a Api) Setup(input SetupInput) (SetupOutput, error) {
-	payload, err := json.Marshal(input)
+	payload, err := json.Marshal(setup{input})
 	if err != nil {
 		return SetupOutput{}, err
 	}

--- a/api/setup_service_test.go
+++ b/api/setup_service_test.go
@@ -64,7 +64,7 @@ var _ = Describe("Setup", func() {
 					"admin_password_confirmation": "some-password-confirmation",
 					"decryption_passphrase": "some-passphrase",
 					"decryption_passphrase_confirmation":"some-passphrase-confirmation",
-					"eula_accepted": "true",
+					"eula_accepted": true,
 					"http_proxy": "http://http-proxy.com",
 					"https_proxy": "http://https-proxy.com",
 					"no_proxy": "10.10.10.10,11.11.11.11"

--- a/api/setup_service_test.go
+++ b/api/setup_service_test.go
@@ -40,7 +40,7 @@ var _ = Describe("Setup", func() {
 				AdminPasswordConfirmation:        "some-password-confirmation",
 				DecryptionPassphrase:             "some-passphrase",
 				DecryptionPassphraseConfirmation: "some-passphrase-confirmation",
-				EULAAccepted:                     true,
+				EULAAccepted:                     "true",
 				HTTPProxyURL:                     "http://http-proxy.com",
 				HTTPSProxyURL:                    "http://https-proxy.com",
 				NoProxy:                          "10.10.10.10,11.11.11.11",
@@ -64,7 +64,7 @@ var _ = Describe("Setup", func() {
 					"admin_password_confirmation": "some-password-confirmation",
 					"decryption_passphrase": "some-passphrase",
 					"decryption_passphrase_confirmation":"some-passphrase-confirmation",
-					"eula_accepted": true,
+					"eula_accepted": "true",
 					"http_proxy": "http://http-proxy.com",
 					"https_proxy": "http://https-proxy.com",
 					"no_proxy": "10.10.10.10,11.11.11.11"

--- a/commands/configure_authentication.go
+++ b/commands/configure_authentication.go
@@ -1,11 +1,10 @@
 package commands
 
 import (
-	"errors"
-	"fmt"
-
-	"github.com/pivotal-cf/jhanda"
 	"github.com/pivotal-cf/om/api"
+	"github.com/pivotal-cf/jhanda"
+	"fmt"
+	"errors"
 )
 
 //go:generate counterfeiter -o ./fakes/configure_authentication_service.go --fake-name ConfigureAuthenticationService . configureAuthenticationService
@@ -18,12 +17,16 @@ type ConfigureAuthentication struct {
 	service configureAuthenticationService
 	logger  logger
 	Options struct {
-		Username             string `long:"username"              short:"u"  required:"true" description:"admin username"`
-		Password             string `long:"password"              short:"p"  required:"true" description:"admin password"`
+		Username             string `long:"username"              short:"u"                  description:"Internal Authentication: admin username"`
+		Password             string `long:"password"              short:"p"                  description:"Internal Authentication: admin password"`
 		DecryptionPassphrase string `long:"decryption-passphrase" short:"dp" required:"true" description:"passphrase used to encrypt the installation"`
 		HTTPProxyURL         string `long:"http-proxy-url"                                   description:"proxy for outbound HTTP network traffic"`
 		HTTPSProxyURL        string `long:"https-proxy-url"                                  description:"proxy for outbound HTTPS network traffic"`
 		NoProxy              string `long:"no-proxy"                                         description:"comma-separated list of hosts that do not go through the proxy"`
+		IDPMetadata          string `long:"saml-idp-metadata"                                description:"SAML Authentication: XML, or URL to XML, for the IDP that Ops Manager should use"`
+		BoshIDPMetadata      string `long:"saml-bosh-idp-metadata"                           description:"SAML Authentication: XML, or URL to XML, for the IDP that BOSH should use"`
+		RBACAdminGroup       string `long:"saml-rbac-admin-group"                            description:"SAML Authentication: If SAML is specified, please provide the admin group for your SAML"`
+		RBACGroupsAttribute  string `long:"saml-rbac-groups-attribute"                       description:"SAML Authentication: If SAML is specified, please provide the groups attribute for your SAML"`
 	}
 }
 
@@ -34,9 +37,57 @@ func NewConfigureAuthentication(service configureAuthenticationService, logger l
 	}
 }
 
+type method int
+
+const (
+	noMethod method = iota
+	internal
+	saml
+)
+
+func (ca ConfigureAuthentication) validate() (method, error) {
+	if ca.Options.Username != "" || ca.Options.Password != "" {
+		// expect all saml not set, other wise: Error: should only o=use internal or saml
+		// expect all internal setother wise, Error, missing field
+		switch {
+		case ca.Options.Username == "":
+			return noMethod, fmt.Errorf("could not parse configure-authentication flags: missing required flag \"--username\"")
+		case ca.Options.Password == "":
+			return noMethod, fmt.Errorf("could not parse configure-authentication flags: missing required flag \"--password\"")
+		case ca.Options.DecryptionPassphrase == "":
+			return noMethod, fmt.Errorf("could not parse configure-authentication flags: missing required flag \"--decryption-passphrase\"")
+		}
+		return internal, nil
+	} else if ca.Options.IDPMetadata != "" ||
+		ca.Options.BoshIDPMetadata != "" ||
+		ca.Options.RBACAdminGroup != "" ||
+		ca.Options.RBACGroupsAttribute != "" {
+		// expect all internal not set,  other wise: Error: should only o=use internal or saml
+		// expect all saml set, other wise: Error, missing field
+		switch {
+		case ca.Options.IDPMetadata == "":
+			return noMethod, fmt.Errorf("could not parse configure-authentication flags: missing required flag \"--saml-idp-metadata\"")
+		case ca.Options.BoshIDPMetadata == "":
+			return noMethod, fmt.Errorf("could not parse configure-authentication flags: missing required flag \"--saml-bosh-idp-metadata\"")
+		case ca.Options.RBACAdminGroup == "":
+			return noMethod, fmt.Errorf("could not parse configure-authentication flags: missing required flag \"--saml-rbac-admin-group\"")
+		case ca.Options.RBACGroupsAttribute == "":
+			return noMethod, fmt.Errorf("could not parse configure-authentication flags: missing required flag \"--saml-rbac-groups-attribute\"")
+		}
+		return saml, nil
+	}
+
+	return noMethod, fmt.Errorf("No values set!")
+}
+
 func (ca ConfigureAuthentication) Execute(args []string) error {
 	if _, err := jhanda.Parse(&ca.Options, args); err != nil {
 		return fmt.Errorf("could not parse configure-authentication flags: %s", err)
+	}
+
+	authType, err := ca.validate()
+	if err != nil {
+		return err
 	}
 
 	ensureAvailabilityOutput, err := ca.service.EnsureAvailability(api.EnsureAvailabilityInput{})
@@ -53,21 +104,46 @@ func (ca ConfigureAuthentication) Execute(args []string) error {
 		return nil
 	}
 
-	ca.logger.Printf("configuring internal userstore...")
-	_, err = ca.service.Setup(api.SetupInput{
-		IdentityProvider:                 "internal",
-		AdminUserName:                    ca.Options.Username,
-		AdminPassword:                    ca.Options.Password,
-		AdminPasswordConfirmation:        ca.Options.Password,
-		DecryptionPassphrase:             ca.Options.DecryptionPassphrase,
-		DecryptionPassphraseConfirmation: ca.Options.DecryptionPassphrase,
-		HTTPProxyURL:                     ca.Options.HTTPProxyURL,
-		HTTPSProxyURL:                    ca.Options.HTTPSProxyURL,
-		NoProxy:                          ca.Options.NoProxy,
-		EULAAccepted:                     true,
-	})
-	if err != nil {
-		return fmt.Errorf("could not configure authentication: %s", err)
+
+	switch authType {
+	case saml:
+		ca.logger.Printf("configuring SAML authentication...")
+
+		_, err = ca.service.Setup(api.SetupInput{
+			IdentityProvider:                 "saml",
+			DecryptionPassphrase:             ca.Options.DecryptionPassphrase,
+			DecryptionPassphraseConfirmation: ca.Options.DecryptionPassphrase,
+			HTTPProxyURL:                     ca.Options.HTTPProxyURL,
+			HTTPSProxyURL:                    ca.Options.HTTPSProxyURL,
+			NoProxy:                          ca.Options.NoProxy,
+			EULAAccepted:                     true,
+			IDPMetadata:                      ca.Options.IDPMetadata,
+			BoshIDPMetadata:                  ca.Options.BoshIDPMetadata,
+			RBACAdminGroup:                   ca.Options.RBACAdminGroup,
+			RBACGroupsAttribute:              ca.Options.RBACGroupsAttribute,
+		})
+		if err != nil {
+			return fmt.Errorf("could not configure authentication: %s", err)
+		}
+	case internal:
+		ca.logger.Printf("configuring internal userstore...")
+		// Check for all fields
+
+		_, err = ca.service.Setup(api.SetupInput{
+			IdentityProvider:                 "internal",
+			AdminUserName:                    ca.Options.Username,
+			AdminPassword:                    ca.Options.Password,
+			AdminPasswordConfirmation:        ca.Options.Password,
+			DecryptionPassphrase:             ca.Options.DecryptionPassphrase,
+			DecryptionPassphraseConfirmation: ca.Options.DecryptionPassphrase,
+			HTTPProxyURL:                     ca.Options.HTTPProxyURL,
+			HTTPSProxyURL:                    ca.Options.HTTPSProxyURL,
+			NoProxy:                          ca.Options.NoProxy,
+			EULAAccepted:                     true,
+		})
+		if err != nil {
+			return fmt.Errorf("could not configure authentication: %s", err)
+		}
 	}
 
 	ca.logger.Printf("waiting for configuration to complete...")

--- a/commands/configure_authentication.go
+++ b/commands/configure_authentication.go
@@ -116,7 +116,7 @@ func (ca ConfigureAuthentication) Execute(args []string) error {
 			HTTPProxyURL:                     ca.Options.HTTPProxyURL,
 			HTTPSProxyURL:                    ca.Options.HTTPSProxyURL,
 			NoProxy:                          ca.Options.NoProxy,
-			EULAAccepted:                     true,
+			EULAAccepted:                     "true",
 			IDPMetadata:                      ca.Options.IDPMetadata,
 			BoshIDPMetadata:                  ca.Options.BoshIDPMetadata,
 			RBACAdminGroup:                   ca.Options.RBACAdminGroup,
@@ -139,7 +139,7 @@ func (ca ConfigureAuthentication) Execute(args []string) error {
 			HTTPProxyURL:                     ca.Options.HTTPProxyURL,
 			HTTPSProxyURL:                    ca.Options.HTTPSProxyURL,
 			NoProxy:                          ca.Options.NoProxy,
-			EULAAccepted:                     true,
+			EULAAccepted:                     "true",
 		})
 		if err != nil {
 			return fmt.Errorf("could not configure authentication: %s", err)

--- a/commands/configure_authentication_test.go
+++ b/commands/configure_authentication_test.go
@@ -45,7 +45,7 @@ var _ = Describe("ConfigureAuthentication", func() {
 				AdminPasswordConfirmation:        "some-password",
 				DecryptionPassphrase:             "some-passphrase",
 				DecryptionPassphraseConfirmation: "some-passphrase",
-				EULAAccepted:                     true,
+				EULAAccepted:                     "true",
 			}))
 
 			Expect(service.EnsureAvailabilityCallCount()).To(Equal(4))
@@ -94,7 +94,7 @@ var _ = Describe("ConfigureAuthentication", func() {
 					IdentityProvider:                 "saml",
 					DecryptionPassphrase:             "some-passphrase",
 					DecryptionPassphraseConfirmation: "some-passphrase",
-					EULAAccepted:                     true,
+					EULAAccepted:                     "true",
 					IDPMetadata:                      "https://saml.example.com:8080",
 					BoshIDPMetadata:                  "https://bosh-saml.example.com:8080",
 					RBACAdminGroup:                   "opsman.full_control",

--- a/commands/configure_authentication_test.go
+++ b/commands/configure_authentication_test.go
@@ -60,6 +60,60 @@ var _ = Describe("ConfigureAuthentication", func() {
 			Expect(fmt.Sprintf(format, content...)).To(Equal("configuration complete"))
 		})
 
+		//It("defaults to internal authentication", func() {
+		//
+		//})
+
+		Context("when provided flags for SAML authentication", func() {
+			It("configures SAML authentication", func() {
+				service := &fakes.ConfigureAuthenticationService{}
+				eaOutputs := []api.EnsureAvailabilityOutput{
+					{Status: api.EnsureAvailabilityStatusUnstarted},
+					{Status: api.EnsureAvailabilityStatusPending},
+					{Status: api.EnsureAvailabilityStatusPending},
+					{Status: api.EnsureAvailabilityStatusComplete},
+				}
+
+				service.EnsureAvailabilityStub = func(api.EnsureAvailabilityInput) (api.EnsureAvailabilityOutput, error) {
+					return eaOutputs[service.EnsureAvailabilityCallCount()-1], nil
+				}
+
+				logger := &fakes.Logger{}
+
+				command := commands.NewConfigureAuthentication(service, logger)
+				err := command.Execute([]string{
+					"--decryption-passphrase", "some-passphrase",
+					"--saml-idp-metadata", "https://saml.example.com:8080",
+					"--saml-bosh-idp-metadata", "https://bosh-saml.example.com:8080",
+					"--saml-rbac-admin-group", "opsman.full_control",
+					"--saml-rbac-groups-attribute", "myenterprise",
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(service.SetupArgsForCall(0)).To(Equal(api.SetupInput{
+					IdentityProvider:                 "saml",
+					DecryptionPassphrase:             "some-passphrase",
+					DecryptionPassphraseConfirmation: "some-passphrase",
+					EULAAccepted:                     true,
+					IDPMetadata:                      "https://saml.example.com:8080",
+					BoshIDPMetadata:                  "https://bosh-saml.example.com:8080",
+					RBACAdminGroup:                   "opsman.full_control",
+					RBACGroupsAttribute:              "myenterprise",
+				}))
+
+				Expect(service.EnsureAvailabilityCallCount()).To(Equal(4))
+
+				format, content := logger.PrintfArgsForCall(0)
+				Expect(fmt.Sprintf(format, content...)).To(Equal("configuring SAML authentication..."))
+
+				format, content = logger.PrintfArgsForCall(1)
+				Expect(fmt.Sprintf(format, content...)).To(Equal("waiting for configuration to complete..."))
+
+				format, content = logger.PrintfArgsForCall(2)
+				Expect(fmt.Sprintf(format, content...)).To(Equal("configuration complete"))
+			})
+		})
+
 		Context("when the authentication setup has already been configured", func() {
 			It("returns without configuring the authentication system", func() {
 				service := &fakes.ConfigureAuthenticationService{}
@@ -172,7 +226,67 @@ var _ = Describe("ConfigureAuthentication", func() {
 				})
 			})
 
-			Context("when the --username flag is missing", func() {
+			Context("when the --saml-idp-metadata field is not configured with others", func() {
+				It("returns an error", func() {
+					command := commands.NewConfigureAuthentication(nil, nil)
+					err := command.Execute([]string{
+						"--decryption-passphrase", "some-passphrase",
+						"--saml-bosh-idp-metadata", "https://bosh-saml.example.com:8080",
+						"--saml-rbac-admin-group", "opsman.full_control",
+						"--saml-rbac-groups-attribute", "myenterprise",
+					})
+					Expect(err).To(HaveOccurred())
+
+					Expect(err).To(MatchError("could not parse configure-authentication flags: missing required flag \"--saml-idp-metadata\""))
+				})
+			})
+
+			Context("when the --saml-bosh-idp-metadata field is not configured with others", func() {
+				It("returns an error", func() {
+					command := commands.NewConfigureAuthentication(nil, nil)
+					err := command.Execute([]string{
+						"--decryption-passphrase", "some-passphrase",
+						"--saml-idp-metadata", "https://saml.example.com:8080",
+						"--saml-rbac-admin-group", "opsman.full_control",
+						"--saml-rbac-groups-attribute", "myenterprise",
+					})
+					Expect(err).To(HaveOccurred())
+
+					Expect(err).To(MatchError("could not parse configure-authentication flags: missing required flag \"--saml-bosh-idp-metadata\""))
+				})
+			})
+
+			Context("when the --saml-rbac-admin-group field is not configured with others", func() {
+				It("returns an error", func() {
+					command := commands.NewConfigureAuthentication(nil, nil)
+					err := command.Execute([]string{
+						"--decryption-passphrase", "some-passphrase",
+						"--saml-idp-metadata", "https://saml.example.com:8080",
+						"--saml-bosh-idp-metadata", "https://bosh-saml.example.com:8080",
+						"--saml-rbac-groups-attribute", "myenterprise",
+					})
+					Expect(err).To(HaveOccurred())
+
+					Expect(err).To(MatchError("could not parse configure-authentication flags: missing required flag \"--saml-rbac-admin-group\""))
+				})
+			})
+
+			Context("when the --saml-rbac-groups-attribute field is not configured with others", func() {
+				It("returns an error", func() {
+					command := commands.NewConfigureAuthentication(nil, nil)
+					err := command.Execute([]string{
+						"--decryption-passphrase", "some-passphrase",
+						"--saml-idp-metadata", "https://saml.example.com:8080",
+						"--saml-bosh-idp-metadata", "https://bosh-saml.example.com:8080",
+						"--saml-rbac-admin-group", "opsman.full_control",
+					})
+					Expect(err).To(HaveOccurred())
+
+					Expect(err).To(MatchError("could not parse configure-authentication flags: missing required flag \"--saml-rbac-groups-attribute\""))
+				})
+			})
+
+			Context("when the --username flag is missing without SAML options", func() {
 				It("returns an error", func() {
 					command := commands.NewConfigureAuthentication(nil, nil)
 					err := command.Execute([]string{
@@ -183,7 +297,7 @@ var _ = Describe("ConfigureAuthentication", func() {
 				})
 			})
 
-			Context("when the --password flag is missing", func() {
+			Context("when the --password flag is missing without SAML options", func() {
 				It("returns an error", func() {
 					command := commands.NewConfigureAuthentication(nil, nil)
 					err := command.Execute([]string{

--- a/docs/configure-authentication/README.md
+++ b/docs/configure-authentication/README.md
@@ -3,7 +3,11 @@
 # `om configure-authentication`
 
 The `configure-authentication` command will allow you to setup your user account on the Ops Manager.
-Currently, the command only supports password authentication.
+
+## Supported Authentication Methods
+##### Using Internal Authentication)
+* Internal
+* SAML
 
 ## Command Usage
 ```
@@ -27,4 +31,25 @@ Command Arguments:
   --http-proxy-url              string  proxy for outbound HTTP network traffic
   --https-proxy-url             string  proxy for outbound HTTPS network traffic
   --no-proxy                    string  comma-separated list of hosts that do not go through the proxy
+  
+Command Arguments:
+  --username, -u                string             Internal Authentication: admin username
+  --password, -p                string             Internal Authentication: admin password
+  --decryption-passphrase, -dp  string (required)  passphrase used to encrypt the installation
+  --saml-idp-metadata           string             SAML Authentication: XML, or URL to XML, for the IDP that Ops Manager should use
+  --saml-bosh-idp-metadata      string             SAML Authentication: XML, or URL to XML, for the IDP that BOSH should use
+  --saml-rbac-admin-group       string             SAML Authentication: If SAML is specified, please provide the admin group for your SAML
+  --saml-rbac-groups-attribute  string             SAML Authentication: If SAML is specified, please provide the groups attribute for your SAML
+  --http-proxy-url              string             proxy for outbound HTTP network traffic
+  --https-proxy-url             string             proxy for outbound HTTPS network traffic
+  --no-proxy                    string             comma-separated list of hosts that do not go through the proxy
 ```
+
+## Using Internal Authentication
+This method requires `--username`, `--password` and `--decryption-passphrase` to be set.
+
+## Using SAML Authentication
+This method requires `--decryption-passphrase`, `--saml-idp-metadata`, `--saml-bosh-idp-metadata`,
+ `--saml-rbac-admin-group`, and `--saml-rbac-groups-attribute` to be set.
+
+The `--saml-idp-metadata` and `--saml-bosh-idp-metadata` can be the same.


### PR DESCRIPTION
Four new flags added to `configure-authenticaion`
```
+  --saml-bosh-idp-metadata      string             SAML Authentication: XML, or URL to XML, for the IDP that BOSH should use
+  --saml-idp-metadata           string             SAML Authentication: XML, or URL to XML, for the IDP that Ops Manager should use
+  --saml-rbac-admin-group       string             SAML Authentication: If SAML is specified, please provide the admin group for your SAML
+  --saml-rbac-groups-attribute  string             SAML Authentication: If SAML is specified, please provide the groups attribute for your SAML
```

