### PR TITLE
add option to export product properties with `(())` bosh style interpolation format

### DIFF
--- a/api/staged_products_service.go
+++ b/api/staged_products_service.go
@@ -9,7 +9,7 @@ import (
 	"net/http"
 	"strings"
 
-	yaml "gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v2"
 )
 
 type StageProductInput struct {
@@ -43,7 +43,8 @@ type UpdateStagedProductNetworksAndAZsInput struct {
 type ResponseProperty struct {
 	Value        interface{}
 	Configurable bool
-	IsCredential bool `yaml:"credential"`
+	IsCredential bool   `yaml:"credential"`
+	Type         string `yaml:"type"`
 }
 
 type UpgradeRequest struct {

--- a/commands/config_template.go
+++ b/commands/config_template.go
@@ -6,14 +6,15 @@ import (
 
 	"github.com/pivotal-cf/jhanda"
 	"github.com/pivotal-cf/kiln/proofing"
-	yaml "gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v2"
 )
 
 type ConfigTemplate struct {
 	metadataExtractor metadataExtractor
 	logger            logger
-	Options           struct {
-		Product string `long:"product"  short:"p"  required:"true" description:"path to product to generate config template for"`
+	Options struct {
+		Product            string `long:"product"  short:"p"  required:"true" description:"path to product to generate config template for"`
+		IncludePlaceholder bool   `short:"r" long:"include-placeholder" description:"replace obscured credentials to interpolatable placeholder"`
 	}
 }
 
@@ -65,6 +66,11 @@ func (ct ConfigTemplate) Execute(args []string) error {
 			continue
 		}
 
+		if ct.Options.IncludePlaceholder {
+			addSecretPlaceholder(pb.Default, pb.Type, configTemplateProperties, pb.Property)
+			continue
+		}
+
 		switch pb.Type {
 		case "simple_credentials":
 			configTemplateProperties[pb.Property] = map[string]map[string]string{
@@ -78,6 +84,7 @@ func (ct ConfigTemplate) Execute(args []string) error {
 				"value": pb.Default,
 			}
 		}
+
 	}
 
 	configTemplate := map[string]interface{}{

--- a/commands/staged_config.go
+++ b/commands/staged_config.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/pivotal-cf/jhanda"
 	"github.com/pivotal-cf/om/api"
-	yaml "gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v2"
 )
 
 type StagedConfig struct {
@@ -14,6 +14,7 @@ type StagedConfig struct {
 	Options struct {
 		Product            string `long:"product-name" short:"p" required:"true" description:"name of product"`
 		IncludeCredentials bool   `short:"c" long:"include-credentials" description:"include credentials. note: requires product to have been deployed"`
+		IncludePlaceholder bool   `short:"r" long:"include-placeholder" description:"replace obscured credentials to interpolatable placeholder"`
 	}
 }
 
@@ -89,6 +90,47 @@ func (ec StagedConfig) Execute(args []string) error {
 					return err
 				}
 				configurableProperties[name] = map[string]interface{}{"value": output.Credential.Value}
+			} else if ec.Options.IncludePlaceholder {
+				// do secrets first
+				switch property.Type {
+				case "secret":
+					configurableProperties[name] = map[string]interface{}{
+						"value": map[string]string{
+							"secret": fmt.Sprintf("((%s.secret))", name),
+						},
+					}
+				case "simple_credentials":
+					configurableProperties[name] = map[string]interface{}{
+						"value": map[string]string{
+							"identity": fmt.Sprintf("((%s.identity))", name),
+							"password": fmt.Sprintf("((%s.password))", name),
+						},
+					}
+				case "rsa_cert_credentials":
+					configurableProperties[name] = map[string]interface{}{
+						"value": map[string]string{
+							"cert_pem": fmt.Sprintf("((%s.cert_pem))", name),
+							"private_key_pem": fmt.Sprintf("((%s.private_key_pem))", name),
+						},
+					}
+				case "rsa_pkey_credentials":
+					configurableProperties[name] = map[string]interface{}{
+						"value": map[string]string{
+							"private_key_pem": fmt.Sprintf("((%s.private_key_pem))", name),
+						},
+					}
+				case "salted_credentials":
+					configurableProperties[name] = map[string]interface{}{
+						"value": map[string]string{
+							"identity": fmt.Sprintf("((%s.identity))", name),
+							"password": fmt.Sprintf("((%s.password))", name),
+							"salt": fmt.Sprintf("((%s.salt))", name),
+						},
+					}
+				default:
+					configurableProperties[name] = map[string]interface{}{"value": property.Value}
+				}
+
 			} else {
 				configurableProperties[name] = map[string]interface{}{"value": property.Value}
 			}

--- a/commands/staged_config.go
+++ b/commands/staged_config.go
@@ -91,7 +91,6 @@ func (ec StagedConfig) Execute(args []string) error {
 				}
 				configurableProperties[name] = map[string]interface{}{"value": output.Credential.Value}
 			} else if ec.Options.IncludePlaceholder {
-				// do secrets first
 				switch property.Type {
 				case "secret":
 					configurableProperties[name] = map[string]interface{}{
@@ -132,7 +131,12 @@ func (ec StagedConfig) Execute(args []string) error {
 				}
 
 			} else {
-				configurableProperties[name] = map[string]interface{}{"value": property.Value}
+				switch property.Type {
+				case "secret","simple_credentials","rsa_cert_credentials","rsa_pkey_credentials","salted_credentials":
+				default:
+					configurableProperties[name] = map[string]interface{}{"value": property.Value}
+				}
+
 			}
 		}
 	}

--- a/commands/staged_config_test.go
+++ b/commands/staged_config_test.go
@@ -143,25 +143,6 @@ var _ = Describe("StagedConfig", func() {
 product-properties:
   .properties.some-string-property:
     value: some-value
-  .properties.some-secret-property:
-    value:
-      secret: "***"
-  .properties.simple-credentials:
-    value:
-      identity: "***"
-      password: "***"
-  .properties.rsa-cert-credentials:
-    value:
-      cert_pem: "***"
-      private_key_pem: "***"
-  .properties.rsa-pkey-credentials:
-    value:
-      private_key_pem: "***"
-  .properties.salted-credentials:
-    value:
-      identity: "***"
-      password: "***"
-      salt: "***"
 network-properties:
   singleton_availability_zone:
     name: az-one

--- a/commands/staged_config_test.go
+++ b/commands/staged_config_test.go
@@ -24,29 +24,66 @@ var _ = Describe("StagedConfig", func() {
 		fakeService = &fakes.StagedConfigService{}
 		fakeService.GetStagedProductPropertiesReturns(
 			map[string]api.ResponseProperty{
-				".properties.some-string-property": api.ResponseProperty{
+				".properties.some-string-property": {
 					Value:        "some-value",
 					Configurable: true,
 				},
-				".properties.some-non-configurable-property": api.ResponseProperty{
+				".properties.some-non-configurable-property": {
 					Value:        "some-value",
 					Configurable: false,
 				},
-				".properties.some-secret-property": api.ResponseProperty{
+				".properties.some-secret-property": {
+					Type: "secret",
 					Value: map[string]interface{}{
-						"some-secret-type": "***",
+						"secret": "***",
 					},
 					IsCredential: true,
 					Configurable: true,
 				},
-				".properties.some-non-configurable-secret-property": api.ResponseProperty{
+				".properties.simple-credentials": {
+					Type: "simple_credentials",
+					Value: map[string]interface{}{
+						"identity": "***",
+						"password": "***",
+					},
+					IsCredential: true,
+					Configurable: true,
+				},
+				".properties.rsa-cert-credentials": {
+					Type: "rsa_cert_credentials",
+					Value: map[string]interface{}{
+						"cert_pem":        "***",
+						"private_key_pem": "***",
+					},
+					IsCredential: true,
+					Configurable: true,
+				},
+				".properties.rsa-pkey-credentials": {
+					Type: "rsa_pkey_credentials",
+					Value: map[string]interface{}{
+						"private_key_pem": "***",
+					},
+					IsCredential: true,
+					Configurable: true,
+				},
+				".properties.salted-credentials": {
+					Type: "salted_credentials",
+					Value: map[string]interface{}{
+						"identity": "***",
+						"salt": "***",
+						"password": "***",
+					},
+					IsCredential: true,
+					Configurable: true,
+				},
+				".properties.some-non-configurable-secret-property": {
 					Value: map[string]interface{}{
 						"some-secret-type": "***",
 					},
 					IsCredential: true,
 					Configurable: false,
 				},
-				".properties.some-null-property": api.ResponseProperty{
+				".properties.some-null-property": {
 					Value:        nil,
 					Configurable: true,
 				},
@@ -108,7 +145,69 @@ product-properties:
     value: some-value
   .properties.some-secret-property:
     value:
-      some-secret-type: "***"
+      secret: "***"
+  .properties.simple-credentials:
+    value:
+      identity: "***"
+      password: "***"
+  .properties.rsa-cert-credentials:
+    value:
+      cert_pem: "***"
+      private_key_pem: "***"
+  .properties.rsa-pkey-credentials:
+    value:
+      private_key_pem: "***"
+  .properties.salted-credentials:
+    value:
+      identity: "***"
+      password: "***"
+      salt: "***"
+network-properties:
+  singleton_availability_zone:
+    name: az-one
+resource-config:
+  some-job:
+    instances: 1
+    instance_type:
+      id: automatic
+`)))
+		})
+	})
+
+	Context("when --include-placeholder is used", func() {
+		It("replace *** with interpolatable placeholder", func() {
+			command := commands.NewStagedConfig(fakeService, logger)
+			err := command.Execute([]string{
+				"--product-name", "some-product",
+				"--include-placeholder",
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(logger.PrintlnCallCount()).To(Equal(1))
+			output := logger.PrintlnArgsForCall(0)
+			Expect(output).To(ContainElement(MatchYAML(`---
+product-properties:
+  .properties.some-string-property:
+    value: some-value
+  .properties.some-secret-property:
+    value:
+      secret: ((.properties.some-secret-property.secret))
+  .properties.simple-credentials:
+    value:
+      identity: ((.properties.simple-credentials.identity))
+      password: ((.properties.simple-credentials.password))
+  .properties.rsa-cert-credentials:
+    value:
+      cert_pem: ((.properties.rsa-cert-credentials.cert_pem))
+      private_key_pem: ((.properties.rsa-cert-credentials.private_key_pem))
+  .properties.rsa-pkey-credentials:
+    value:
+      private_key_pem: ((.properties.rsa-pkey-credentials.private_key_pem))
+  .properties.salted-credentials:
+    value:
+      identity: ((.properties.salted-credentials.identity))
+      password: ((.properties.salted-credentials.password))
+      salt: ((.properties.salted-credentials.salt))
 network-properties:
   singleton_availability_zone:
     name: az-one
@@ -148,11 +247,7 @@ resource-config:
 			})
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(fakeService.GetDeployedProductCredentialCallCount()).To(Equal(1))
-			Expect(fakeService.GetDeployedProductCredentialArgsForCall(0)).To(Equal(api.GetDeployedProductCredentialInput{
-				DeployedGUID:        "some-product-guid",
-				CredentialReference: ".properties.some-secret-property",
-			}))
+			Expect(fakeService.GetDeployedProductCredentialCallCount()).To(Equal(5))
 
 			Expect(logger.PrintlnCallCount()).To(Equal(1))
 			output := logger.PrintlnArgsForCall(0)
@@ -161,6 +256,18 @@ product-properties:
   .properties.some-string-property:
     value: some-value
   .properties.some-secret-property:
+    value:
+      some-secret-key: some-secret-value
+  .properties.simple-credentials:
+    value:
+      some-secret-key: some-secret-value
+  .properties.rsa-cert-credentials:
+    value:
+      some-secret-key: some-secret-value
+  .properties.rsa-pkey-credentials:
+    value:
+      some-secret-key: some-secret-value
+  .properties.salted-credentials:
     value:
       some-secret-key: some-secret-value
 network-properties:


### PR DESCRIPTION
The following will close #169.

This add support to `staged-config` and `config-template` with an option to have credentials exported as bosh style parameters that then can be substituted with an external vars file. A first pass at extract creds from the main config file.