### PR TITLE
add retrive errand for staged-config

### DIFF
--- a/acceptance/staged_config_test.go
+++ b/acceptance/staged_config_test.go
@@ -115,6 +115,18 @@ var _ = Describe("staged-config command", func() {
 							}
 						}
 					}`))
+			case "/api/v0/staged/products/some-product-guid/errands":
+				w.Write([]byte(`{ "errands": [
+                           {
+                             "name": "errand-1",
+                             "post_deploy": false,
+                             "label": "Errand 1 Label"
+                           },
+                           {
+                             "name": "errand-2",
+                             "pre_delete": true,
+                             "label": "Errand 2 Label"
+                           }]}`))
 			default:
 				out, err := httputil.DumpRequest(req, true)
 				Expect(err).NotTo(HaveOccurred())
@@ -157,6 +169,11 @@ resource-config:
     instance_type: { id: automatic }
     elb_names: ["my-elb"]
     internet_connected: true
+errand-config:
+  errand-1:
+    post-deploy-state: false
+  errand-2:
+    pre-delete-state: true
 `))
 	})
 
@@ -199,6 +216,11 @@ resource-config:
     instance_type: { id: automatic }
     elb_names: ["my-elb"]
     internet_connected: true
+errand-config:
+  errand-1:
+    post-deploy-state: false
+  errand-2:
+    pre-delete-state: true
 `))
 		})
 	})

--- a/commands/fakes/staged_config_service.go
+++ b/commands/fakes/staged_config_service.go
@@ -98,6 +98,19 @@ type StagedConfigService struct {
 		result1 map[string]string
 		result2 error
 	}
+	ListStagedProductErrandsStub        func(productID string) (api.ErrandsListOutput, error)
+	listStagedProductErrandsMutex       sync.RWMutex
+	listStagedProductErrandsArgsForCall []struct {
+		productID string
+	}
+	listStagedProductErrandsReturns struct {
+		result1 api.ErrandsListOutput
+		result2 error
+	}
+	listStagedProductErrandsReturnsOnCall map[int]struct {
+		result1 api.ErrandsListOutput
+		result2 error
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
@@ -452,6 +465,57 @@ func (fake *StagedConfigService) ListStagedProductJobsReturnsOnCall(i int, resul
 	}{result1, result2}
 }
 
+func (fake *StagedConfigService) ListStagedProductErrands(productID string) (api.ErrandsListOutput, error) {
+	fake.listStagedProductErrandsMutex.Lock()
+	ret, specificReturn := fake.listStagedProductErrandsReturnsOnCall[len(fake.listStagedProductErrandsArgsForCall)]
+	fake.listStagedProductErrandsArgsForCall = append(fake.listStagedProductErrandsArgsForCall, struct {
+		productID string
+	}{productID})
+	fake.recordInvocation("ListStagedProductErrands", []interface{}{productID})
+	fake.listStagedProductErrandsMutex.Unlock()
+	if fake.ListStagedProductErrandsStub != nil {
+		return fake.ListStagedProductErrandsStub(productID)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fake.listStagedProductErrandsReturns.result1, fake.listStagedProductErrandsReturns.result2
+}
+
+func (fake *StagedConfigService) ListStagedProductErrandsCallCount() int {
+	fake.listStagedProductErrandsMutex.RLock()
+	defer fake.listStagedProductErrandsMutex.RUnlock()
+	return len(fake.listStagedProductErrandsArgsForCall)
+}
+
+func (fake *StagedConfigService) ListStagedProductErrandsArgsForCall(i int) string {
+	fake.listStagedProductErrandsMutex.RLock()
+	defer fake.listStagedProductErrandsMutex.RUnlock()
+	return fake.listStagedProductErrandsArgsForCall[i].productID
+}
+
+func (fake *StagedConfigService) ListStagedProductErrandsReturns(result1 api.ErrandsListOutput, result2 error) {
+	fake.ListStagedProductErrandsStub = nil
+	fake.listStagedProductErrandsReturns = struct {
+		result1 api.ErrandsListOutput
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *StagedConfigService) ListStagedProductErrandsReturnsOnCall(i int, result1 api.ErrandsListOutput, result2 error) {
+	fake.ListStagedProductErrandsStub = nil
+	if fake.listStagedProductErrandsReturnsOnCall == nil {
+		fake.listStagedProductErrandsReturnsOnCall = make(map[int]struct {
+			result1 api.ErrandsListOutput
+			result2 error
+		})
+	}
+	fake.listStagedProductErrandsReturnsOnCall[i] = struct {
+		result1 api.ErrandsListOutput
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *StagedConfigService) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
@@ -469,6 +533,8 @@ func (fake *StagedConfigService) Invocations() map[string][][]interface{} {
 	defer fake.listDeployedProductsMutex.RUnlock()
 	fake.listStagedProductJobsMutex.RLock()
 	defer fake.listStagedProductJobsMutex.RUnlock()
+	fake.listStagedProductErrandsMutex.RLock()
+	defer fake.listStagedProductErrandsMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/commands/staged_config_test.go
+++ b/commands/staged_config_test.go
@@ -151,7 +151,12 @@ var _ = Describe("StagedConfig", func() {
 				GUID: "some-product-guid",
 			},
 		}, nil)
-
+		fakeService.ListStagedProductErrandsReturns(api.ErrandsListOutput{
+			Errands: []api.Errand{
+				{Name: "first-errand", PostDeploy: true, PreDelete: "do-something"},
+				{Name: "second-errand", PostDeploy: false},
+			},
+		}, nil)
 		fakeService.ListStagedProductJobsReturns(map[string]string{
 			"some-job": "some-job-guid",
 		}, nil)
@@ -207,6 +212,12 @@ resource-config:
     instances: 1
     instance_type:
       id: automatic
+errand-config:
+  first-errand:
+    post-deploy-state: true
+    pre-delete-state: do-something
+  second-errand:
+    post-deploy-state: false
 `)))
 		})
 	})
@@ -265,7 +276,12 @@ resource-config:
     instances: 1
     instance_type:
       id: automatic
-
+errand-config:
+  first-errand:
+    post-deploy-state: true
+    pre-delete-state: do-something
+  second-errand:
+    post-deploy-state: false
 `)))
 		})
 	})
@@ -371,6 +387,12 @@ resource-config:
     instances: 1
     instance_type:
       id: automatic
+errand-config:
+  first-errand:
+    post-deploy-state: true
+    pre-delete-state: do-something
+  second-errand:
+    post-deploy-state: false
 `)))
 		})
 


### PR DESCRIPTION
re issue #261 

expected output:
```
$ om staged-config -p cf
<truncated>
errand-config:
  deploy-autoscaler:
    post-deploy-state: true
  deploy-notifications:
    post-deploy-state: false
  deploy-notifications-ui:
    post-deploy-state: false
  nfsbrokerpush:
    post-deploy-state: false
  push-apps-manager:
    post-deploy-state: false
  push-usage-service:
    post-deploy-state: false
  smoke_tests:
    post-deploy-state: true
  test-autoscaling:
    post-deploy-state: false
```