### PR TITLE
Allow Product Name to be set in the config file for configure-product

### DIFF
--- a/docs/configure-product/README.md
+++ b/docs/configure-product/README.md
@@ -45,6 +45,7 @@ A real product may have many more product properties to configure but this gives
 you the general structure of the file:
 
 ```yaml
+product-name: sample-product
 product-properties:
   .cloud_controller.apps_domain:
     value: apps.example.com


### PR DESCRIPTION
providing the `--product-name` flag will overwrite what is written in the config file. If the flag is missing, it will try to check if the value exists in a provided config, else it will fail and require the property be provided. 