### PR TITLE
Fix configure-product YAML example

### DIFF
--- a/docs/configure-product/README.md
+++ b/docs/configure-product/README.md
@@ -215,9 +215,9 @@ network-properties:
   singleton_availability_zone:
     name: us-west-2a
 resource-config:
-  diego-cell:
+  diego_cell:
     instances: 3
-  diego-brain:
+  diego_brain:
     elb_names:
     - some-elb
 ```


### PR DESCRIPTION
This is a small change but it held us up for a bit. The instance groups listed in the resource config YAML example are wrong, and should match the actual values you can set. The error you get back from `om` does not indicate that it's a job that doesn't exist, so this should help folks that want to learn to use that functionality.