### PR TITLE
change placeholder separate to _

### DIFF
--- a/api/staged_director_service.go
+++ b/api/staged_director_service.go
@@ -31,8 +31,8 @@ type AvailabilityZonesOutput struct {
 }
 
 type AvailabilityZoneOutput struct {
-	Name     string                 `yaml:"name"`
-	Clusters []ClusterOutput        `yaml:"clusters,omitempty"`
+	Name     string          `yaml:"name"`
+	Clusters []ClusterOutput `yaml:"clusters,omitempty"`
 }
 
 type ClusterOutput struct {

--- a/commands/staged_config.go
+++ b/commands/staged_config.go
@@ -92,7 +92,9 @@ func (ec StagedConfig) Execute(args []string) error {
 		if property.Type == "selector" {
 			selectorProperties[name] = property.Value.(string)
 		}
-		output, err := ec.parseProperties(productGUID, name, property)
+		output, err := ec.parseProperties(productGUID, propertyName{
+			prefix: name,
+		}, property)
 		if err != nil {
 			return err
 		}
@@ -155,13 +157,41 @@ func (ec StagedConfig) Execute(args []string) error {
 	return nil
 }
 
-func (ec StagedConfig) parseProperties(productGUID string, name string, property api.ResponseProperty) (map[string]interface{}, error) {
+type propertyName struct {
+	prefix         string
+	index          int
+	collectionName string
+}
+
+func (n *propertyName) credentialName() string {
+	if n.collectionName != "" {
+		return n.prefix + "[" + strconv.Itoa(n.index) + "]." + n.collectionName
+	}
+
+	return n.prefix
+}
+
+func (n *propertyName) placeholderName() string {
+	name := n.prefix
+	if n.collectionName != "" {
+		name = n.prefix + "_" + strconv.Itoa(n.index) + "_" + n.collectionName
+	}
+
+	return strings.Replace(
+		strings.TrimLeft(
+			name,
+			".",
+		),
+		".",
+		"_",
+		-1,
+	)
+}
+
+func (ec StagedConfig) parseProperties(productGUID string, name propertyName, property api.ResponseProperty) (map[string]interface{}, error) {
 	if !property.Configurable {
 		return nil, nil
 	}
-
-
-
 	if property.IsCredential {
 		return ec.handleCredential(productGUID, name, property)
 	}
@@ -171,7 +201,7 @@ func (ec StagedConfig) parseProperties(productGUID string, name string, property
 	return map[string]interface{}{"value": property.Value}, nil
 }
 
-func (ec StagedConfig) handleCollection(productGUID string, name string, property api.ResponseProperty) (map[string]interface{}, error) {
+func (ec StagedConfig) handleCollection(productGUID string, name propertyName, property api.ResponseProperty) (map[string]interface{}, error) {
 	var valueItems []map[string]interface{}
 
 	for index, item := range property.Value.([]interface{}) {
@@ -185,9 +215,11 @@ func (ec StagedConfig) handleCollection(productGUID string, name string, propert
 				IsCredential: typeAssertedInnerValue["credential"].(bool),
 				Type:         typeAssertedInnerValue["type"].(string),
 			}
-
-			innerValueNamePrefix := name + "_" + strconv.Itoa(index) + "_" + innerKey.(string)
-			returnValue, err := ec.parseProperties(productGUID, innerValueNamePrefix, innerValueProperty)
+			returnValue, err := ec.parseProperties(productGUID, propertyName{
+				prefix:         name.prefix,
+				index:          index,
+				collectionName: innerKey.(string),
+			}, innerValueProperty)
 			if err != nil {
 				return nil, err
 			}
@@ -205,13 +237,13 @@ func (ec StagedConfig) handleCollection(productGUID string, name string, propert
 	return nil, nil
 }
 
-func (ec StagedConfig) handleCredential(productGUID string, name string, property api.ResponseProperty) (map[string]interface{}, error) {
+func (ec StagedConfig) handleCredential(productGUID string, name propertyName, property api.ResponseProperty) (map[string]interface{}, error) {
 	var output map[string]interface{}
 
 	if ec.Options.IncludeCredentials {
 		apiOutput, err := ec.service.GetDeployedProductCredential(api.GetDeployedProductCredentialInput{
 			DeployedGUID:        productGUID,
-			CredentialReference: name,
+			CredentialReference: name.credentialName(),
 		})
 		if err != nil {
 			return nil, err
@@ -220,40 +252,39 @@ func (ec StagedConfig) handleCredential(productGUID string, name string, propert
 		return output, nil
 	}
 	if ec.Options.IncludePlaceholder {
-		name = strings.Replace(strings.TrimLeft(name, "."), ".", "_", -1)
 		switch property.Type {
 		case "secret":
 			output = map[string]interface{}{
 				"value": map[string]string{
-					"secret": fmt.Sprintf("((%s.secret))", name),
+					"secret": fmt.Sprintf("((%s.secret))", name.placeholderName()),
 				},
 			}
 		case "simple_credentials":
 			output = map[string]interface{}{
 				"value": map[string]string{
-					"identity": fmt.Sprintf("((%s.identity))", name),
-					"password": fmt.Sprintf("((%s.password))", name),
+					"identity": fmt.Sprintf("((%s.identity))", name.placeholderName()),
+					"password": fmt.Sprintf("((%s.password))", name.placeholderName()),
 				},
 			}
 		case "rsa_cert_credentials":
 			output = map[string]interface{}{
 				"value": map[string]string{
-					"cert_pem":        fmt.Sprintf("((%s.cert_pem))", name),
-					"private_key_pem": fmt.Sprintf("((%s.private_key_pem))", name),
+					"cert_pem":        fmt.Sprintf("((%s.cert_pem))", name.placeholderName()),
+					"private_key_pem": fmt.Sprintf("((%s.private_key_pem))", name.placeholderName()),
 				},
 			}
 		case "rsa_pkey_credentials":
 			output = map[string]interface{}{
 				"value": map[string]string{
-					"private_key_pem": fmt.Sprintf("((%s.private_key_pem))", name),
+					"private_key_pem": fmt.Sprintf("((%s.private_key_pem))", name.placeholderName()),
 				},
 			}
 		case "salted_credentials":
 			output = map[string]interface{}{
 				"value": map[string]string{
-					"identity": fmt.Sprintf("((%s.identity))", name),
-					"password": fmt.Sprintf("((%s.password))", name),
-					"salt":     fmt.Sprintf("((%s.salt))", name),
+					"identity": fmt.Sprintf("((%s.identity))", name.placeholderName()),
+					"password": fmt.Sprintf("((%s.password))", name.placeholderName()),
+					"salt":     fmt.Sprintf("((%s.salt))", name.placeholderName()),
 				},
 			}
 		}

--- a/commands/staged_config.go
+++ b/commands/staged_config.go
@@ -159,6 +159,9 @@ func (ec StagedConfig) parseProperties(productGUID string, name string, property
 	if !property.Configurable {
 		return nil, nil
 	}
+
+
+
 	if property.IsCredential {
 		return ec.handleCredential(productGUID, name, property)
 	}
@@ -183,7 +186,7 @@ func (ec StagedConfig) handleCollection(productGUID string, name string, propert
 				Type:         typeAssertedInnerValue["type"].(string),
 			}
 
-			innerValueNamePrefix := name + "[" + strconv.Itoa(index) + "]." + innerKey.(string)
+			innerValueNamePrefix := name + "_" + strconv.Itoa(index) + "_" + innerKey.(string)
 			returnValue, err := ec.parseProperties(productGUID, innerValueNamePrefix, innerValueProperty)
 			if err != nil {
 				return nil, err
@@ -217,6 +220,7 @@ func (ec StagedConfig) handleCredential(productGUID string, name string, propert
 		return output, nil
 	}
 	if ec.Options.IncludePlaceholder {
+		name = strings.Replace(strings.TrimLeft(name, "."), ".", "_", -1)
 		switch property.Type {
 		case "secret":
 			output = map[string]interface{}{

--- a/commands/staged_config_test.go
+++ b/commands/staged_config_test.go
@@ -231,34 +231,34 @@ product-properties:
     value: some-value
   ".properties.some-secret-property":
     value:
-      secret: "((.properties.some-secret-property.secret))"
+      secret: "((properties_some-secret-property.secret))"
   ".properties.some-selector":
     value: internal
   ".properties.simple-credentials":
     value:
-      identity: "((.properties.simple-credentials.identity))"
-      password: "((.properties.simple-credentials.password))"
+      identity: "((properties_simple-credentials.identity))"
+      password: "((properties_simple-credentials.password))"
   ".properties.rsa-cert-credentials":
     value:
-      cert_pem: "((.properties.rsa-cert-credentials.cert_pem))"
-      private_key_pem: "((.properties.rsa-cert-credentials.private_key_pem))"
+      cert_pem: "((properties_rsa-cert-credentials.cert_pem))"
+      private_key_pem: "((properties_rsa-cert-credentials.private_key_pem))"
   ".properties.rsa-pkey-credentials":
     value:
-      private_key_pem: "((.properties.rsa-pkey-credentials.private_key_pem))"
+      private_key_pem: "((properties_rsa-pkey-credentials.private_key_pem))"
   ".properties.salted-credentials":
     value:
-      identity: "((.properties.salted-credentials.identity))"
-      password: "((.properties.salted-credentials.password))"
-      salt: "((.properties.salted-credentials.salt))"
+      identity: "((properties_salted-credentials.identity))"
+      password: "((properties_salted-credentials.password))"
+      salt: "((properties_salted-credentials.salt))"
   ".properties.collection":
     value:
     - certificate:
-        private_key_pem: "((.properties.collection[0].certificate.private_key_pem))"
-        cert_pem: "((.properties.collection[0].certificate.cert_pem))"
+        private_key_pem: "((properties_collection_0_certificate.private_key_pem))"
+        cert_pem: "((properties_collection_0_certificate.cert_pem))"
       name: Certificate
     - certificate2:
-        private_key_pem: "((.properties.collection[1].certificate2.private_key_pem))"
-        cert_pem: "((.properties.collection[1].certificate2.cert_pem))"
+        private_key_pem: "((properties_collection_1_certificate2.private_key_pem))"
+        cert_pem: "((properties_collection_1_certificate2.cert_pem))"
 network-properties:
   singleton_availability_zone:
     name: az-one

--- a/commands/staged_config_test.go
+++ b/commands/staged_config_test.go
@@ -341,6 +341,41 @@ resource-config:
 
 			Expect(fakeService.GetDeployedProductCredentialCallCount()).To(Equal(7))
 
+			apiInputs := []api.GetDeployedProductCredentialInput{}
+			for i := 0; i < 7; i++ {
+				apiInputs = append(apiInputs, fakeService.GetDeployedProductCredentialArgsForCall(i))
+			}
+			Expect(apiInputs).To(ConsistOf([]api.GetDeployedProductCredentialInput{
+				{
+					DeployedGUID:        "some-product-guid",
+					CredentialReference: ".properties.some-secret-property",
+				},
+				{
+					DeployedGUID:        "some-product-guid",
+					CredentialReference: ".properties.salted-credentials",
+				},
+				{
+					DeployedGUID:        "some-product-guid",
+					CredentialReference: ".properties.collection[0].certificate",
+				},
+				{
+					DeployedGUID:        "some-product-guid",
+					CredentialReference: ".properties.collection[1].certificate2",
+				},
+				{
+					DeployedGUID:        "some-product-guid",
+					CredentialReference: ".properties.simple-credentials",
+				},
+				{
+					DeployedGUID:        "some-product-guid",
+					CredentialReference: ".properties.rsa-cert-credentials",
+				},
+				{
+					DeployedGUID:        "some-product-guid",
+					CredentialReference: ".properties.rsa-pkey-credentials",
+				},
+			}))
+
 			Expect(logger.PrintlnCallCount()).To(Equal(1))
 			output := logger.PrintlnArgsForCall(0)
 			Expect(output).To(ContainElement(MatchYAML(`product-properties:


### PR DESCRIPTION
This follows the pattern of cf-deployment when generating parameter names. These names enforce that the vars can come from separate sources without conflict.

[#157747884]

This changes the exported properties to now be named `properties_some_name.private_key` instead of `.properties.some_name.private_key`.

This is to resolve the interpolation [issue](https://github.com/cloudfoundry/bosh-cli/issues/437) with vars-file not merge objects in YAML. 

Signed-off-by: Huan Wang <huwang@pivotal.io>

*edit:*
We also noticed that collections of credentials did not accurately retrieve the credential value when using `--include-credentials`. We added another commit to resolve that issue.

This helps resolve #178.