### PR TITLE
Change generated placeholder names from periods to underscores in `config-template` (again)

### DIFF
--- a/commands/config_template.go
+++ b/commands/config_template.go
@@ -126,42 +126,48 @@ func (ct ConfigTemplate) Usage() jhanda.Usage {
 }
 
 func addSecretPlaceholder(value interface{}, t string, configurableProperties map[string]interface{}, name string) {
+	formattedName := formatKeyName(name)
+
 	switch t {
 	case "secret":
 		configurableProperties[name] = map[string]interface{}{
 			"value": map[string]string{
-				"secret": fmt.Sprintf("((%s.secret))", name),
+				"secret": fmt.Sprintf("((%s.secret))", formattedName),
 			},
 		}
 	case "simple_credentials":
 		configurableProperties[name] = map[string]interface{}{
 			"value": map[string]string{
-				"identity": fmt.Sprintf("((%s.identity))", name),
-				"password": fmt.Sprintf("((%s.password))", name),
+				"identity": fmt.Sprintf("((%s.identity))", formattedName),
+				"password": fmt.Sprintf("((%s.password))", formattedName),
 			},
 		}
 	case "rsa_cert_credentials":
 		configurableProperties[name] = map[string]interface{}{
 			"value": map[string]string{
-				"cert_pem":        fmt.Sprintf("((%s.cert_pem))", name),
-				"private_key_pem": fmt.Sprintf("((%s.private_key_pem))", name),
+				"cert_pem":        fmt.Sprintf("((%s.cert_pem))", formattedName),
+				"private_key_pem": fmt.Sprintf("((%s.private_key_pem))", formattedName),
 			},
 		}
 	case "rsa_pkey_credentials":
 		configurableProperties[name] = map[string]interface{}{
 			"value": map[string]string{
-				"private_key_pem": fmt.Sprintf("((%s.private_key_pem))", name),
+				"private_key_pem": fmt.Sprintf("((%s.private_key_pem))", formattedName),
 			},
 		}
 	case "salted_credentials":
 		configurableProperties[name] = map[string]interface{}{
 			"value": map[string]string{
-				"identity": fmt.Sprintf("((%s.identity))", name),
-				"password": fmt.Sprintf("((%s.password))", name),
-				"salt":     fmt.Sprintf("((%s.salt))", name),
+				"identity": fmt.Sprintf("((%s.identity))", formattedName),
+				"password": fmt.Sprintf("((%s.password))", formattedName),
+				"salt":     fmt.Sprintf("((%s.salt))", formattedName),
 			},
 		}
 	default:
 		configurableProperties[name] = map[string]interface{}{"value": value}
 	}
+}
+
+func formatKeyName(name string) string {
+	return strings.Replace(name,".","_",-1)[1:]
 }

--- a/commands/config_template_test.go
+++ b/commands/config_template_test.go
@@ -131,8 +131,8 @@ property_blueprints:
 product-properties:
   .properties.some-name:
     value:
-      identity: ((.properties.some-name.identity))
-      password: ((.properties.some-name.password))
+      identity: ((properties_some-name.identity))
+      password: ((properties_some-name.password))
 `)))
 				})
 			})


### PR DESCRIPTION
This is the same PR as https://github.com/pivotal-cf/om/pull/209. Github won't let us reopen that one due to an unfortunate force push. It fixes the problem described in https://github.com/pivotal-cf/om/issues/189.

We discussed approaches @chendrix and @genevieve, and agreed that while unified logic for this is desirable, the weight of that refactor might be a heavy (and potentially premature) lift.

So, while we'd like to revisit the structure of all these commands that output templates/config down the road, we'd like to merge this fix that gets behavior consistent and then refactor under green at some point in the future.

Signed-off-by: Huan Wang <huwang@pivotal.io>