### PR TITLE
Fix bug in import installation

### DIFF
--- a/commands/import_installation.go
+++ b/commands/import_installation.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/pivotal-cf/jhanda"
 	"github.com/pivotal-cf/om/api"
+	"strings"
 	"time"
 )
 
@@ -95,6 +96,10 @@ func (ii ImportInstallation) Execute(args []string) error {
 		time.Sleep(time.Second * time.Duration(ii.Options.PollingInterval))
 		ensureAvailabilityOutput, err = ii.service.EnsureAvailability(api.EnsureAvailabilityInput{})
 		if err != nil {
+			if strings.Contains(err.Error(), "connection refused") {
+				ii.logger.Printf("waiting for ops manager web server boots up...")
+				continue
+			}
 			return fmt.Errorf("could not check Ops Manager Status: %s", err)
 		}
 	}


### PR DESCRIPTION
OpsManager will restart nginx server if the installation contains custom ssl certificate. During the restart, om cli would not able to connect to OpsManager and will return an error saying connection refused. This change add a retry logic in import installation ensure availability state.

Polling interval was not being used in the code. This has been repurposed to customize the time between retries.