### PR TITLE
Add connect timeout var

### DIFF
--- a/acceptance/help_test.go
+++ b/acceptance/help_test.go
@@ -15,6 +15,7 @@ om helps you interact with an Ops Manager
 Usage: om [options] <command> [<args>]
   --client-id, -c            string  Client ID for the Ops Manager VM (not required for unauthenticated commands, $OM_CLIENT_ID)
   --client-secret, -s        string  Client Secret for the Ops Manager VM (not required for unauthenticated commands, $OM_CLIENT_SECRET)
+  --connect-timeout, -o      int     timeout in seconds to make TCP connections (default: 5)
   --format, -f               string  Format to print as (options: table,json) (default: table)
   --help, -h                 bool    prints this usage information (default: false)
   --password, -p             string  admin password for the Ops Manager VM (not required for unauthenticated commands, $OM_PASSWORD)
@@ -76,6 +77,7 @@ The "internal" userstore mechanism is the only currently supported option.
 Usage: om [options] configure-authentication [<args>]
   --client-id, -c            string  Client ID for the Ops Manager VM (not required for unauthenticated commands, $OM_CLIENT_ID)
   --client-secret, -s        string  Client Secret for the Ops Manager VM (not required for unauthenticated commands, $OM_CLIENT_SECRET)
+  --connect-timeout, -o      int     timeout in seconds to make TCP connections (default: 5)
   --format, -f               string  Format to print as (options: table,json) (default: table)
   --help, -h                 bool    prints this usage information (default: false)
   --password, -p             string  admin password for the Ops Manager VM (not required for unauthenticated commands, $OM_PASSWORD)

--- a/docs/configure-product/README.md
+++ b/docs/configure-product/README.md
@@ -215,9 +215,9 @@ network-properties:
   singleton_availability_zone:
     name: us-west-2a
 resource-config:
-  diego-cell:
+  diego_cell:
     instances: 3
-  diego-brain:
+  diego_brain:
     elb_names:
     - some-elb
 ```

--- a/main.go
+++ b/main.go
@@ -39,6 +39,7 @@ func main() {
 		Format            string `short:"f"  long:"format"              default:"table" description:"Format to print as (options: table,json)"`
 		Help              bool   `short:"h"  long:"help"                default:"false" description:"prints this usage information"`
 		Password          string `short:"p"  long:"password"                            description:"admin password for the Ops Manager VM (not required for unauthenticated commands, $OM_PASSWORD)"`
+		ConnectTimeout    int    `short:"o"  long:"connect-timeout"     default:"5"     description:"timeout in seconds to make TCP connections"`
 		RequestTimeout    int    `short:"r"  long:"request-timeout"     default:"1800"  description:"timeout in seconds for HTTP requests to Ops Manager"`
 		SkipSSLValidation bool   `short:"k"  long:"skip-ssl-validation" default:"false" description:"skip ssl certificate validation during http requests"`
 		Target            string `short:"t"  long:"target"                              description:"location of the Ops Manager VM"`
@@ -91,14 +92,15 @@ func main() {
 	}
 
 	requestTimeout := time.Duration(global.RequestTimeout) * time.Second
+	connectTimeout := time.Duration(global.ConnectTimeout) * time.Second
 
 	var unauthenticatedClient, authedClient, authedCookieClient, unauthenticatedProgressClient, authedProgressClient httpClient
-	unauthenticatedClient = network.NewUnauthenticatedClient(global.Target, global.SkipSSLValidation, requestTimeout)
-	authedClient, err = network.NewOAuthClient(global.Target, global.Username, global.Password, global.ClientID, global.ClientSecret, global.SkipSSLValidation, false, requestTimeout)
+	unauthenticatedClient = network.NewUnauthenticatedClient(global.Target, global.SkipSSLValidation, requestTimeout, connectTimeout)
+	authedClient, err = network.NewOAuthClient(global.Target, global.Username, global.Password, global.ClientID, global.ClientSecret, global.SkipSSLValidation, false, requestTimeout, connectTimeout)
 	if err != nil {
 		stdout.Fatal(err)
 	}
-	authedCookieClient, err = network.NewOAuthClient(global.Target, global.Username, global.Password, global.ClientID, global.ClientSecret, global.SkipSSLValidation, true, requestTimeout)
+	authedCookieClient, err = network.NewOAuthClient(global.Target, global.Username, global.Password, global.ClientID, global.ClientSecret, global.SkipSSLValidation, true, requestTimeout, connectTimeout)
 	if err != nil {
 		stdout.Fatal(err)
 	}

--- a/network/oauth_client.go
+++ b/network/oauth_client.go
@@ -26,7 +26,7 @@ type OAuthClient struct {
 	timeout       time.Duration
 }
 
-func NewOAuthClient(target, username, password string, clientID, clientSecret string, insecureSkipVerify bool, includeCookies bool, requestTimeout time.Duration) (OAuthClient, error) {
+func NewOAuthClient(target, username, password string, clientID, clientSecret string, insecureSkipVerify bool, includeCookies bool, requestTimeout time.Duration, connectTimeout time.Duration) (OAuthClient, error) {
 	conf := &oauth2.Config{
 		ClientID:     "opsman",
 		ClientSecret: "",
@@ -45,7 +45,7 @@ func NewOAuthClient(target, username, password string, clientID, clientSecret st
 				InsecureSkipVerify: insecureSkipVerify,
 			},
 			Dial: (&net.Dialer{
-				Timeout:   5 * time.Second,
+				Timeout:   connectTimeout,
 				KeepAlive: 30 * time.Second,
 			}).Dial,
 		},

--- a/network/oauth_client_test.go
+++ b/network/oauth_client_test.go
@@ -61,7 +61,7 @@ var _ = Describe("OAuthClient", func() {
 
 	Describe("Do", func() {
 		It("makes a request with authentication", func() {
-			client, err := network.NewOAuthClient(server.URL, "opsman-username", "opsman-password", "", "", true, false, time.Duration(30)*time.Second)
+			client, err := network.NewOAuthClient(server.URL, "opsman-username", "opsman-password", "", "", true, false, time.Duration(30)*time.Second, time.Duration(5)*time.Second)
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(callCount).To(Equal(0))
@@ -95,7 +95,7 @@ var _ = Describe("OAuthClient", func() {
 		})
 
 		It("makes a request with client credentials", func() {
-			client, err := network.NewOAuthClient(server.URL, "", "", "client_id", "client_secret", true, false, time.Duration(30)*time.Second)
+			client, err := network.NewOAuthClient(server.URL, "", "", "client_id", "client_secret", true, false, time.Duration(30)*time.Second, time.Duration(5)*time.Second)
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(callCount).To(Equal(0))
@@ -134,7 +134,7 @@ var _ = Describe("OAuthClient", func() {
 				noScheme.Scheme = ""
 				finalURL := noScheme.String()
 
-				client, err := network.NewOAuthClient(finalURL, "opsman-username", "opsman-password", "", "", true, false, time.Duration(30)*time.Second)
+				client, err := network.NewOAuthClient(finalURL, "opsman-username", "opsman-password", "", "", true, false, time.Duration(30)*time.Second, time.Duration(5)*time.Second)
 				Expect(err).NotTo(HaveOccurred())
 
 				req, err := http.NewRequest("GET", "/some/path", strings.NewReader("request-body"))
@@ -150,7 +150,7 @@ var _ = Describe("OAuthClient", func() {
 		Context("when insecureSkipVerify is configured", func() {
 			Context("when it is set to false", func() {
 				It("throws an error for invalid certificates", func() {
-					client, err := network.NewOAuthClient(server.URL, "opsman-username", "opsman-password", "", "", false, false, time.Duration(30)*time.Second)
+					client, err := network.NewOAuthClient(server.URL, "opsman-username", "opsman-password", "", "", false, false, time.Duration(30)*time.Second, time.Duration(5)*time.Second)
 					Expect(err).NotTo(HaveOccurred())
 
 					req, err := http.NewRequest("GET", "/some/path", strings.NewReader("request-body"))
@@ -163,7 +163,7 @@ var _ = Describe("OAuthClient", func() {
 
 			Context("when it is set to true", func() {
 				It("does not verify certificates", func() {
-					client, err := network.NewOAuthClient(server.URL, "opsman-username", "opsman-password", "", "", true, false, time.Duration(30)*time.Second)
+					client, err := network.NewOAuthClient(server.URL, "opsman-username", "opsman-password", "", "", true, false, time.Duration(30)*time.Second, time.Duration(5)*time.Second)
 					Expect(err).NotTo(HaveOccurred())
 
 					req, err := http.NewRequest("GET", "/some/path", strings.NewReader("request-body"))
@@ -178,7 +178,7 @@ var _ = Describe("OAuthClient", func() {
 		Context("when includeCookies is configured", func() {
 			Context("when it is set to true", func() {
 				It("has a cookie jar", func() {
-					client, err := network.NewOAuthClient(server.URL, "opsman-username", "opsman-password", "", "", true, true, time.Duration(30)*time.Second)
+					client, err := network.NewOAuthClient(server.URL, "opsman-username", "opsman-password", "", "", true, true, time.Duration(30)*time.Second, time.Duration(5)*time.Second)
 					Expect(err).NotTo(HaveOccurred())
 
 					req, err := http.NewRequest("GET", "/some/path", strings.NewReader("request-body"))
@@ -200,7 +200,7 @@ var _ = Describe("OAuthClient", func() {
 
 			Context("when it is false", func() {
 				It("does not collect any of the cookies", func() {
-					client, err := network.NewOAuthClient(server.URL, "opsman-username", "opsman-password", "", "", true, false, time.Duration(30)*time.Second)
+					client, err := network.NewOAuthClient(server.URL, "opsman-username", "opsman-password", "", "", true, false, time.Duration(30)*time.Second, time.Duration(5)*time.Second)
 					Expect(err).NotTo(HaveOccurred())
 
 					req, err := http.NewRequest("GET", "/some/path", strings.NewReader("request-body"))
@@ -231,7 +231,7 @@ var _ = Describe("OAuthClient", func() {
 				})
 
 				It("returns an error", func() {
-					client, err := network.NewOAuthClient(badServer.URL, "username", "password", "", "", true, false, time.Duration(30)*time.Second)
+					client, err := network.NewOAuthClient(badServer.URL, "username", "password", "", "", true, false, time.Duration(30)*time.Second, time.Duration(5)*time.Second)
 					Expect(err).NotTo(HaveOccurred())
 
 					req, err := http.NewRequest("GET", "/some/path", strings.NewReader("request-body"))
@@ -244,7 +244,7 @@ var _ = Describe("OAuthClient", func() {
 
 			Context("when the target url is empty", func() {
 				It("returns an error", func() {
-					client, err := network.NewOAuthClient("", "username", "password", "", "", false, false, time.Duration(30)*time.Second)
+					client, err := network.NewOAuthClient("", "username", "password", "", "", false, false, time.Duration(30)*time.Second, time.Duration(5)*time.Second)
 					Expect(err).NotTo(HaveOccurred())
 
 					req, err := http.NewRequest("GET", "/some/path", strings.NewReader("request-body"))

--- a/network/unauthenticated_client.go
+++ b/network/unauthenticated_client.go
@@ -15,7 +15,7 @@ type UnauthenticatedClient struct {
 	client *http.Client
 }
 
-func NewUnauthenticatedClient(target string, insecureSkipVerify bool, requestTimeout time.Duration) UnauthenticatedClient {
+func NewUnauthenticatedClient(target string, insecureSkipVerify bool, requestTimeout time.Duration, connectTimeout time.Duration) UnauthenticatedClient {
 	return UnauthenticatedClient{
 		target: target,
 		client: &http.Client{
@@ -28,7 +28,7 @@ func NewUnauthenticatedClient(target string, insecureSkipVerify bool, requestTim
 					InsecureSkipVerify: insecureSkipVerify,
 				},
 				Dial: (&net.Dialer{
-					Timeout:   5 * time.Second,
+					Timeout:   connectTimeout,
 					KeepAlive: 30 * time.Second,
 				}).Dial,
 			},

--- a/network/unauthenticated_client_test.go
+++ b/network/unauthenticated_client_test.go
@@ -31,7 +31,7 @@ var _ = Describe("UnauthenticatedClient", func() {
 				w.Write([]byte("response"))
 			}))
 
-			client := network.NewUnauthenticatedClient(server.URL, true, time.Duration(30)*time.Second)
+			client := network.NewUnauthenticatedClient(server.URL, true, time.Duration(30)*time.Second, time.Duration(5)*time.Second)
 
 			request, err := http.NewRequest("GET", "/path?query", strings.NewReader("request"))
 			Expect(err).NotTo(HaveOccurred())
@@ -70,7 +70,7 @@ var _ = Describe("UnauthenticatedClient", func() {
 				noScheme.Scheme = ""
 				finalURL := strings.Replace(noScheme.String(), "//", "", 1)
 
-				client := network.NewUnauthenticatedClient(finalURL, true, time.Duration(30)*time.Second)
+				client := network.NewUnauthenticatedClient(finalURL, true, time.Duration(30)*time.Second, time.Duration(5)*time.Second)
 				Expect(err).NotTo(HaveOccurred())
 
 				request, err := http.NewRequest("GET", "/some/path", strings.NewReader("request-body"))
@@ -87,7 +87,7 @@ var _ = Describe("UnauthenticatedClient", func() {
 		Context("failure cases", func() {
 			Context("when the target url cannot be parsed", func() {
 				It("returns an error", func() {
-					client := network.NewUnauthenticatedClient("%%%", false, time.Duration(30)*time.Second)
+					client := network.NewUnauthenticatedClient("%%%", false, time.Duration(30)*time.Second, time.Duration(5)*time.Second)
 					_, err := client.Do(&http.Request{})
 					Expect(err).To(MatchError("could not parse target url: parse //%%%: invalid URL escape \"%%%\""))
 				})
@@ -95,7 +95,7 @@ var _ = Describe("UnauthenticatedClient", func() {
 
 			Context("when the target url is empty", func() {
 				It("returns an error", func() {
-					client := network.NewUnauthenticatedClient("", false, time.Duration(30)*time.Second)
+					client := network.NewUnauthenticatedClient("", false, time.Duration(30)*time.Second, time.Duration(5)*time.Second)
 					_, err := client.Do(&http.Request{})
 					Expect(err).To(MatchError("target flag is required. Run `om help` for more info."))
 				})


### PR DESCRIPTION
I have a client that uses their own DNS servers, and one of them was broken, and it took > 5s to do a DNS lookup. This exposed the hardcoded Dialer connect timeout of `5s`. This is an attempt to fix that. The default is still 5 seconds, and no existing code would be affected, as the flag is optional. 

Unit testing this change was basically impossible, as the `http.Client` masks the `net.Dialer`, but the change is small enough that hopefully it's easy to integrate. 