### PR TITLE
Remove `guid` in `staged-director-config`

### DIFF
--- a/api/staged_director_service.go
+++ b/api/staged_director_service.go
@@ -26,6 +26,20 @@ type SubnetOutput struct {
 	AvailabilityZones []string `yaml:"availability_zone_names,omitempty"`
 }
 
+type AvailabilityZonesOutput struct {
+	AvailabilityZones []AvailabilityZoneOutput `yaml:"availability_zones"`
+}
+
+type AvailabilityZoneOutput struct {
+	Name     string                 `yaml:"name"`
+	Clusters []ClusterOutput        `yaml:"clusters,omitempty"`
+}
+
+type ClusterOutput struct {
+	Cluster      string `yaml:"cluster"`
+	ResourcePool string `yaml:"resource_pool"`
+}
+
 func (a Api) GetStagedDirectorProperties() (map[string]map[string]interface{}, error) {
 	resp, err := a.sendAPIRequest("GET", "/api/v0/staged/director/properties", nil)
 	if err != nil {
@@ -47,22 +61,22 @@ func (a Api) GetStagedDirectorProperties() (map[string]map[string]interface{}, e
 	return properties, nil
 }
 
-func (a Api) GetStagedDirectorAvailabilityZones() (map[string][]map[string]interface{}, error) {
+func (a Api) GetStagedDirectorAvailabilityZones() (AvailabilityZonesOutput, error) {
 	resp, err := a.sendAPIRequest("GET", "/api/v0/staged/director/availability_zones", nil)
+	var properties AvailabilityZonesOutput
 	if err != nil {
-		return nil, err // un-tested
+		return properties, err // un-tested
 	}
 
 	defer resp.Body.Close()
 
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return nil, err
+		return properties, err
 	}
 
-	var properties map[string][]map[string]interface{}
 	if err = yaml.Unmarshal(body, &properties); err != nil {
-		return nil, fmt.Errorf("could not parse json: %s", err)
+		return properties, fmt.Errorf("could not parse json: %s", err)
 	}
 
 	return properties, nil

--- a/api/staged_director_service.go
+++ b/api/staged_director_service.go
@@ -6,6 +6,26 @@ import (
 	"io/ioutil"
 )
 
+type NetworksConfigurationOutput struct {
+	ICMP     bool `yaml:"icmp_checks_enabled,omitempty"`
+	Networks []NetworkConfigurationOutput
+}
+
+type NetworkConfigurationOutput struct {
+	Name           string         `yaml:"name"`
+	ServiceNetwork *bool          `yaml:"service_network,omitempty"`
+	Subnets        []SubnetOutput `yaml:"subnets,omitempty"`
+}
+
+type SubnetOutput struct {
+	IAASIdentifier    string   `yaml:"iaas_identifier"`
+	CIDR              string   `yaml:"cidr"`
+	DNS               string   `yaml:"dns"`
+	Gateway           string   `yaml:"gateway"`
+	ReservedIPRanges  string   `yaml:"reserved_ip_ranges"`
+	AvailabilityZones []string `yaml:"availability_zone_names,omitempty"`
+}
+
 func (a Api) GetStagedDirectorProperties() (map[string]map[string]interface{}, error) {
 	resp, err := a.sendAPIRequest("GET", "/api/v0/staged/director/properties", nil)
 	if err != nil {
@@ -48,22 +68,22 @@ func (a Api) GetStagedDirectorAvailabilityZones() (map[string][]map[string]inter
 	return properties, nil
 }
 
-func (a Api) GetStagedDirectorNetworks() (map[string]interface{}, error) {
+func (a Api) GetStagedDirectorNetworks() (NetworksConfigurationOutput, error) {
 	resp, err := a.sendAPIRequest("GET", "/api/v0/staged/director/networks", nil)
+	var properties NetworksConfigurationOutput
 	if err != nil {
-		return nil, err // un-tested
+		return properties, err // un-tested
 	}
 
 	defer resp.Body.Close()
 
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return nil, err
+		return properties, err
 	}
 
-	var properties map[string]interface{}
 	if err = yaml.Unmarshal(body, &properties); err != nil {
-		return nil, fmt.Errorf("could not parse json: %s", err)
+		return properties, fmt.Errorf("could not parse json: %s", err)
 	}
 
 	return properties, nil

--- a/api/staged_director_service.go
+++ b/api/staged_director_service.go
@@ -7,7 +7,7 @@ import (
 )
 
 type NetworksConfigurationOutput struct {
-	ICMP     bool `yaml:"icmp_checks_enabled,omitempty"`
+	ICMP     bool `yaml:"icmp_checks_enabled"`
 	Networks []NetworkConfigurationOutput
 }
 

--- a/api/staged_director_service_test.go
+++ b/api/staged_director_service_test.go
@@ -252,14 +252,12 @@ var _ = Describe("StagedProducts", func() {
 			config, err := service.GetStagedDirectorAvailabilityZones()
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(config["availability_zones"]).To(Equal([]map[string]interface{}{
+			Expect(config.AvailabilityZones).To(Equal([]api.AvailabilityZoneOutput{
 				{
-					"name": "Availability Zone 1",
-					"guid": "guid-1",
+					Name: "Availability Zone 1",
 				},
 				{
-					"name": "Availability Zone 2",
-					"guid": "guid-4",
+					Name: "Availability Zone 2",
 				},
 			}))
 		})

--- a/api/staged_director_service_test.go
+++ b/api/staged_director_service_test.go
@@ -367,23 +367,24 @@ var _ = Describe("StagedProducts", func() {
 			config, err := service.GetStagedDirectorNetworks()
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(config["icmp_checks_enabled"]).To(Equal(true))
+			Expect(config.ICMP).To(Equal(true))
 
-			Expect(config["networks"]).To(ContainElement(Equal(
-				map[interface{}]interface{}{
-					"name": "first-network",
-					"guid": "0d35c70db3c592cb1ac7",
-					"subnets": []interface{}{
-						map[interface{}]interface{}{"guid": "433d16d727706e3be752",
-							"iaas_identifier":    "hinterlands-1",
-							"cidr":               "10.85.41.0/24",
-							"dns":                "10.87.8.10",
-							"gateway":            "10.85.41.1",
-							"reserved_ip_ranges": "10.85.41.1-10.85.41.97,10.85.41.117-10.85.41.255",
-							"availability_zone_names": []interface{}{
+			Expect(config.Networks).To(ContainElement(Equal(
+				api.NetworkConfigurationOutput{
+					Name: "first-network",
+					Subnets: []api.SubnetOutput{
+						api.SubnetOutput{
+							IAASIdentifier:   "hinterlands-1",
+							CIDR:             "10.85.41.0/24",
+							DNS:              "10.87.8.10",
+							Gateway:          "10.85.41.1",
+							ReservedIPRanges: "10.85.41.1-10.85.41.97,10.85.41.117-10.85.41.255",
+							AvailabilityZones: []string{
 								"first-az",
 								"second-az",
-							}}},
+							},
+						},
+					},
 				},
 			)))
 		})

--- a/commands/fakes/staged_director_config_service.go
+++ b/commands/fakes/staged_director_config_service.go
@@ -19,15 +19,15 @@ type StagedDirectorConfigService struct {
 		result1 map[string]map[string]interface{}
 		result2 error
 	}
-	GetStagedDirectorAvailabilityZonesStub        func() (map[string][]map[string]interface{}, error)
+	GetStagedDirectorAvailabilityZonesStub        func() (api.AvailabilityZonesOutput, error)
 	getStagedDirectorAvailabilityZonesMutex       sync.RWMutex
 	getStagedDirectorAvailabilityZonesArgsForCall []struct{}
 	getStagedDirectorAvailabilityZonesReturns     struct {
-		result1 map[string][]map[string]interface{}
+		result1 api.AvailabilityZonesOutput
 		result2 error
 	}
 	getStagedDirectorAvailabilityZonesReturnsOnCall map[int]struct {
-		result1 map[string][]map[string]interface{}
+		result1 api.AvailabilityZonesOutput
 		result2 error
 	}
 	GetStagedDirectorNetworksStub        func() (api.NetworksConfigurationOutput, error)
@@ -141,7 +141,7 @@ func (fake *StagedDirectorConfigService) GetStagedDirectorPropertiesReturnsOnCal
 	}{result1, result2}
 }
 
-func (fake *StagedDirectorConfigService) GetStagedDirectorAvailabilityZones() (map[string][]map[string]interface{}, error) {
+func (fake *StagedDirectorConfigService) GetStagedDirectorAvailabilityZones() (api.AvailabilityZonesOutput, error) {
 	fake.getStagedDirectorAvailabilityZonesMutex.Lock()
 	ret, specificReturn := fake.getStagedDirectorAvailabilityZonesReturnsOnCall[len(fake.getStagedDirectorAvailabilityZonesArgsForCall)]
 	fake.getStagedDirectorAvailabilityZonesArgsForCall = append(fake.getStagedDirectorAvailabilityZonesArgsForCall, struct{}{})
@@ -162,24 +162,24 @@ func (fake *StagedDirectorConfigService) GetStagedDirectorAvailabilityZonesCallC
 	return len(fake.getStagedDirectorAvailabilityZonesArgsForCall)
 }
 
-func (fake *StagedDirectorConfigService) GetStagedDirectorAvailabilityZonesReturns(result1 map[string][]map[string]interface{}, result2 error) {
+func (fake *StagedDirectorConfigService) GetStagedDirectorAvailabilityZonesReturns(result1 api.AvailabilityZonesOutput, result2 error) {
 	fake.GetStagedDirectorAvailabilityZonesStub = nil
 	fake.getStagedDirectorAvailabilityZonesReturns = struct {
-		result1 map[string][]map[string]interface{}
+		result1 api.AvailabilityZonesOutput
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *StagedDirectorConfigService) GetStagedDirectorAvailabilityZonesReturnsOnCall(i int, result1 map[string][]map[string]interface{}, result2 error) {
+func (fake *StagedDirectorConfigService) GetStagedDirectorAvailabilityZonesReturnsOnCall(i int, result1 api.AvailabilityZonesOutput, result2 error) {
 	fake.GetStagedDirectorAvailabilityZonesStub = nil
 	if fake.getStagedDirectorAvailabilityZonesReturnsOnCall == nil {
 		fake.getStagedDirectorAvailabilityZonesReturnsOnCall = make(map[int]struct {
-			result1 map[string][]map[string]interface{}
+			result1 api.AvailabilityZonesOutput
 			result2 error
 		})
 	}
 	fake.getStagedDirectorAvailabilityZonesReturnsOnCall[i] = struct {
-		result1 map[string][]map[string]interface{}
+		result1 api.AvailabilityZonesOutput
 		result2 error
 	}{result1, result2}
 }

--- a/commands/fakes/staged_director_config_service.go
+++ b/commands/fakes/staged_director_config_service.go
@@ -30,15 +30,15 @@ type StagedDirectorConfigService struct {
 		result1 map[string][]map[string]interface{}
 		result2 error
 	}
-	GetStagedDirectorNetworksStub        func() (map[string]interface{}, error)
+	GetStagedDirectorNetworksStub        func() (api.NetworksConfigurationOutput, error)
 	getStagedDirectorNetworksMutex       sync.RWMutex
 	getStagedDirectorNetworksArgsForCall []struct{}
 	getStagedDirectorNetworksReturns     struct {
-		result1 map[string]interface{}
+		result1 api.NetworksConfigurationOutput
 		result2 error
 	}
 	getStagedDirectorNetworksReturnsOnCall map[int]struct {
-		result1 map[string]interface{}
+		result1 api.NetworksConfigurationOutput
 		result2 error
 	}
 	GetStagedProductByNameStub        func(productName string) (api.StagedProductsFindOutput, error)
@@ -184,7 +184,7 @@ func (fake *StagedDirectorConfigService) GetStagedDirectorAvailabilityZonesRetur
 	}{result1, result2}
 }
 
-func (fake *StagedDirectorConfigService) GetStagedDirectorNetworks() (map[string]interface{}, error) {
+func (fake *StagedDirectorConfigService) GetStagedDirectorNetworks() (api.NetworksConfigurationOutput, error) {
 	fake.getStagedDirectorNetworksMutex.Lock()
 	ret, specificReturn := fake.getStagedDirectorNetworksReturnsOnCall[len(fake.getStagedDirectorNetworksArgsForCall)]
 	fake.getStagedDirectorNetworksArgsForCall = append(fake.getStagedDirectorNetworksArgsForCall, struct{}{})
@@ -205,24 +205,24 @@ func (fake *StagedDirectorConfigService) GetStagedDirectorNetworksCallCount() in
 	return len(fake.getStagedDirectorNetworksArgsForCall)
 }
 
-func (fake *StagedDirectorConfigService) GetStagedDirectorNetworksReturns(result1 map[string]interface{}, result2 error) {
+func (fake *StagedDirectorConfigService) GetStagedDirectorNetworksReturns(result1 api.NetworksConfigurationOutput, result2 error) {
 	fake.GetStagedDirectorNetworksStub = nil
 	fake.getStagedDirectorNetworksReturns = struct {
-		result1 map[string]interface{}
+		result1 api.NetworksConfigurationOutput
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *StagedDirectorConfigService) GetStagedDirectorNetworksReturnsOnCall(i int, result1 map[string]interface{}, result2 error) {
+func (fake *StagedDirectorConfigService) GetStagedDirectorNetworksReturnsOnCall(i int, result1 api.NetworksConfigurationOutput, result2 error) {
 	fake.GetStagedDirectorNetworksStub = nil
 	if fake.getStagedDirectorNetworksReturnsOnCall == nil {
 		fake.getStagedDirectorNetworksReturnsOnCall = make(map[int]struct {
-			result1 map[string]interface{}
+			result1 api.NetworksConfigurationOutput
 			result2 error
 		})
 	}
 	fake.getStagedDirectorNetworksReturnsOnCall[i] = struct {
-		result1 map[string]interface{}
+		result1 api.NetworksConfigurationOutput
 		result2 error
 	}{result1, result2}
 }

--- a/commands/staged_director_config_test.go
+++ b/commands/staged_director_config_test.go
@@ -54,15 +54,14 @@ var _ bool = Describe("StagedDirectorConfig", func() {
 				},
 			}
 			fakeService.GetStagedDirectorPropertiesReturns(expectedDirectorProperties, nil)
-
-			expectedNetworks := map[string]interface{}{
-				"networks": []interface{}{
-					map[string]string{
-						"name": "network-1",
-						"guid": "network-1-guid",
+			expectedNetworks := api.NetworksConfigurationOutput{
+				Networks: []api.NetworkConfigurationOutput{
+					{
+						Name: "network-1",
 					},
 				},
 			}
+
 			fakeService.GetStagedDirectorNetworksReturns(expectedNetworks, nil)
 
 			fakeService.GetStagedProductByNameReturns(api.StagedProductsFindOutput{
@@ -102,7 +101,6 @@ var _ bool = Describe("StagedDirectorConfig", func() {
 			Expect(output).To(ContainElement(MatchYAML(`
 az-configuration:
 - name: some-az
-  guid: some-az-guid
 director-configuration:
   max_threads: 5
 iaas-configuration:
@@ -115,7 +113,6 @@ network-assignment:
 networks-configuration:
   networks:
   - name: network-1
-    guid: network-1-guid
 resource-configuration:
   some-job:
     instances: 1
@@ -151,7 +148,6 @@ syslog-configuration:
 			Expect(string(output)).To(MatchYAML(`
 az-configuration:
 - name: some-az
-  guid: some-az-guid
 director-configuration:
   max_threads: 5
 iaas-configuration:
@@ -164,7 +160,6 @@ network-assignment:
 networks-configuration:
   networks:
   - name: network-1
-    guid: network-1-guid
 resource-configuration:
   some-job:
     instances: 1
@@ -225,7 +220,7 @@ syslog-configuration:
 
 		Context("when looking up the director networks fails", func() {
 			BeforeEach(func() {
-				fakeService.GetStagedDirectorNetworksReturns(nil, errors.New("some-error"))
+				fakeService.GetStagedDirectorNetworksReturns(api.NetworksConfigurationOutput{}, errors.New("some-error"))
 			})
 
 			It("returns an error", func() {

--- a/commands/staged_director_config_test.go
+++ b/commands/staged_director_config_test.go
@@ -111,6 +111,7 @@ network-assignment:
   singleton_availability_zone:
     name: "some-az"
 networks-configuration:
+  icmp_checks_enabled: false
   networks:
   - name: network-1
 resource-configuration:
@@ -158,6 +159,7 @@ network-assignment:
   singleton_availability_zone:
     name: "some-az"
 networks-configuration:
+  icmp_checks_enabled: false
   networks:
   - name: network-1
 resource-configuration:

--- a/commands/staged_director_config_test.go
+++ b/commands/staged_director_config_test.go
@@ -29,11 +29,10 @@ var _ bool = Describe("StagedDirectorConfig", func() {
 	Describe("Execute", func() {
 
 		BeforeEach(func() {
-			expectedDirectorAZs := map[string][]map[string]interface{}{
-				"availability_zones": {
-					{
-						"name": "some-az",
-						"guid": "some-az-guid",
+			expectedDirectorAZs := api.AvailabilityZonesOutput{
+				AvailabilityZones: []api.AvailabilityZoneOutput{
+					api.AvailabilityZoneOutput{
+						Name: "some-az",
 					},
 				},
 			}
@@ -210,7 +209,7 @@ syslog-configuration:
 
 		Context("when looking up the director azs fails", func() {
 			BeforeEach(func() {
-				fakeService.GetStagedDirectorAvailabilityZonesReturns(nil, errors.New("some-error"))
+				fakeService.GetStagedDirectorAvailabilityZonesReturns(api.AvailabilityZonesOutput{}, errors.New("some-error"))
 			})
 
 			It("returns an error", func() {


### PR DESCRIPTION
Here is a yamldiff in the payload returned by `staged-director-config`
```diff
-   guid: "d0d8a581761ad2f9b9a7",
-   guid: "e05565e0f0d6b9bbad49",
-   guid: "972870601b177cc825d1",
-    guid: "7ed1a39e060aebb9a4ee",
-      guid: "0f6c7c24eed38802172a",
-    guid: "073ed694903051e8c17e",
-      guid: "16e06eb88f6f57e271f3",
-    guid: "5435d51a1252e56151df",
-      guid: "a5693ddc72c48f1e2fa4",
-    guid: "85b62bee9a0e5f6cca10",
-      guid: "08b7920ea01cc9ee57e5",
```
Basically remove all the guid fields as they are incresing noise in the configuration.

The roundtrip `om configure-director <(om staged-director-config)` is still working.
Caveat: 
1. roundtrip only works if the `iaas-configuration` section is removed (regardless of this PR), as the section contains obscure creds fields (e.g. `auth_json: '****'` for gcp)
1. roundtrip doesn't work for **vsphere** until https://github.com/pivotal-cf/om/issues/170 is done, as that story adds necessary `cluster guid` back to the payload.

~~TODO: when I write the `caveat`, it reminds me that I didn't implement the logic to remove `cluster guid` for vsphere, will do that...~~ Done
 
Diff for vsphere az-configuration part:

Before:
```yaml
az-configuration:
  - name: AZ01
    guid: ed9fd3e85cc3851406e4
    clusters:
    - guid: a3eb20363a2fda7211cd
      cluster: canada
      resource_pool: oshawa
```

After:
```yaml
az-configuration:
- name: AZ01
  clusters:
  - cluster: canada
    resource_pool: oshawa
```