### PR TITLE
add global decryption-passphrase (breaking change to import-installation)

### DIFF
--- a/acceptance/help_test.go
+++ b/acceptance/help_test.go
@@ -13,18 +13,19 @@ const GLOBAL_USAGE = `ॐ
 om helps you interact with an Ops Manager
 
 Usage: om [options] <command> [<args>]
-  --client-id, -c, OM_CLIENT_ID          string  Client ID for the Ops Manager VM (not required for unauthenticated commands)
-  --client-secret, -s, OM_CLIENT_SECRET  string  Client Secret for the Ops Manager VM (not required for unauthenticated commands)
-  --connect-timeout, -o                  int     timeout in seconds to make TCP connections (default: 5)
-  --env, -e                              string  env file with login credentials
-  --help, -h                             bool    prints this usage information (default: false)
-  --password, -p, OM_PASSWORD            string  admin password for the Ops Manager VM (not required for unauthenticated commands)
-  --request-timeout, -r                  int     timeout in seconds for HTTP requests to Ops Manager (default: 1800)
-  --skip-ssl-validation, -k              bool    skip ssl certificate validation during http requests (default: false)
-  --target, -t, OM_TARGET                string  location of the Ops Manager VM
-  --trace, -tr                           bool    prints HTTP requests and response payloads
-  --username, -u, OM_USERNAME            string  admin username for the Ops Manager VM (not required for unauthenticated commands)
-  --version, -v                          bool    prints the om release version (default: false)
+  --client-id, -c, OM_CLIENT_ID                          string  Client ID for the Ops Manager VM (not required for unauthenticated commands)
+  --client-secret, -s, OM_CLIENT_SECRET                  string  Client Secret for the Ops Manager VM (not required for unauthenticated commands)
+  --connect-timeout, -o                                  int     timeout in seconds to make TCP connections (default: 5)
+  --decryption-passphrase, -d, OM_DECRYPTION_PASSPHRASE  string  Passphrase to decrypt the installation if the Ops Manager VM has been rebooted (optional for most commands)
+  --env, -e                                              string  env file with login credentials
+  --help, -h                                             bool    prints this usage information (default: false)
+  --password, -p, OM_PASSWORD                            string  admin password for the Ops Manager VM (not required for unauthenticated commands)
+  --request-timeout, -r                                  int     timeout in seconds for HTTP requests to Ops Manager (default: 1800)
+  --skip-ssl-validation, -k                              bool    skip ssl certificate validation during http requests (default: false)
+  --target, -t, OM_TARGET                                string  location of the Ops Manager VM
+  --trace, -tr                                           bool    prints HTTP requests and response payloads
+  --username, -u, OM_USERNAME                            string  admin username for the Ops Manager VM (not required for unauthenticated commands)
+  --version, -v                                          bool    prints the om release version (default: false)
 
 Commands:
   activate-certificate-authority  activates a certificate authority on the Ops Manager
@@ -78,18 +79,19 @@ const CONFIGURE_AUTHENTICATION_USAGE = `ॐ  configure-authentication
 This unauthenticated command helps setup the internal userstore authentication mechanism for your Ops Manager.
 
 Usage: om [options] configure-authentication [<args>]
-  --client-id, -c, OM_CLIENT_ID          string  Client ID for the Ops Manager VM (not required for unauthenticated commands)
-  --client-secret, -s, OM_CLIENT_SECRET  string  Client Secret for the Ops Manager VM (not required for unauthenticated commands)
-  --connect-timeout, -o                  int     timeout in seconds to make TCP connections (default: 5)
-  --env, -e                              string  env file with login credentials
-  --help, -h                             bool    prints this usage information (default: false)
-  --password, -p, OM_PASSWORD            string  admin password for the Ops Manager VM (not required for unauthenticated commands)
-  --request-timeout, -r                  int     timeout in seconds for HTTP requests to Ops Manager (default: 1800)
-  --skip-ssl-validation, -k              bool    skip ssl certificate validation during http requests (default: false)
-  --target, -t, OM_TARGET                string  location of the Ops Manager VM
-  --trace, -tr                           bool    prints HTTP requests and response payloads
-  --username, -u, OM_USERNAME            string  admin username for the Ops Manager VM (not required for unauthenticated commands)
-  --version, -v                          bool    prints the om release version (default: false)
+  --client-id, -c, OM_CLIENT_ID                          string  Client ID for the Ops Manager VM (not required for unauthenticated commands)
+  --client-secret, -s, OM_CLIENT_SECRET                  string  Client Secret for the Ops Manager VM (not required for unauthenticated commands)
+  --connect-timeout, -o                                  int     timeout in seconds to make TCP connections (default: 5)
+  --decryption-passphrase, -d, OM_DECRYPTION_PASSPHRASE  string  Passphrase to decrypt the installation if the Ops Manager VM has been rebooted (optional for most commands)
+  --env, -e                                              string  env file with login credentials
+  --help, -h                                             bool    prints this usage information (default: false)
+  --password, -p, OM_PASSWORD                            string  admin password for the Ops Manager VM (not required for unauthenticated commands)
+  --request-timeout, -r                                  int     timeout in seconds for HTTP requests to Ops Manager (default: 1800)
+  --skip-ssl-validation, -k                              bool    skip ssl certificate validation during http requests (default: false)
+  --target, -t, OM_TARGET                                string  location of the Ops Manager VM
+  --trace, -tr                                           bool    prints HTTP requests and response payloads
+  --username, -u, OM_USERNAME                            string  admin username for the Ops Manager VM (not required for unauthenticated commands)
+  --version, -v                                          bool    prints the om release version (default: false)
 
 Command Arguments:
   --config, -c                  string             path to yml file for configuration (keys must match the following command line flags)

--- a/acceptance/import_installation_test.go
+++ b/acceptance/import_installation_test.go
@@ -75,10 +75,10 @@ var _ = Describe("import-installation command", func() {
 	It("successfully uploads an installation to the Ops Manager", func() {
 		command := exec.Command(pathToMain,
 			"--target", server.URL,
+			"--decryption-passphrase", "fake-passphrase",
 			"--skip-ssl-validation",
 			"import-installation",
 			"--installation", content.Name(),
-			"--decryption-passphrase", "fake-passphrase",
 		)
 
 		session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
@@ -116,10 +116,10 @@ var _ = Describe("import-installation command", func() {
 		It("returns an error", func() {
 			command := exec.Command(pathToMain,
 				"--target", server.URL,
+				"--decryption-passphrase", "fake-passphrase",
 				"--skip-ssl-validation",
 				"import-installation",
 				"--installation", content.Name(),
-				"--decryption-passphrase", "fake-passphrase",
 			)
 
 			session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
@@ -148,10 +148,10 @@ var _ = Describe("import-installation command", func() {
 			It("returns an error", func() {
 				command := exec.Command(pathToMain,
 					"--target", server.URL,
+					"--decryption-passphrase", "fake-passphrase",
 					"--skip-ssl-validation",
 					"import-installation",
 					"--installation", emptyContent.Name(),
-					"--decryption-passphrase", "fake-passphrase",
 				)
 
 				session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
@@ -171,10 +171,10 @@ var _ = Describe("import-installation command", func() {
 			It("returns an error", func() {
 				command := exec.Command(pathToMain,
 					"--target", server.URL,
+					"--decryption-passphrase", "fake-passphrase",
 					"--skip-ssl-validation",
 					"import-installation",
 					"--installation", content.Name(),
-					"--decryption-passphrase", "fake-passphrase",
 				)
 
 				session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)

--- a/network/decrypt_client.go
+++ b/network/decrypt_client.go
@@ -1,0 +1,128 @@
+package network
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+type DecryptClient struct {
+	unauthedClient httpClient
+	authedClient   httpClient
+
+	decryptionPassphrase string
+	writer               io.Writer
+}
+
+func NewDecryptClient(authdClient httpClient, unAuthedClient httpClient, decryptionPassphrase string, writer io.Writer) DecryptClient {
+	return DecryptClient{
+		authedClient:         authdClient,
+		unauthedClient:       unAuthedClient,
+		decryptionPassphrase: decryptionPassphrase,
+		writer:               writer,
+	}
+}
+
+func (c DecryptClient) Do(request *http.Request) (*http.Response, error) {
+	if err := c.decrypt(); err != nil {
+		return nil, err
+	}
+
+	return c.authedClient.Do(request)
+}
+
+func (c DecryptClient) decrypt() error {
+	const unlock = "/api/v0/unlock"
+	request, err := http.NewRequest("PUT", unlock, bytes.NewBufferString(fmt.Sprintf("{\"passphrase\": \"%s\"}", c.decryptionPassphrase)))
+	if err != nil {
+		return err
+	}
+
+	request.Header.Set("Content-Type", "application/json")
+	resp, err := c.unauthedClient.Do(request)
+	if err != nil {
+		return fmt.Errorf("could not make api request to unlock endpoint: %s", err)
+	}
+
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("could not unlock ops manager, check if the decryption passphrase is correct")
+	}
+
+	return c.waitUntilAvailable()
+}
+
+func (c DecryptClient) waitUntilAvailable() error {
+	var status = "unknown"
+	var err error
+
+	var trial = 1
+	for status != "complete" {
+		if trial == 2 {
+			c.writer.Write([]byte("Waiting for Ops Manager's auth systems to start. This may take a few minutes...\n"))
+		}
+		status, err = c.checkAvailability()
+		if err != nil {
+			return fmt.Errorf("could not check Ops Manager Status: %s", err)
+		}
+		trial += 1
+	}
+
+	return nil
+}
+
+func (c DecryptClient) checkAvailability() (string, error) {
+	// the below code is copied from api/setup_service. Don't really want to import api here as it will break
+	// dag dependency graph. It's probably make sense to separate that logic from api package into a standalone one
+	// to just maintain the dependencies.
+
+	request, err := http.NewRequest("GET", "/login/ensure_availability", nil)
+	if err != nil {
+		return "", err
+	}
+
+	response, err := c.unauthedClient.Do(request)
+	if err != nil {
+		return "", fmt.Errorf("could not make request round trip: %s", err)
+	}
+
+	defer response.Body.Close()
+
+	status := "unknown"
+	switch {
+	case response.StatusCode == http.StatusFound:
+		location, err := url.Parse(response.Header.Get("Location"))
+		if err != nil {
+			return "", fmt.Errorf("could not parse redirect url: %s", err)
+		}
+
+		if location.Path == "/setup" {
+			status = "unstarted"
+		} else if location.Path == "/auth/cloudfoundry" {
+			status = "complete"
+		} else {
+			return "", fmt.Errorf("Unexpected redirect location: %s", location.Path)
+		}
+
+	case response.StatusCode == http.StatusOK:
+		respBody, err := ioutil.ReadAll(response.Body)
+		if err != nil {
+			return "", err
+		}
+
+		if strings.Contains(string(respBody), "Waiting for authentication system to start...") {
+			status = "pending"
+		} else {
+			return "", fmt.Errorf("Received OK with an unexpected body: %s", string(respBody))
+		}
+
+	default:
+		return "", fmt.Errorf("Unexpected response code: %d %s", response.StatusCode, http.StatusText(response.StatusCode))
+	}
+
+	return status, nil
+}

--- a/network/decrypt_client_test.go
+++ b/network/decrypt_client_test.go
@@ -1,0 +1,101 @@
+package network_test
+
+import (
+	"errors"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gbytes"
+	"github.com/pivotal-cf/om/network"
+	"github.com/pivotal-cf/om/network/fakes"
+	"io/ioutil"
+	"net/http"
+	"strings"
+)
+
+var _ = Describe("DecryptClient", func() {
+	var (
+		fakeClient *fakes.HttpClient
+	)
+
+	BeforeEach(func() {
+		fakeClient = &fakes.HttpClient{}
+	})
+
+	const correctDP = `correct-decryption-passphrase`
+
+	Describe("Do", func() {
+		Context("when the response is successful", func() {
+			BeforeEach(func() {
+				fakeClient.DoReturnsOnCall(0, &http.Response{ // /api/v0/unlock
+					StatusCode:    http.StatusOK,
+					ContentLength: int64(len([]byte("{}"))),
+					Body:          ioutil.NopCloser(strings.NewReader("{}")),
+				}, nil)
+				fakeClient.DoReturnsOnCall(1, &http.Response{ // /api/v0/ensure_availability
+					StatusCode:    http.StatusOK,
+					ContentLength: int64(len([]byte("Waiting for authentication system to start..."))),
+					Body:          ioutil.NopCloser(strings.NewReader("Waiting for authentication system to start...")),
+				}, nil)
+				fakeClient.DoReturnsOnCall(2, &http.Response{ // /api/v0/ensure_availability
+					StatusCode: http.StatusFound,
+					Header: map[string][]string{
+						"Location": []string{
+							"https://example.com/auth/cloudfoundry",
+						},
+					},
+					ContentLength: int64(len([]byte("Waiting for authentication system to start..."))),
+					Body:          ioutil.NopCloser(strings.NewReader("Waiting for authentication system to start...")),
+				}, nil)
+				fakeClient.DoReturnsOnCall(3, &http.Response{StatusCode: http.StatusOK}, nil) // actual request
+			})
+
+			It("returns the response", func() {
+				out := gbytes.NewBuffer()
+				decryptClient := network.NewDecryptClient(fakeClient, fakeClient, correctDP, out)
+
+				req := http.Request{Method: "some-method"}
+				resp, err := decryptClient.Do(&req)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(fakeClient.DoCallCount()).To(Equal(4))
+				Expect(fakeClient.DoArgsForCall(3).Method).To(Equal("some-method"))
+				Expect(resp.StatusCode).To(Equal(http.StatusOK))
+				Expect(string(out.Contents())).To(ContainSubstring("Waiting for Ops Manager's auth systems to start. This may take a few minutes..."))
+			})
+		})
+
+		Context("when the response is error", func() {
+			BeforeEach(func() {
+				fakeClient.DoReturns(nil, errors.New("some-error"))
+			})
+
+			It("returns error", func() {
+				out := gbytes.NewBuffer()
+				decryptClient := network.NewDecryptClient(fakeClient, fakeClient, correctDP, out)
+
+				req := http.Request{Method: "some-method"}
+				_, err := decryptClient.Do(&req)
+				Expect(err).To(HaveOccurred())
+			})
+		})
+
+		Context("when the decryption passphrase provided is wrong", func() {
+			BeforeEach(func() {
+				fakeClient.DoReturnsOnCall(0, &http.Response{ // /api/v0/unlock
+					StatusCode:    http.StatusForbidden,
+					ContentLength: int64(len([]byte("{}"))),
+					Body:          ioutil.NopCloser(strings.NewReader("{}")),
+				}, nil)
+			})
+
+			It("returns the error", func() {
+				out := gbytes.NewBuffer()
+				decryptClient := network.NewDecryptClient(fakeClient, fakeClient, correctDP, out)
+
+				req := http.Request{Method: "some-method"}
+				_, err := decryptClient.Do(&req)
+				Expect(err).To(MatchError("could not unlock ops manager, check if the decryption passphrase is correct"))
+			})
+		})
+	})
+})


### PR DESCRIPTION
As discussed in Issue https://github.com/pivotal-cf/om/issues/268, we've added `decryption-passphrase` as a global flag. We've done this such that it's only required for `import-installation` - for all other commands, it's optional.

For `import-installation`, this is a **breaking change**, as it's now a required global flag rather than a required command flag, which means people will need to change which side of the command they pass it on.

Use case:
normally, if the ops manager vm is rebooted, the user need to manually decrypt the vm.  
With this pr merged in, as long as the user stick the decrytion-passphrase as a global flag, `om` will tries to unlock the vm automatically if the vm is locked.

Signed-off-by: Jesse Alford <jalford@pivotal.io>