### PR TITLE
Add --product-name flag to apply-changes command

### DIFF
--- a/api/info_service.go
+++ b/api/info_service.go
@@ -1,0 +1,34 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// Info contains information about Ops Manager itself.
+type Info struct {
+	Version string `json:"version"`
+}
+
+// Info gets information about Ops Manager.
+func (a Api) Info() (Info, error) {
+	var r struct {
+		Info Info `json:"info"`
+	}
+	req, err := http.NewRequest("GET", "/api/v0/info", nil)
+	if err != nil {
+		return r.Info, err
+	}
+	resp, err := a.client.Do(req)
+	if err != nil {
+		return r.Info, fmt.Errorf("could not make request to info endpoint: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if err = validateStatusOK(resp); err != nil {
+		return r.Info, err
+	}
+	err = json.NewDecoder(resp.Body).Decode(&r)
+	return r.Info, err
+}

--- a/api/info_service.go
+++ b/api/info_service.go
@@ -4,11 +4,35 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strconv"
+	"strings"
 )
 
 // Info contains information about Ops Manager itself.
 type Info struct {
 	Version string `json:"version"`
+}
+
+func (i Info) VersionAtLeast(major, minor int) bool {
+	// Given: X.Y-build.Z
+	// Extract X and Y
+	idx := strings.Index(i.Version, ".")
+	majv := i.Version[:idx]                                  // take substring up to '.'
+	minv := i.Version[idx+1 : strings.Index(i.Version, "-")] // take substring between '.' and '-'
+
+	maj, err := strconv.Atoi(majv)
+	if err != nil {
+		panic("invalid version: " + i.Version)
+	}
+	min, err := strconv.Atoi(minv)
+	if err != nil {
+		panic("invalid version: " + i.Version)
+	}
+
+	if maj < major || (maj == major && min < minor) {
+		return false
+	}
+	return true
 }
 
 // Info gets information about Ops Manager.

--- a/api/info_service_test.go
+++ b/api/info_service_test.go
@@ -12,46 +12,67 @@ import (
 	"github.com/pivotal-cf/om/api/fakes"
 )
 
-var _ = Describe("Info", func() {
-	var (
-		client  *fakes.HttpClient
-		service api.Api
-	)
-
-	BeforeEach(func() {
-		client = &fakes.HttpClient{}
-		service = api.New(api.ApiInput{
-			Client: client,
+var _ = Describe("Info Service", func() {
+	Context("VersionAtLeast()", func() {
+		It("determines whether a version meets a minimum requirement", func() {
+			tests := []struct {
+				ver    string
+				result bool
+			}{
+				{"1.2-build10", false},
+				{"2.2-build3", true},
+				{"1.9-build1", false},
+				{"1.12-build1", false},
+				{"2.0-build1", false},
+				{"2.3-build33", true},
+			}
+			for _, test := range tests {
+				Expect(api.Info{Version: test.ver}.VersionAtLeast(2, 2)).To(Equal(test.result))
+			}
 		})
 	})
 
-	It("lists the info", func() {
-		client.DoReturns(&http.Response{
-			StatusCode: http.StatusOK,
-			Body:       ioutil.NopCloser(strings.NewReader(`{ "info": { "version": "v2.1-build.79" } }`)),
-		}, nil)
+	Context("Info()", func() {
+		var (
+			client  *fakes.HttpClient
+			service api.Api
+		)
 
-		info, err := service.Info()
-		Expect(err).NotTo(HaveOccurred())
-		Expect(info.Version).To(Equal("v2.1-build.79"))
-	})
-
-	Context("Error Cases", func() {
-		It("errors if the API call fails", func() {
-			client.DoReturns(nil, errors.New("request failed"))
-			info, err := service.Info()
-			Expect(err).To(HaveOccurred())
-			Expect(info).To(BeZero())
+		BeforeEach(func() {
+			client = &fakes.HttpClient{}
+			service = api.New(api.ApiInput{
+				Client: client,
+			})
 		})
 
-		It("errors if the response is not valid", func() {
+		It("lists the info", func() {
 			client.DoReturns(&http.Response{
-				StatusCode: http.StatusNotFound,
-				Body:       ioutil.NopCloser(strings.NewReader("")),
+				StatusCode: http.StatusOK,
+				Body:       ioutil.NopCloser(strings.NewReader(`{ "info": { "version": "v2.1-build.79" } }`)),
 			}, nil)
+
 			info, err := service.Info()
-			Expect(err).To(HaveOccurred())
-			Expect(info).To(BeZero())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(info.Version).To(Equal("v2.1-build.79"))
+		})
+
+		Context("Error Cases", func() {
+			It("errors if the API call fails", func() {
+				client.DoReturns(nil, errors.New("request failed"))
+				info, err := service.Info()
+				Expect(err).To(HaveOccurred())
+				Expect(info).To(BeZero())
+			})
+
+			It("errors if the response is not valid", func() {
+				client.DoReturns(&http.Response{
+					StatusCode: http.StatusNotFound,
+					Body:       ioutil.NopCloser(strings.NewReader("")),
+				}, nil)
+				info, err := service.Info()
+				Expect(err).To(HaveOccurred())
+				Expect(info).To(BeZero())
+			})
 		})
 	})
 })

--- a/api/info_service_test.go
+++ b/api/info_service_test.go
@@ -1,0 +1,57 @@
+package api_test
+
+import (
+	"errors"
+	"io/ioutil"
+	"net/http"
+	"strings"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/pivotal-cf/om/api"
+	"github.com/pivotal-cf/om/api/fakes"
+)
+
+var _ = Describe("Info", func() {
+	var (
+		client  *fakes.HttpClient
+		service api.Api
+	)
+
+	BeforeEach(func() {
+		client = &fakes.HttpClient{}
+		service = api.New(api.ApiInput{
+			Client: client,
+		})
+	})
+
+	It("lists the info", func() {
+		client.DoReturns(&http.Response{
+			StatusCode: http.StatusOK,
+			Body:       ioutil.NopCloser(strings.NewReader(`{ "info": { "version": "v2.1-build.79" } }`)),
+		}, nil)
+
+		info, err := service.Info()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(info.Version).To(Equal("v2.1-build.79"))
+	})
+
+	Context("Error Cases", func() {
+		It("errors if the API call fails", func() {
+			client.DoReturns(nil, errors.New("request failed"))
+			info, err := service.Info()
+			Expect(err).To(HaveOccurred())
+			Expect(info).To(BeZero())
+		})
+
+		It("errors if the response is not valid", func() {
+			client.DoReturns(&http.Response{
+				StatusCode: http.StatusNotFound,
+				Body:       ioutil.NopCloser(strings.NewReader("")),
+			}, nil)
+			info, err := service.Info()
+			Expect(err).To(HaveOccurred())
+			Expect(info).To(BeZero())
+		})
+	})
+})

--- a/commands/apply_changes.go
+++ b/commands/apply_changes.go
@@ -3,8 +3,6 @@ package commands
 import (
 	"errors"
 	"fmt"
-	"strconv"
-	"strings"
 	"time"
 
 	"github.com/pivotal-cf/jhanda"
@@ -60,7 +58,7 @@ func (ac ApplyChanges) Execute(args []string) error {
 		if err != nil {
 			return fmt.Errorf("could not retrieve info from targetted ops manager: %v", err)
 		}
-		if !versionAtLeast(info.Version, 2, 2) {
+		if !info.VersionAtLeast(2, 2) {
 			return fmt.Errorf("--product-name is only available with Ops Manager 2.2 or later: you are running %s", info.Version)
 		}
 	}
@@ -114,26 +112,4 @@ func (ac ApplyChanges) Usage() jhanda.Usage {
 		ShortDescription: "triggers an install on the Ops Manager targeted",
 		Flags:            ac.Options,
 	}
-}
-
-func versionAtLeast(version string, major, minor int) bool {
-	// Given: X.Y-build.Z
-	// Extract X and Y
-	i := strings.Index(version, ".")
-	majv := version[:i]                                // take substring up to '.'
-	minv := version[i+1 : strings.Index(version, "-")] // take substring between '.' and '-'
-
-	maj, err := strconv.Atoi(majv)
-	if err != nil {
-		panic("invalid version: " + version)
-	}
-	min, err := strconv.Atoi(minv)
-	if err != nil {
-		panic("invalid version: " + version)
-	}
-
-	if maj < major || (maj == major && min < minor) {
-		return false
-	}
-	return true
 }

--- a/commands/fakes/apply_changes_service.go
+++ b/commands/fakes/apply_changes_service.go
@@ -49,6 +49,17 @@ type ApplyChangesService struct {
 		result1 api.InstallationsServiceOutput
 		result2 error
 	}
+	InfoStub        func() (api.Info, error)
+	infoMutex       sync.RWMutex
+	infoArgsForCall []struct{}
+	infoReturns     struct {
+		result1 api.Info
+		result2 error
+	}
+	infoReturnsOnCall map[int]struct {
+		result1 api.Info
+		result2 error
+	}
 	RunningInstallationStub        func() (api.InstallationsServiceOutput, error)
 	runningInstallationMutex       sync.RWMutex
 	runningInstallationArgsForCall []struct{}
@@ -235,6 +246,49 @@ func (fake *ApplyChangesService) GetInstallationLogsReturnsOnCall(i int, result1
 	}{result1, result2}
 }
 
+func (fake *ApplyChangesService) Info() (api.Info, error) {
+	fake.infoMutex.Lock()
+	ret, specificReturn := fake.infoReturnsOnCall[len(fake.infoArgsForCall)]
+	fake.infoArgsForCall = append(fake.infoArgsForCall, struct{}{})
+	fake.recordInvocation("Info", []interface{}{})
+	fake.infoMutex.Unlock()
+	if fake.InfoStub != nil {
+		return fake.InfoStub()
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fake.infoReturns.result1, fake.infoReturns.result2
+}
+
+func (fake *ApplyChangesService) InfoCallCount() int {
+	fake.infoMutex.RLock()
+	defer fake.infoMutex.RUnlock()
+	return len(fake.infoArgsForCall)
+}
+
+func (fake *ApplyChangesService) InfoReturns(result1 api.Info, result2 error) {
+	fake.InfoStub = nil
+	fake.infoReturns = struct {
+		result1 api.Info
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *ApplyChangesService) InfoReturnsOnCall(i int, result1 api.Info, result2 error) {
+	fake.InfoStub = nil
+	if fake.infoReturnsOnCall == nil {
+		fake.infoReturnsOnCall = make(map[int]struct {
+			result1 api.Info
+			result2 error
+		})
+	}
+	fake.infoReturnsOnCall[i] = struct {
+		result1 api.Info
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *ApplyChangesService) RunningInstallation() (api.InstallationsServiceOutput, error) {
 	fake.runningInstallationMutex.Lock()
 	ret, specificReturn := fake.runningInstallationReturnsOnCall[len(fake.runningInstallationArgsForCall)]
@@ -330,6 +384,8 @@ func (fake *ApplyChangesService) Invocations() map[string][][]interface{} {
 	defer fake.getInstallationMutex.RUnlock()
 	fake.getInstallationLogsMutex.RLock()
 	defer fake.getInstallationLogsMutex.RUnlock()
+	fake.infoMutex.RLock()
+	defer fake.infoMutex.RUnlock()
 	fake.runningInstallationMutex.RLock()
 	defer fake.runningInstallationMutex.RUnlock()
 	fake.listInstallationsMutex.RLock()

--- a/commands/fakes/apply_changes_service.go
+++ b/commands/fakes/apply_changes_service.go
@@ -8,11 +8,12 @@ import (
 )
 
 type ApplyChangesService struct {
-	CreateInstallationStub        func(bool, bool) (api.InstallationsServiceOutput, error)
+	CreateInstallationStub        func(bool, bool, []string) (api.InstallationsServiceOutput, error)
 	createInstallationMutex       sync.RWMutex
 	createInstallationArgsForCall []struct {
 		arg1 bool
 		arg2 bool
+		arg3 []string
 	}
 	createInstallationReturns struct {
 		result1 api.InstallationsServiceOutput
@@ -74,17 +75,23 @@ type ApplyChangesService struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *ApplyChangesService) CreateInstallation(arg1 bool, arg2 bool) (api.InstallationsServiceOutput, error) {
+func (fake *ApplyChangesService) CreateInstallation(arg1 bool, arg2 bool, arg3 []string) (api.InstallationsServiceOutput, error) {
+	var arg3Copy []string
+	if arg3 != nil {
+		arg3Copy = make([]string, len(arg3))
+		copy(arg3Copy, arg3)
+	}
 	fake.createInstallationMutex.Lock()
 	ret, specificReturn := fake.createInstallationReturnsOnCall[len(fake.createInstallationArgsForCall)]
 	fake.createInstallationArgsForCall = append(fake.createInstallationArgsForCall, struct {
 		arg1 bool
 		arg2 bool
-	}{arg1, arg2})
-	fake.recordInvocation("CreateInstallation", []interface{}{arg1, arg2})
+		arg3 []string
+	}{arg1, arg2, arg3Copy})
+	fake.recordInvocation("CreateInstallation", []interface{}{arg1, arg2, arg3Copy})
 	fake.createInstallationMutex.Unlock()
 	if fake.CreateInstallationStub != nil {
-		return fake.CreateInstallationStub(arg1, arg2)
+		return fake.CreateInstallationStub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -98,10 +105,10 @@ func (fake *ApplyChangesService) CreateInstallationCallCount() int {
 	return len(fake.createInstallationArgsForCall)
 }
 
-func (fake *ApplyChangesService) CreateInstallationArgsForCall(i int) (bool, bool) {
+func (fake *ApplyChangesService) CreateInstallationArgsForCall(i int) (bool, bool, []string) {
 	fake.createInstallationMutex.RLock()
 	defer fake.createInstallationMutex.RUnlock()
-	return fake.createInstallationArgsForCall[i].arg1, fake.createInstallationArgsForCall[i].arg2
+	return fake.createInstallationArgsForCall[i].arg1, fake.createInstallationArgsForCall[i].arg2, fake.createInstallationArgsForCall[i].arg3
 }
 
 func (fake *ApplyChangesService) CreateInstallationReturns(result1 api.InstallationsServiceOutput, result2 error) {


### PR DESCRIPTION
Add support for OM 2.2's selective apply changes.

Fixes #141

For example:
```
$ om  [...] apply-changes --product-name ert --product-name p-healthwatch
```

When `--product-name` is used, a call to the `info` endpoint is made to ensure that the specified ops manager supports this operation.  If it doesn't, the user receives an error:

```
$ om -t https://opsman.example.com -p redacted -u admin apply-changes --product-name p-healthwatch
could not execute "apply-changes": --product-name is only available with Ops Manager 2.2 or later: you are running 2.1-build.326
```