### PR TITLE
Fix configure director cluster guid

### DIFF
--- a/api/director_service.go
+++ b/api/director_service.go
@@ -203,6 +203,7 @@ func (a Api) addGUIDToExistingAZs(azs AvailabilityZones) (AvailabilityZones, err
 		for _, existingAZ := range existingAZs.AvailabilityZones {
 			if az.Name == existingAZ.Name {
 				az.GUID = existingAZ.GUID
+				az.Fields = existingAZ.Fields
 				break
 			}
 		}

--- a/api/director_service.go
+++ b/api/director_service.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 
 	yamlConverter "github.com/ghodss/yaml"
-	yaml "gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v2"
 )
 
 type AvailabilityZoneInput struct {
@@ -30,10 +30,17 @@ type Network struct {
 	Fields map[string]interface{} `yaml:",inline"`
 }
 
-type AZ struct {
+type Cluster struct {
 	GUID   string                 `yaml:"guid,omitempty"`
-	Name   string                 `yaml:"name"`
+	Name   string                 `yaml:"cluster"`
 	Fields map[string]interface{} `yaml:",inline"`
+}
+
+type AZ struct {
+	GUID     string                 `yaml:"guid,omitempty"`
+	Name     string                 `yaml:"name"`
+	Clusters []*Cluster             `yaml:"clusters,omitempty"`
+	Fields   map[string]interface{} `yaml:",inline"`
 }
 
 type AvailabilityZones struct {
@@ -203,7 +210,16 @@ func (a Api) addGUIDToExistingAZs(azs AvailabilityZones) (AvailabilityZones, err
 		for _, existingAZ := range existingAZs.AvailabilityZones {
 			if az.Name == existingAZ.Name {
 				az.GUID = existingAZ.GUID
-				az.Fields = existingAZ.Fields
+
+				for _, cluster := range az.Clusters {
+					for _, existingCluster := range existingAZ.Clusters {
+						if cluster.Name == existingCluster.Name {
+							cluster.GUID = existingCluster.GUID
+							break
+						}
+					}
+				}
+
 				break
 			}
 		}

--- a/api/director_service_test.go
+++ b/api/director_service_test.go
@@ -37,7 +37,11 @@ var _ = Describe("Director", func() {
 					return &http.Response{
 						StatusCode: http.StatusOK,
 						Body: ioutil.NopCloser(strings.NewReader(
-							`{"availability_zones": [{"guid": "existing-az-guid", "name": "existing-az"}]}`,
+							`{"availability_zones": [
+									{"guid": "existing-az-guid",
+									 "name": "existing-az",
+									 "clusters":
+										[{"cluster":"pizza", "guid":"pepperoni"}]}]}`,
 						))}, nil
 				} else {
 					return &http.Response{
@@ -50,7 +54,7 @@ var _ = Describe("Director", func() {
 		It("configures availability zones", func() {
 			err := service.UpdateStagedDirectorAvailabilityZones(api.AvailabilityZoneInput{
 				AvailabilityZones: json.RawMessage(`[
-          {"name": "existing-az"},
+          {"clusters":[{"cluster":"pizza"}],"name":"existing-az"},
           {"name": "new-az"}
         ]`),
 			})
@@ -74,7 +78,7 @@ var _ = Describe("Director", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(jsonBody).To(MatchJSON(`{
         "availability_zones": [
-         {"guid": "existing-az-guid", "name": "existing-az"},
+         {"guid": "existing-az-guid","name":"existing-az","clusters":[{"cluster":"pizza","guid":"pepperoni"}]},
          {"name": "new-az"}
         ]
 			}`))

--- a/api/director_service_test.go
+++ b/api/director_service_test.go
@@ -41,7 +41,9 @@ var _ = Describe("Director", func() {
 									{"guid": "existing-az-guid",
 									 "name": "existing-az",
 									 "clusters":
-										[{"cluster":"pizza", "guid":"pepperoni"}]}]}`,
+										[{"cluster":"pizza", 
+                                          "guid":"pepperoni",
+                                          "res_pool":"dcba"}]}]}`,
 						))}, nil
 				} else {
 					return &http.Response{
@@ -54,10 +56,9 @@ var _ = Describe("Director", func() {
 		It("configures availability zones", func() {
 			err := service.UpdateStagedDirectorAvailabilityZones(api.AvailabilityZoneInput{
 				AvailabilityZones: json.RawMessage(`[
-          {"clusters":[{"cluster":"pizza"}],"name":"existing-az"},
-          {"name": "new-az"}
-        ]`),
-			})
+          			{"clusters":[{"cluster":"pizza","res_pool":"abcd"}],"name":"existing-az","a_field":"some_val"},
+          			{"name": "new-az"}
+          			  ]`)})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(stderr.Invocations()).To(HaveLen(0))
 
@@ -77,11 +78,11 @@ var _ = Describe("Director", func() {
 			jsonBody, err := ioutil.ReadAll(putReq.Body)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(jsonBody).To(MatchJSON(`{
-        "availability_zones": [
-         {"guid": "existing-az-guid","name":"existing-az","clusters":[{"cluster":"pizza","guid":"pepperoni"}]},
-         {"name": "new-az"}
-        ]
-			}`))
+        		"availability_zones": [
+        		 {"a_field":"some_val","guid": "existing-az-guid","name":"existing-az",
+        		     "clusters":[{"cluster":"pizza","guid":"pepperoni","res_pool":"abcd"}]},
+        		 {"name": "new-az"}
+        		]}`))
 		})
 
 		It("preserves all provided fields", func() {

--- a/commands/configure_director.go
+++ b/commands/configure_director.go
@@ -182,7 +182,7 @@ func (c ConfigureDirector) Execute(args []string) error {
 		var userProvidedConfig map[string]json.RawMessage
 		err = json.Unmarshal([]byte(c.Options.ResourceConfiguration), &userProvidedConfig)
 		if err != nil {
-			return fmt.Errorf("could not decode resource-configuration json: %s", err)
+			return fmt.Errorf("could not decode resource-configuration json: %s", c.Options.ResourceConfiguration)
 		}
 
 		jobs, err := c.service.ListStagedProductJobs(productGUID)


### PR DESCRIPTION
Link to issue #170 
Link to story [#157950247]

before:
```
started configuring availability zone options for bosh tile
could not execute "configure-director": availability zones configuration could not be applied: request failed: unexpected response:
{"errors":["Cannot delete the cluster 'canada' in the availability zone 'AZ01' of a deployed product",
"Cannot delete the cluster 'canada' in the availability zone 'AZ02' of a deployed product",
"Cannot delete the cluster 'canada' in the availability zone 'AZ03' of a deployed product"]}
```

after:
```
started configuring availability zone options for bosh tile
finished configuring availability zone options for bosh tile
```