### PR TITLE
fix order of vars-file interpolation

### DIFF
--- a/commands/interpolate.go
+++ b/commands/interpolate.go
@@ -59,7 +59,8 @@ func interpolate(templateFile string, varsFiles []string) ([]byte, error) {
 	tpl := boshtpl.NewTemplate(contents)
 	vars := []boshtpl.Variables{}
 
-	for _, path := range varsFiles {
+	for i := len(varsFiles) - 1; i >= 0; i-=1 {
+		path := varsFiles[i]
 		payload, err := ioutil.ReadFile(path)
 		if err != nil {
 			return nil, fmt.Errorf("could not read template variables file (%s): %s", path, err.Error())


### PR DESCRIPTION
The order of vars files are evaluated in a right to left precedence in
`bosh int`.

For example,

`manifest.yml`
```yml
a: ((name))
```

`vars1.yml`
```yaml
name: Bob
```

`vars2.yml`
```yaml
name: Moe
```

From a terminal windows far away.
```
bosh int manifest.yml -l vars1.yml -l vars2.yml
a: Moe
```

A value in `vars2.yml` will override a value defined in `vars1.yml`.

This behaviour has been added to `om int` to maintain usage patterns.

[#158312710]
