### PR TITLE
include iaas configuration guid in the director az retrieval

### DIFF
--- a/api/staged_director_service.go
+++ b/api/staged_director_service.go
@@ -31,8 +31,9 @@ type AvailabilityZonesOutput struct {
 }
 
 type AvailabilityZoneOutput struct {
-	Name     string                 `yaml:"name"`
-	Clusters []ClusterOutput        `yaml:"clusters,omitempty"`
+	Name                  string          `yaml:"name"`
+	Clusters              []ClusterOutput `yaml:"clusters,omitempty"`
+	IAASConfigurationGUID string          `yaml:"iaas_configuration_guid,omitempty"`
 }
 
 type ClusterOutput struct {

--- a/api/staged_director_service_test.go
+++ b/api/staged_director_service_test.go
@@ -234,7 +234,8 @@ var _ = Describe("StagedProducts", func() {
   "availability_zones": [
     {
       "name": "Availability Zone 1",
-      "guid": "guid-1"
+      "guid": "guid-1",
+      "iaas_configuration_guid": "iaas-configuration-guid"
     },
     {
       "name": "Availability Zone 2",
@@ -255,6 +256,7 @@ var _ = Describe("StagedProducts", func() {
 			Expect(config.AvailabilityZones).To(Equal([]api.AvailabilityZoneOutput{
 				{
 					Name: "Availability Zone 1",
+					IAASConfigurationGUID: "iaas-configuration-guid",
 				},
 				{
 					Name: "Availability Zone 2",

--- a/commands/staged_director_config_test.go
+++ b/commands/staged_director_config_test.go
@@ -31,8 +31,12 @@ var _ bool = Describe("StagedDirectorConfig", func() {
 		BeforeEach(func() {
 			expectedDirectorAZs := api.AvailabilityZonesOutput{
 				AvailabilityZones: []api.AvailabilityZoneOutput{
-					api.AvailabilityZoneOutput{
+					{
 						Name: "some-az",
+						IAASConfigurationGUID: "some-iaas-guid",
+					},
+					{
+						Name: "some-other-az",
 					},
 				},
 			}
@@ -100,6 +104,8 @@ var _ bool = Describe("StagedDirectorConfig", func() {
 			Expect(output).To(ContainElement(MatchYAML(`
 az-configuration:
 - name: some-az
+  iaas_configuration_guid: some-iaas-guid
+- name: some-other-az
 director-configuration:
   max_threads: 5
 iaas-configuration:
@@ -148,6 +154,8 @@ syslog-configuration:
 			Expect(string(output)).To(MatchYAML(`
 az-configuration:
 - name: some-az
+  iaas_configuration_guid: some-iaas-guid
+- name: some-other-az
 director-configuration:
   max_threads: 5
 iaas-configuration:


### PR DESCRIPTION
[#157754768]

This adds the `iaas_configuration_guid` to the list of AZs returned for the bosh director configuration. This is for the new multi-CPI support.

Signed-off-by: Huan Wang <huwang@pivotal.io>