### PR TITLE
prevent stage/configure product/director if apply-change is running

### DIFF
--- a/acceptance/configure_director_test.go
+++ b/acceptance/configure_director_test.go
@@ -42,6 +42,8 @@ var _ = Describe("configure-director command", func() {
 			w.Header().Set("Content-Type", "application/json")
 
 			switch req.URL.Path {
+			case "/api/v0/installations":
+				w.Write([]byte(`{"installations": []}`))
 			case "/uaa/oauth/token":
 				username := req.FormValue("username")
 

--- a/acceptance/configure_product_test.go
+++ b/acceptance/configure_product_test.go
@@ -31,6 +31,8 @@ var _ = Describe("configure-product command", func() {
 			w.Header().Set("Content-Type", "application/json")
 
 			switch req.URL.Path {
+			case "/api/v0/installations":
+				w.Write([]byte(`{"installations": []}`))
 			case "/uaa/oauth/token":
 				w.Write([]byte(`{
 				"access_token": "some-opsman-token",

--- a/acceptance/stage_product_test.go
+++ b/acceptance/stage_product_test.go
@@ -29,6 +29,8 @@ var _ = Describe("stage-product command", func() {
 				w.Header().Set("Content-Type", "application/json")
 
 				switch req.URL.Path {
+				case "/api/v0/installations":
+					w.Write([]byte(`{"installations": []}`))
 				case "/uaa/oauth/token":
 					responseString = `{
 						"access_token": "some-opsman-token",
@@ -120,6 +122,8 @@ var _ = Describe("stage-product command", func() {
 				w.Header().Set("Content-Type", "application/json")
 
 				switch req.URL.Path {
+				case "/api/v0/installations":
+					w.Write([]byte(`{"installations": []}`))
 				case "/uaa/oauth/token":
 					responseString = `{
 						"access_token": "some-opsman-token",
@@ -227,6 +231,8 @@ var _ = Describe("stage-product command", func() {
 				w.Header().Set("Content-Type", "application/json")
 
 				switch req.URL.Path {
+				case "/api/v0/installations":
+					w.Write([]byte(`{"installations": []}`))
 				case "/uaa/oauth/token":
 					responseString = `{
 						"access_token": "some-opsman-token",
@@ -333,6 +339,8 @@ var _ = Describe("stage-product command", func() {
 				w.Header().Set("Content-Type", "application/json")
 
 				switch req.URL.Path {
+				case "/api/v0/installations":
+					w.Write([]byte(`{"installations": []}`))
 				case "/uaa/oauth/token":
 					responseString = `{
 						"access_token": "some-opsman-token",

--- a/commands/fakes/configure_director_service.go
+++ b/commands/fakes/configure_director_service.go
@@ -70,6 +70,18 @@ type ConfigureDirectorService struct {
 		result1 string
 		result2 error
 	}
+	ListInstallationsStub        func() ([]api.InstallationsServiceOutput, error)
+	listInstallationsMutex       sync.RWMutex
+	listInstallationsArgsForCall []struct {
+	}
+	listInstallationsReturns struct {
+		result1 []api.InstallationsServiceOutput
+		result2 error
+	}
+	listInstallationsReturnsOnCall map[int]struct {
+		result1 []api.InstallationsServiceOutput
+		result2 error
+	}
 	ListStagedProductJobsStub        func(string) (map[string]string, error)
 	listStagedProductJobsMutex       sync.RWMutex
 	listStagedProductJobsArgsForCall []struct {
@@ -462,6 +474,61 @@ func (fake *ConfigureDirectorService) GetStagedProductManifestReturnsOnCall(i in
 	}
 	fake.getStagedProductManifestReturnsOnCall[i] = struct {
 		result1 string
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *ConfigureDirectorService) ListInstallations() ([]api.InstallationsServiceOutput, error) {
+	fake.listInstallationsMutex.Lock()
+	ret, specificReturn := fake.listInstallationsReturnsOnCall[len(fake.listInstallationsArgsForCall)]
+	fake.listInstallationsArgsForCall = append(fake.listInstallationsArgsForCall, struct {
+	}{})
+	fake.recordInvocation("ListInstallations", []interface{}{})
+	fake.listInstallationsMutex.Unlock()
+	if fake.ListInstallationsStub != nil {
+		return fake.ListInstallationsStub()
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.listInstallationsReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *ConfigureDirectorService) ListInstallationsCallCount() int {
+	fake.listInstallationsMutex.RLock()
+	defer fake.listInstallationsMutex.RUnlock()
+	return len(fake.listInstallationsArgsForCall)
+}
+
+func (fake *ConfigureDirectorService) ListInstallationsCalls(stub func() ([]api.InstallationsServiceOutput, error)) {
+	fake.listInstallationsMutex.Lock()
+	defer fake.listInstallationsMutex.Unlock()
+	fake.ListInstallationsStub = stub
+}
+
+func (fake *ConfigureDirectorService) ListInstallationsReturns(result1 []api.InstallationsServiceOutput, result2 error) {
+	fake.listInstallationsMutex.Lock()
+	defer fake.listInstallationsMutex.Unlock()
+	fake.ListInstallationsStub = nil
+	fake.listInstallationsReturns = struct {
+		result1 []api.InstallationsServiceOutput
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *ConfigureDirectorService) ListInstallationsReturnsOnCall(i int, result1 []api.InstallationsServiceOutput, result2 error) {
+	fake.listInstallationsMutex.Lock()
+	defer fake.listInstallationsMutex.Unlock()
+	fake.ListInstallationsStub = nil
+	if fake.listInstallationsReturnsOnCall == nil {
+		fake.listInstallationsReturnsOnCall = make(map[int]struct {
+			result1 []api.InstallationsServiceOutput
+			result2 error
+		})
+	}
+	fake.listInstallationsReturnsOnCall[i] = struct {
+		result1 []api.InstallationsServiceOutput
 		result2 error
 	}{result1, result2}
 }
@@ -899,6 +966,8 @@ func (fake *ConfigureDirectorService) Invocations() map[string][][]interface{} {
 	defer fake.getStagedProductJobResourceConfigMutex.RUnlock()
 	fake.getStagedProductManifestMutex.RLock()
 	defer fake.getStagedProductManifestMutex.RUnlock()
+	fake.listInstallationsMutex.RLock()
+	defer fake.listInstallationsMutex.RUnlock()
 	fake.listStagedProductJobsMutex.RLock()
 	defer fake.listStagedProductJobsMutex.RUnlock()
 	fake.listStagedVMExtensionsMutex.RLock()

--- a/commands/fakes/configure_product_service.go
+++ b/commands/fakes/configure_product_service.go
@@ -22,6 +22,18 @@ type ConfigureProductService struct {
 		result1 api.JobProperties
 		result2 error
 	}
+	ListInstallationsStub        func() ([]api.InstallationsServiceOutput, error)
+	listInstallationsMutex       sync.RWMutex
+	listInstallationsArgsForCall []struct {
+	}
+	listInstallationsReturns struct {
+		result1 []api.InstallationsServiceOutput
+		result2 error
+	}
+	listInstallationsReturnsOnCall map[int]struct {
+		result1 []api.InstallationsServiceOutput
+		result2 error
+	}
 	ListStagedProductJobsStub        func(string) (map[string]string, error)
 	listStagedProductJobsMutex       sync.RWMutex
 	listStagedProductJobsArgsForCall []struct {
@@ -160,6 +172,61 @@ func (fake *ConfigureProductService) GetStagedProductJobResourceConfigReturnsOnC
 	}
 	fake.getStagedProductJobResourceConfigReturnsOnCall[i] = struct {
 		result1 api.JobProperties
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *ConfigureProductService) ListInstallations() ([]api.InstallationsServiceOutput, error) {
+	fake.listInstallationsMutex.Lock()
+	ret, specificReturn := fake.listInstallationsReturnsOnCall[len(fake.listInstallationsArgsForCall)]
+	fake.listInstallationsArgsForCall = append(fake.listInstallationsArgsForCall, struct {
+	}{})
+	fake.recordInvocation("ListInstallations", []interface{}{})
+	fake.listInstallationsMutex.Unlock()
+	if fake.ListInstallationsStub != nil {
+		return fake.ListInstallationsStub()
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.listInstallationsReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *ConfigureProductService) ListInstallationsCallCount() int {
+	fake.listInstallationsMutex.RLock()
+	defer fake.listInstallationsMutex.RUnlock()
+	return len(fake.listInstallationsArgsForCall)
+}
+
+func (fake *ConfigureProductService) ListInstallationsCalls(stub func() ([]api.InstallationsServiceOutput, error)) {
+	fake.listInstallationsMutex.Lock()
+	defer fake.listInstallationsMutex.Unlock()
+	fake.ListInstallationsStub = stub
+}
+
+func (fake *ConfigureProductService) ListInstallationsReturns(result1 []api.InstallationsServiceOutput, result2 error) {
+	fake.listInstallationsMutex.Lock()
+	defer fake.listInstallationsMutex.Unlock()
+	fake.ListInstallationsStub = nil
+	fake.listInstallationsReturns = struct {
+		result1 []api.InstallationsServiceOutput
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *ConfigureProductService) ListInstallationsReturnsOnCall(i int, result1 []api.InstallationsServiceOutput, result2 error) {
+	fake.listInstallationsMutex.Lock()
+	defer fake.listInstallationsMutex.Unlock()
+	fake.ListInstallationsStub = nil
+	if fake.listInstallationsReturnsOnCall == nil {
+		fake.listInstallationsReturnsOnCall = make(map[int]struct {
+			result1 []api.InstallationsServiceOutput
+			result2 error
+		})
+	}
+	fake.listInstallationsReturnsOnCall[i] = struct {
+		result1 []api.InstallationsServiceOutput
 		result2 error
 	}{result1, result2}
 }
@@ -532,6 +599,8 @@ func (fake *ConfigureProductService) Invocations() map[string][][]interface{} {
 	defer fake.invocationsMutex.RUnlock()
 	fake.getStagedProductJobResourceConfigMutex.RLock()
 	defer fake.getStagedProductJobResourceConfigMutex.RUnlock()
+	fake.listInstallationsMutex.RLock()
+	defer fake.listInstallationsMutex.RUnlock()
 	fake.listStagedProductJobsMutex.RLock()
 	defer fake.listStagedProductJobsMutex.RUnlock()
 	fake.listStagedProductsMutex.RLock()

--- a/commands/fakes/stage_product_service.go
+++ b/commands/fakes/stage_product_service.go
@@ -46,6 +46,18 @@ type StageProductService struct {
 		result1 []api.DeployedProductOutput
 		result2 error
 	}
+	ListInstallationsStub        func() ([]api.InstallationsServiceOutput, error)
+	listInstallationsMutex       sync.RWMutex
+	listInstallationsArgsForCall []struct {
+	}
+	listInstallationsReturns struct {
+		result1 []api.InstallationsServiceOutput
+		result2 error
+	}
+	listInstallationsReturnsOnCall map[int]struct {
+		result1 []api.InstallationsServiceOutput
+		result2 error
+	}
 	StageStub        func(api.StageProductInput, string) error
 	stageMutex       sync.RWMutex
 	stageArgsForCall []struct {
@@ -236,6 +248,61 @@ func (fake *StageProductService) ListDeployedProductsReturnsOnCall(i int, result
 	}{result1, result2}
 }
 
+func (fake *StageProductService) ListInstallations() ([]api.InstallationsServiceOutput, error) {
+	fake.listInstallationsMutex.Lock()
+	ret, specificReturn := fake.listInstallationsReturnsOnCall[len(fake.listInstallationsArgsForCall)]
+	fake.listInstallationsArgsForCall = append(fake.listInstallationsArgsForCall, struct {
+	}{})
+	fake.recordInvocation("ListInstallations", []interface{}{})
+	fake.listInstallationsMutex.Unlock()
+	if fake.ListInstallationsStub != nil {
+		return fake.ListInstallationsStub()
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.listInstallationsReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *StageProductService) ListInstallationsCallCount() int {
+	fake.listInstallationsMutex.RLock()
+	defer fake.listInstallationsMutex.RUnlock()
+	return len(fake.listInstallationsArgsForCall)
+}
+
+func (fake *StageProductService) ListInstallationsCalls(stub func() ([]api.InstallationsServiceOutput, error)) {
+	fake.listInstallationsMutex.Lock()
+	defer fake.listInstallationsMutex.Unlock()
+	fake.ListInstallationsStub = stub
+}
+
+func (fake *StageProductService) ListInstallationsReturns(result1 []api.InstallationsServiceOutput, result2 error) {
+	fake.listInstallationsMutex.Lock()
+	defer fake.listInstallationsMutex.Unlock()
+	fake.ListInstallationsStub = nil
+	fake.listInstallationsReturns = struct {
+		result1 []api.InstallationsServiceOutput
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *StageProductService) ListInstallationsReturnsOnCall(i int, result1 []api.InstallationsServiceOutput, result2 error) {
+	fake.listInstallationsMutex.Lock()
+	defer fake.listInstallationsMutex.Unlock()
+	fake.ListInstallationsStub = nil
+	if fake.listInstallationsReturnsOnCall == nil {
+		fake.listInstallationsReturnsOnCall = make(map[int]struct {
+			result1 []api.InstallationsServiceOutput
+			result2 error
+		})
+	}
+	fake.listInstallationsReturnsOnCall[i] = struct {
+		result1 []api.InstallationsServiceOutput
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *StageProductService) Stage(arg1 api.StageProductInput, arg2 string) error {
 	fake.stageMutex.Lock()
 	ret, specificReturn := fake.stageReturnsOnCall[len(fake.stageArgsForCall)]
@@ -306,6 +373,8 @@ func (fake *StageProductService) Invocations() map[string][][]interface{} {
 	defer fake.getDiagnosticReportMutex.RUnlock()
 	fake.listDeployedProductsMutex.RLock()
 	defer fake.listDeployedProductsMutex.RUnlock()
+	fake.listInstallationsMutex.RLock()
+	defer fake.listInstallationsMutex.RUnlock()
 	fake.stageMutex.RLock()
 	defer fake.stageMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}


### PR DESCRIPTION
If a product is staged/configured while apply-change is running,
the product will be unstaged/unconfigured after the apply-change
finishes. This is an unexpected behavior to the users, so we want
to prevent stage/configure product/director if there is a running
installation.

The change in this commit will fail fast if the cli user tries to
stage/configure if apply-change is running.

The prevention logic will eventually live in Ops Manager as well.

[#161630968]