### PR TITLE
Add tile-metadata command for product name and version

### DIFF
--- a/acceptance/help_test.go
+++ b/acceptance/help_test.go
@@ -67,6 +67,7 @@ Commands:
   staged-director-config          **EXPERIMENTAL** generates a config from a staged director
   staged-manifest                 prints the staged manifest for a product
   staged-products                 lists staged products
+  tile-metadata                   prints tile metadata
   unstage-product                 unstages a given product from the Ops Manager targeted
   upload-product                  uploads a given product to the Ops Manager targeted
   upload-stemcell                 uploads a given stemcell to the Ops Manager targeted

--- a/acceptance/tile_metadata_test.go
+++ b/acceptance/tile_metadata_test.go
@@ -1,0 +1,68 @@
+package acceptance
+
+import (
+	"archive/zip"
+	"io/ioutil"
+	"os"
+
+	"os/exec"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gexec"
+)
+
+var _ = Describe("tile-metadata command", func() {
+	var (
+		productFile *os.File
+		err         error
+	)
+
+	BeforeEach(func() {
+		productFile, err = ioutil.TempFile("", "fake-tile")
+		z := zip.NewWriter(productFile)
+
+		f, err := z.Create("metadata/fake-tile.yml")
+		Expect(err).NotTo(HaveOccurred())
+
+		_, err = f.Write([]byte(`
+name: fake-tile
+product_version: 1.2.3
+`))
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(z.Close()).To(Succeed())
+	})
+
+	AfterEach(func() {
+		Expect(os.RemoveAll(productFile.Name())).To(Succeed())
+	})
+
+	It("shows product name from tile metadata file", func() {
+		command := exec.Command(pathToMain,
+			"tile-metadata",
+			"-p", productFile.Name(),
+			"--product-name",
+		)
+
+		session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
+		Expect(err).NotTo(HaveOccurred())
+
+		Eventually(session).Should(gexec.Exit(0))
+		Expect(session.Out.Contents()).To(ContainSubstring("fake-tile"))
+	})
+
+	It("shows product version from tile metadata file", func() {
+		command := exec.Command(pathToMain,
+			"tile-metadata",
+			"-p", productFile.Name(),
+			"--product-version",
+		)
+
+		session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
+		Expect(err).NotTo(HaveOccurred())
+
+		Eventually(session).Should(gexec.Exit(0))
+		Expect(session.Out.Contents()).To(ContainSubstring("1.2.3"))
+	})
+})

--- a/commands/tile_metadata.go
+++ b/commands/tile_metadata.go
@@ -1,0 +1,86 @@
+package commands
+
+import (
+	"errors"
+	"fmt"
+
+	"archive/zip"
+
+	"regexp"
+
+	"github.com/pivotal-cf/jhanda"
+	"gopkg.in/yaml.v2"
+)
+
+type TileMetadata struct {
+	stdout  logger
+	Options struct {
+		ProductPath    string `long:"product-path" short:"p"   required:"true" description:"path to product file"`
+		ProductName    bool   `long:"product-name"  description:"show product name"`
+		ProductVersion bool   `long:"product-version"  description:"show product version"`
+	}
+}
+
+func NewTileMetadata(stdout logger) TileMetadata {
+	return TileMetadata{stdout: stdout}
+}
+
+func (t TileMetadata) Execute(args []string) error {
+	if _, err := jhanda.Parse(&t.Options, args); err != nil {
+		return fmt.Errorf("could not parse tile-metadata flags: %s", err)
+	}
+
+	if !t.Options.ProductName && !t.Options.ProductVersion {
+		return errors.New("you must specify product-name and/or product-version")
+	}
+
+	file, err := zip.OpenReader(t.Options.ProductPath)
+	if err != nil {
+		return fmt.Errorf("failed to open product file: %s", err)
+	}
+	defer file.Close()
+
+	for _, f := range file.File {
+		matched, err := regexp.MatchString("metadata/.*", f.Name)
+		if err != nil {
+			return fmt.Errorf("failed to match file name regex: %s", err)
+		}
+
+		if matched {
+			meta, err := f.Open()
+			if err != nil {
+				return fmt.Errorf("failed to open metadata file: %s", err)
+			}
+
+			type DecodedFile struct {
+				ProductName    string `yaml:"name"`
+				ProductVersion string `yaml:"product_version"`
+			}
+			var v DecodedFile
+			err = yaml.NewDecoder(meta).Decode(&v)
+			if err != nil {
+				return fmt.Errorf("failed to decode metadata file: %s", err)
+			}
+
+			if t.Options.ProductName {
+				t.stdout.Println(v.ProductName)
+			}
+
+			if t.Options.ProductVersion {
+				t.stdout.Println(v.ProductVersion)
+			}
+
+			return nil
+		}
+	}
+
+	return errors.New("failed to find metadata file")
+}
+
+func (t TileMetadata) Usage() jhanda.Usage {
+	return jhanda.Usage{
+		Description:      "This command prints metadata about the given tile",
+		ShortDescription: "prints tile metadata",
+		Flags:            t.Options,
+	}
+}

--- a/commands/tile_metadata_test.go
+++ b/commands/tile_metadata_test.go
@@ -1,0 +1,132 @@
+package commands_test
+
+import (
+	"archive/zip"
+
+	"os"
+
+	"io/ioutil"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/pivotal-cf/jhanda"
+	"github.com/pivotal-cf/om/commands"
+	"github.com/pivotal-cf/om/commands/fakes"
+)
+
+var _ = Describe("TileMetadata", func() {
+	Describe("Execute", func() {
+		var (
+			command commands.TileMetadata
+			stdout  *fakes.Logger
+
+			productFile *os.File
+			err         error
+		)
+
+		BeforeEach(func() {
+			stdout = &fakes.Logger{}
+
+			command = commands.NewTileMetadata(stdout)
+
+			// write fake file
+			productFile, err = ioutil.TempFile("", "fake-tile")
+			z := zip.NewWriter(productFile)
+
+			f, err := z.Create("metadata/fake-tile.yml")
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = f.Write([]byte(`
+name: fake-tile
+product_version: 1.2.3
+`))
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(z.Close()).To(Succeed())
+		})
+
+		AfterEach(func() {
+			Expect(os.RemoveAll(productFile.Name())).To(Succeed())
+		})
+
+		It("shows product name from tile metadata file", func() {
+			err = command.Execute([]string{
+				"-p",
+				productFile.Name(),
+				"--product-name",
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			content := stdout.PrintlnArgsForCall(0)
+			Expect(content).To(ContainElement("fake-tile"))
+		})
+
+		It("shows product version from tile metadata file", func() {
+			err = command.Execute([]string{
+				"-p",
+				productFile.Name(),
+				"--product-version",
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			content := stdout.PrintlnArgsForCall(0)
+			Expect(content).To(ContainElement("1.2.3"))
+		})
+
+		Context("failure cases", func() {
+			Context("when the flags cannot be parsed", func() {
+				It("returns an error", func() {
+					err = command.Execute([]string{"--bad-flag", "some-value"})
+					Expect(err).To(MatchError(MatchRegexp("could not parse tile-metadata flags")))
+				})
+			})
+
+			Context("when the flags are not specified", func() {
+				It("returns an error", func() {
+					err = command.Execute([]string{"-p", productFile.Name()})
+					Expect(err).To(MatchError(MatchRegexp("you must specify product-name and/or product-version")))
+				})
+			})
+
+			Context("when the specified product file is not found", func() {
+				It("returns an error", func() {
+					err = command.Execute([]string{"-p", "non-existent-file", "--product-name"})
+					Expect(err).To(MatchError(MatchRegexp("failed to open product file")))
+				})
+			})
+
+			Context("when the file does not have metadata", func() {
+				var (
+					badTile *os.File
+				)
+
+				BeforeEach(func() {
+					badTile, err = ioutil.TempFile("", "bad-tile")
+					Expect(err).NotTo(HaveOccurred())
+					z := zip.NewWriter(badTile)
+					Expect(z.Close()).To(Succeed())
+				})
+
+				AfterEach(func() {
+					Expect(os.RemoveAll(badTile.Name())).To(Succeed())
+				})
+
+				It("returns an error", func() {
+					err = command.Execute([]string{"-p", badTile.Name(), "--product-name"})
+					Expect(err).To(MatchError(MatchRegexp("failed to find metadata file")))
+				})
+			})
+		})
+	})
+
+	Describe("Usage", func() {
+		It("returns the usage information for the tile-metadata command", func() {
+			command := commands.TileMetadata{}
+			Expect(command.Usage()).To(Equal(jhanda.Usage{
+				Description:      "This command prints metadata about the given tile",
+				ShortDescription: "prints tile metadata",
+				Flags:            command.Options,
+			}))
+		})
+	})
+})

--- a/main.go
+++ b/main.go
@@ -172,6 +172,7 @@ func main() {
 	commandSet["stage-product"] = commands.NewStageProduct(api, stdout)
 	commandSet["staged-manifest"] = commands.NewStagedManifest(api, stdout)
 	commandSet["staged-products"] = commands.NewStagedProducts(presenter, api)
+	commandSet["tile-metadata"] = commands.NewTileMetadata(stdout)
 	commandSet["unstage-product"] = commands.NewUnstageProduct(api, stdout)
 	commandSet["upload-product"] = commands.NewUploadProduct(form, metadataExtractor, api, stdout)
 	commandSet["upload-stemcell"] = commands.NewUploadStemcell(form, api, stdout)


### PR DESCRIPTION
Parses *.pivotal files to look for a metadata/*.yml file

Will print out product-name or product-version
Will fail if it's not a zip file, or if no metadata file is found.

[#159774047] pivotal-cf/om #231: Ability to parse tile metadata from *.pivotal file
[fixes #231]

Signed-off-by: David Deriso <davidderiso@gmail.com>