### PR TITLE
api layer has standardized http resp validation

### DIFF
--- a/api/available_products_service.go
+++ b/api/available_products_service.go
@@ -67,7 +67,12 @@ func (a Api) ListAvailableProducts() (AvailableProductsOutput, error) {
 	if err != nil {
 		return AvailableProductsOutput{}, errors.Wrap(err, "could not make api request to available_products endpoint")
 	}
+
 	defer resp.Body.Close()
+
+	if err = validateStatusOK(resp); err != nil {
+		return AvailableProductsOutput{}, err
+	}
 
 	var availableProducts []ProductInfo
 	if err := json.NewDecoder(resp.Body).Decode(&availableProducts); err != nil {

--- a/api/certificate_authorities_service.go
+++ b/api/certificate_authorities_service.go
@@ -39,13 +39,33 @@ func (a Api) ListCertificateAuthorities() (CertificateAuthoritiesOutput, error) 
 		return output, err
 	}
 
+	defer resp.Body.Close()
+
+	if err = validateStatusOK(resp); err != nil {
+		return CertificateAuthoritiesOutput{}, err
+	}
+
 	err = json.NewDecoder(resp.Body).Decode(&output)
-	return output, err
+	if err != nil {
+		return CertificateAuthoritiesOutput{}, err
+	}
+
+	return output, nil
 }
 
 func (a Api) RegenerateCertificates() error {
-	_, err := a.sendAPIRequest("POST", "/api/v0/certificate_authorities/active/regenerate", nil)
-	return err
+	resp, err := a.sendAPIRequest("POST", "/api/v0/certificate_authorities/active/regenerate", nil)
+	if err != nil {
+		return err
+	}
+
+	defer resp.Body.Close()
+
+	if err = validateStatusOK(resp); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (a Api) GenerateCertificateAuthority() (CA, error) {
@@ -56,8 +76,18 @@ func (a Api) GenerateCertificateAuthority() (CA, error) {
 		return CA{}, err
 	}
 
+	defer resp.Body.Close()
+
+	if err = validateStatusOK(resp); err != nil {
+		return CA{}, err
+	}
+
 	err = json.NewDecoder(resp.Body).Decode(&output)
-	return output, err
+	if err != nil {
+		return CA{}, err
+	}
+
+	return output, nil
 }
 
 func (a Api) CreateCertificateAuthority(certBody CertificateAuthorityInput) (CA, error) {
@@ -73,17 +103,47 @@ func (a Api) CreateCertificateAuthority(certBody CertificateAuthorityInput) (CA,
 		return CA{}, err
 	}
 
+	defer resp.Body.Close()
+
+	if err = validateStatusOK(resp); err != nil {
+		return CA{}, err
+	}
+
 	err = json.NewDecoder(resp.Body).Decode(&output)
-	return output, err
+	if err != nil {
+		return CA{}, err
+	}
+
+	return output, nil
 }
 
 func (a Api) ActivateCertificateAuthority(input ActivateCertificateAuthorityInput) error {
-	_, err := a.sendAPIRequest("POST", fmt.Sprintf("/api/v0/certificate_authorities/%s/activate", input.GUID), []byte("{}"))
-	return err
+	resp, err := a.sendAPIRequest("POST", fmt.Sprintf("/api/v0/certificate_authorities/%s/activate", input.GUID), []byte("{}"))
+	if err != nil {
+		return err
+	}
+
+	defer resp.Body.Close()
+
+	if err = validateStatusOK(resp); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (a Api) DeleteCertificateAuthority(input DeleteCertificateAuthorityInput) error {
 	path := fmt.Sprintf("/api/v0/certificate_authorities/%s", input.GUID)
-	_, err := a.sendAPIRequest("DELETE", path, nil)
-	return err
+	resp, err := a.sendAPIRequest("DELETE", path, nil)
+	if err != nil {
+		return err
+	}
+
+	defer resp.Body.Close()
+
+	if err = validateStatusOK(resp); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/api/certificates_service.go
+++ b/api/certificates_service.go
@@ -21,6 +21,14 @@ func (a Api) GenerateCertificate(domains DomainsInput) (string, error) {
 	}
 	defer resp.Body.Close()
 
+	if err = validateStatusOK(resp); err != nil {
+		return "", err
+	}
+
 	respBody, err := ioutil.ReadAll(resp.Body)
-	return string(respBody), err
+	if err != nil {
+		return "", err
+	}
+
+	return string(respBody), nil
 }

--- a/api/credentials_service.go
+++ b/api/credentials_service.go
@@ -32,6 +32,10 @@ func (a Api) GetDeployedProductCredential(input GetDeployedProductCredentialInpu
 	}
 	defer resp.Body.Close()
 
+	if err = validateStatusOK(resp); err != nil {
+		return GetDeployedProductCredentialOutput{}, err
+	}
+
 	var credentialOutput GetDeployedProductCredentialOutput
 	if err := json.NewDecoder(resp.Body).Decode(&credentialOutput); err != nil {
 		return GetDeployedProductCredentialOutput{}, errors.Wrap(err, "could not unmarshal credentials response")
@@ -46,6 +50,10 @@ func (a Api) ListDeployedProductCredentials(deployedGUID string) (CredentialRefe
 		return CredentialReferencesOutput{}, errors.Wrap(err, "could not make api request to credentials endpoint")
 	}
 	defer resp.Body.Close()
+
+	if err = validateStatusOK(resp); err != nil {
+		return CredentialReferencesOutput{}, err
+	}
 
 	var credentialReferences CredentialReferencesOutput
 	if err := json.NewDecoder(resp.Body).Decode(&credentialReferences); err != nil {

--- a/api/deployed_products_service.go
+++ b/api/deployed_products_service.go
@@ -20,13 +20,21 @@ func (a Api) GetDeployedProductManifest(guid string) (string, error) {
 	}
 	defer resp.Body.Close()
 
+	if err = validateStatusOK(resp); err != nil {
+		return "", err
+	}
+
 	var contents interface{}
 	if err := yaml.NewDecoder(resp.Body).Decode(&contents); err != nil {
 		return "", errors.Wrap(err, "could not parse json")
 	}
 
 	manifest, err := yaml.Marshal(contents)
-	return string(manifest), err
+	if err != nil {
+		return "", nil
+	}
+
+	return string(manifest), nil
 }
 
 func (a Api) ListDeployedProducts() ([]DeployedProductOutput, error) {
@@ -35,6 +43,10 @@ func (a Api) ListDeployedProducts() ([]DeployedProductOutput, error) {
 		return []DeployedProductOutput{}, errors.Wrap(err, "could not make api request to deployed products endpoint")
 	}
 	defer resp.Body.Close()
+
+	if err = validateStatusOK(resp); err != nil {
+		return nil, err
+	}
 
 	var deployedProducts []DeployedProductOutput
 	if err := json.NewDecoder(resp.Body).Decode(&deployedProducts); err != nil {

--- a/api/diagnostic_service.go
+++ b/api/diagnostic_service.go
@@ -29,12 +29,17 @@ func (du DiagnosticReportUnavailable) Error() string {
 func (a Api) GetDiagnosticReport() (DiagnosticReport, error) {
 	resp, err := a.sendAPIRequest("GET", "/api/v0/diagnostic_report", nil)
 	if err != nil {
-		if resp != nil && resp.StatusCode == http.StatusInternalServerError {
-			return DiagnosticReport{}, DiagnosticReportUnavailable{}
-		}
 		return DiagnosticReport{}, errors.Wrap(err, "could not make api request to diagnostic_report endpoint")
 	}
 	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusInternalServerError {
+		return DiagnosticReport{}, DiagnosticReportUnavailable{}
+	}
+
+	if err = validateStatusOK(resp); err != nil {
+		return DiagnosticReport{}, err
+	}
 
 	var apiResponse *struct {
 		DiagnosticReport

--- a/api/director_service.go
+++ b/api/director_service.go
@@ -6,9 +6,9 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	yaml "github.com/cloudfoundry/routing-release/src/gopkg.in/yaml.v2"
 	yamlConverter "github.com/ghodss/yaml"
 	"github.com/pkg/errors"
+	"gopkg.in/yaml.v2"
 )
 
 type AvailabilityZoneInput struct {

--- a/api/director_service.go
+++ b/api/director_service.go
@@ -155,11 +155,11 @@ func (a Api) UpdateStagedDirectorNetworkAndAZ(input NetworkAndAZConfiguration) e
 		if err != nil {
 			return err
 		}
+		defer resp.Body.Close()
 
 		if err = validateStatusOK(resp); err != nil {
 			return err
 		}
-		//TODO does this PUT actually return a body, I say yes.
 
 		return nil
 	default:

--- a/api/errands_service.go
+++ b/api/errands_service.go
@@ -36,9 +36,14 @@ func (a Api) UpdateStagedProductErrands(productID string, errandName string, pos
 	}
 
 	path := fmt.Sprintf("/api/v0/staged/products/%s/errands", productID)
-	_, err = a.sendAPIRequest("PUT", path, payload)
+	resp, err := a.sendAPIRequest("PUT", path, payload)
 	if err != nil {
 		return errors.Wrap(err, "failed to set errand state")
+	}
+	defer resp.Body.Close()
+
+	if err = validateStatusOK(resp); err != nil {
+		return err
 	}
 
 	return nil
@@ -50,6 +55,11 @@ func (a Api) ListStagedProductErrands(productID string) (ErrandsListOutput, erro
 	resp, err := a.sendAPIRequest("GET", fmt.Sprintf("/api/v0/staged/products/%s/errands", productID), nil)
 	if err != nil {
 		return errandsListOutput, errors.Wrap(err, "failed to list errands")
+	}
+	defer resp.Body.Close()
+
+	if err = validateStatusOK(resp); err != nil {
+		return ErrandsListOutput{}, err
 	}
 
 	err = json.NewDecoder(resp.Body).Decode(&errandsListOutput)

--- a/api/errands_service_test.go
+++ b/api/errands_service_test.go
@@ -71,7 +71,7 @@ var _ = Describe("ErrandsService", func() {
 					}
 
 					err := service.UpdateStagedProductErrands("some-product-id", "some-errand", "when-changed", "false")
-					Expect(err).To(MatchError("failed to set errand state: request failed: unexpected response:\nHTTP/0.0 418 I'm a teapot\r\n\r\nI'm a teapot"))
+					Expect(err).To(MatchError("request failed: unexpected response:\nHTTP/0.0 418 I'm a teapot\r\n\r\nI'm a teapot"))
 				})
 			})
 
@@ -164,7 +164,7 @@ var _ = Describe("ErrandsService", func() {
 
 					_, err := service.ListStagedProductErrands("future-moon-and-assimilation")
 					Expect(err).To(HaveOccurred())
-					Expect(err).To(MatchError(ContainSubstring("failed to list errands: request failed: unexpected response:\nHTTP/0.0 409 Conflict\r\n\r\nConflict")))
+					Expect(err).To(MatchError(ContainSubstring("request failed: unexpected response:\nHTTP/0.0 409 Conflict\r\n\r\nConflict")))
 				})
 			})
 		})

--- a/api/info_service.go
+++ b/api/info_service.go
@@ -47,6 +47,10 @@ func (a Api) Info() (Info, error) {
 	}
 	defer resp.Body.Close()
 
+	if err = validateStatusOK(resp); err != nil {
+		return Info{}, err
+	}
+
 	err = json.NewDecoder(resp.Body).Decode(&r)
 	return r.Info, err
 }

--- a/api/installation_asset_service.go
+++ b/api/installation_asset_service.go
@@ -24,6 +24,10 @@ func (a Api) DownloadInstallationAssetCollection(outputFile string) error {
 	}
 	defer resp.Body.Close()
 
+	if err = validateStatusOK(resp); err != nil {
+		return err
+	}
+
 	outputFileHandle, err := os.Create(outputFile)
 	if err != nil {
 		return errors.Wrap(err, "cannot create output file")
@@ -67,12 +71,17 @@ func (a Api) UploadInstallationAssetCollection(input ImportInstallationInput) er
 func (a Api) DeleteInstallationAssetCollection() (InstallationsServiceOutput, error) {
 	resp, err := a.sendAPIRequest("DELETE", "/api/v0/installation_asset_collection", []byte(`{"errands": {}}`))
 	if err != nil {
-		if resp.StatusCode == http.StatusGone {
-			return InstallationsServiceOutput{}, nil
-		}
 		return InstallationsServiceOutput{}, errors.Wrap(err, "could not make api request to installation_asset_collection endpoint")
 	}
 	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusGone {
+		return InstallationsServiceOutput{}, nil
+	}
+
+	if err = validateStatusOK(resp); err != nil {
+		return InstallationsServiceOutput{}, err
+	}
 
 	var installation struct {
 		Install struct {

--- a/api/installations_service.go
+++ b/api/installations_service.go
@@ -30,6 +30,10 @@ func (a Api) ListInstallations() ([]InstallationsServiceOutput, error) {
 	}
 	defer resp.Body.Close()
 
+	if err = validateStatusOK(resp); err != nil {
+		return []InstallationsServiceOutput{}, err
+	}
+
 	var responseStruct struct {
 		Installations []InstallationsServiceOutput
 	}
@@ -87,6 +91,10 @@ func (a Api) CreateInstallation(ignoreWarnings bool, deployProducts bool, produc
 	}
 	defer resp.Body.Close()
 
+	if err = validateStatusOK(resp); err != nil {
+		return InstallationsServiceOutput{}, err
+	}
+
 	var installation struct {
 		Install struct {
 			ID int
@@ -107,6 +115,10 @@ func (a Api) GetInstallation(id int) (InstallationsServiceOutput, error) {
 	}
 	defer resp.Body.Close()
 
+	if err = validateStatusOK(resp); err != nil {
+		return InstallationsServiceOutput{}, err
+	}
+
 	var output struct {
 		Status string
 	}
@@ -124,6 +136,10 @@ func (a Api) GetInstallationLogs(id int) (InstallationsServiceOutput, error) {
 		return InstallationsServiceOutput{}, errors.Wrap(err, "could not make api request to installations logs endpoint")
 	}
 	defer resp.Body.Close()
+
+	if err = validateStatusOK(resp); err != nil {
+		return InstallationsServiceOutput{}, err
+	}
 
 	var output struct {
 		Logs string

--- a/api/jobs_service.go
+++ b/api/jobs_service.go
@@ -47,6 +47,10 @@ func (a Api) ListStagedProductJobs(productGUID string) (map[string]string, error
 	}
 	defer resp.Body.Close()
 
+	if err = validateStatusOK(resp); err != nil {
+		return nil, err
+	}
+
 	var jobsOutput struct {
 		Jobs []Job
 	}
@@ -71,6 +75,10 @@ func (a Api) GetStagedProductJobResourceConfig(productGUID, jobGUID string) (Job
 	}
 	defer resp.Body.Close()
 
+	if err = validateStatusOK(resp); err != nil {
+		return JobProperties{}, err
+	}
+
 	var existingConfig JobProperties
 	if err := json.NewDecoder(resp.Body).Decode(&existingConfig); err != nil {
 		return JobProperties{}, err
@@ -85,9 +93,13 @@ func (a Api) UpdateStagedProductJobResourceConfig(productGUID, jobGUID string, j
 		return err
 	}
 
-	_, err = a.sendAPIRequest("PUT", fmt.Sprintf("/api/v0/staged/products/%s/jobs/%s/resource_config", productGUID, jobGUID), jsonPayload)
+	resp, err := a.sendAPIRequest("PUT", fmt.Sprintf("/api/v0/staged/products/%s/jobs/%s/resource_config", productGUID, jobGUID), jsonPayload)
 	if err != nil {
 		return errors.Wrap(err, "could not make api request to jobs resource_config endpoint")
+	}
+
+	if err = validateStatusOK(resp); err != nil {
+		return err
 	}
 
 	return nil

--- a/api/pending_changes_service.go
+++ b/api/pending_changes_service.go
@@ -32,6 +32,10 @@ func (a Api) ListStagedPendingChanges() (PendingChangesOutput, error) {
 	}
 	defer resp.Body.Close()
 
+	if err = validateStatusOK(resp); err != nil {
+		return PendingChangesOutput{}, err
+	}
+
 	var pendingChanges PendingChangesOutput
 	if err := json.NewDecoder(resp.Body).Decode(&pendingChanges); err != nil {
 		return PendingChangesOutput{}, errors.Wrap(err, "could not unmarshal pending_changes response")

--- a/api/security_service.go
+++ b/api/security_service.go
@@ -17,6 +17,10 @@ func (a Api) GetSecurityRootCACertificate() (string, error) {
 	}
 	defer resp.Body.Close()
 
+	if err = validateStatusOK(resp); err != nil {
+		return "", err
+	}
+
 	var certResponse certResponse
 	if err := json.NewDecoder(resp.Body).Decode(&certResponse); err != nil {
 		return "", errors.Wrap(err, "failed to unmarshal response")

--- a/api/sendAPIRequest.go
+++ b/api/sendAPIRequest.go
@@ -30,12 +30,7 @@ func sendRequest(client httpClient, method, endpoint string, jsonData []byte) (*
 
 	resp, err := client.Do(req)
 	if err != nil {
-		return resp, errors.Wrap(err, fmt.Sprintf("could not send api request to %s %s", method, endpoint))
-	}
-
-	err = validateStatusOK(resp)
-	if err != nil {
-		return resp, err
+		return nil, errors.Wrap(err, fmt.Sprintf("could not send api request to %s %s", method, endpoint))
 	}
 
 	return resp, nil

--- a/api/setup_service.go
+++ b/api/setup_service.go
@@ -55,10 +55,16 @@ func (a Api) Setup(input SetupInput) (SetupOutput, error) {
 		return SetupOutput{}, err
 	}
 
-	_, err = a.sendUnauthedAPIRequest("POST", "/api/v0/setup", payload)
+	resp, err := a.sendUnauthedAPIRequest("POST", "/api/v0/setup", payload)
 	if err != nil {
 		return SetupOutput{}, errors.Wrap(err, "could not make api request to setup endpoint")
 	}
+	defer resp.Body.Close()
+
+	if err = validateStatusOK(resp); err != nil {
+		return SetupOutput{}, err
+	}
+
 	return SetupOutput{}, nil
 }
 

--- a/api/staged_director_service.go
+++ b/api/staged_director_service.go
@@ -49,6 +49,10 @@ func (a Api) GetStagedDirectorProperties() (map[string]map[string]interface{}, e
 	}
 	defer resp.Body.Close()
 
+	if err = validateStatusOK(resp); err != nil {
+		return nil, err
+	}
+
 	var properties map[string]map[string]interface{}
 	if err = yaml.NewDecoder(resp.Body).Decode(&properties); err != nil {
 		return nil, errors.Wrap(err, "could not parse json")
@@ -58,16 +62,21 @@ func (a Api) GetStagedDirectorProperties() (map[string]map[string]interface{}, e
 }
 
 func (a Api) GetStagedDirectorAvailabilityZones() (AvailabilityZonesOutput, error) {
-	resp, err := a.sendAPIRequest("GET", "/api/v0/staged/director/availability_zones", nil)
 	var properties AvailabilityZonesOutput
-	if err != nil {
-		if resp.StatusCode == http.StatusMethodNotAllowed {
-			return properties, nil
-		}
 
+	resp, err := a.sendAPIRequest("GET", "/api/v0/staged/director/availability_zones", nil)
+	if err != nil {
 		return properties, err // un-tested
 	}
 	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusMethodNotAllowed {
+		return properties, nil
+	}
+
+	if err = validateStatusOK(resp); err != nil {
+		return AvailabilityZonesOutput{}, err
+	}
 
 	if err = yaml.NewDecoder(resp.Body).Decode(&properties); err != nil {
 		return properties, errors.Wrap(err, "could not parse json")
@@ -77,12 +86,17 @@ func (a Api) GetStagedDirectorAvailabilityZones() (AvailabilityZonesOutput, erro
 }
 
 func (a Api) GetStagedDirectorNetworks() (NetworksConfigurationOutput, error) {
-	resp, err := a.sendAPIRequest("GET", "/api/v0/staged/director/networks", nil)
 	var properties NetworksConfigurationOutput
+
+	resp, err := a.sendAPIRequest("GET", "/api/v0/staged/director/networks", nil)
 	if err != nil {
 		return properties, err // un-tested
 	}
 	defer resp.Body.Close()
+
+	if err = validateStatusOK(resp); err != nil {
+		return NetworksConfigurationOutput{}, err
+	}
 
 	if err = yaml.NewDecoder(resp.Body).Decode(&properties); err != nil {
 		return properties, errors.Wrap(err, "could not parse json")

--- a/api/staged_director_service_test.go
+++ b/api/staged_director_service_test.go
@@ -262,6 +262,7 @@ var _ = Describe("StagedProducts", func() {
 				},
 			}))
 		})
+
 		It("returns an empty list when status code is 405", func() {
 			client.DoStub = func(req *http.Request) (*http.Response, error) {
 				var resp *http.Response
@@ -269,6 +270,7 @@ var _ = Describe("StagedProducts", func() {
 				case "/api/v0/staged/director/availability_zones":
 					resp = &http.Response{
 						StatusCode: http.StatusMethodNotAllowed,
+						Body:       ioutil.NopCloser(bytes.NewBufferString("")),
 					}
 				}
 				return resp, nil

--- a/api/staged_products_service_test.go
+++ b/api/staged_products_service_test.go
@@ -1057,7 +1057,6 @@ key-4: 2147483648
 							StatusCode: http.StatusNotFound,
 							Body:       ioutil.NopCloser(nil),
 						}
-						err = errors.New("Products without jobs cannot have networks and azs")
 					}
 					return resp, err
 				}

--- a/api/stemcell_service.go
+++ b/api/stemcell_service.go
@@ -26,9 +26,17 @@ func (a Api) ListStemcells() (ProductStemcells, error) {
 	}
 	defer resp.Body.Close()
 
+	if err = validateStatusOK(resp); err != nil {
+		return ProductStemcells{}, err
+	}
+
 	var productStemcells ProductStemcells
 	err = json.NewDecoder(resp.Body).Decode(&productStemcells)
-	return productStemcells, err
+	if err != nil {
+		return ProductStemcells{}, nil
+	}
+
+	return productStemcells, nil
 }
 
 func (a Api) AssignStemcell(input ProductStemcells) error {
@@ -37,6 +45,14 @@ func (a Api) AssignStemcell(input ProductStemcells) error {
 		return errors.Wrap(err, "could not marshal json")
 	}
 
-	_, err = a.sendAPIRequest("PATCH", "/api/v0/stemcell_assignments", jsonData)
-	return err
+	resp, err := a.sendAPIRequest("PATCH", "/api/v0/stemcell_assignments", jsonData)
+	if err != nil {
+		return err
+	}
+
+	if err = validateStatusOK(resp); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/api/validation.go
+++ b/api/validation.go
@@ -17,5 +17,6 @@ func validateStatusOK(resp *http.Response) error {
 
 		return fmt.Errorf("request failed: unexpected response:\n%s", out)
 	}
+
 	return nil
 }

--- a/api/vm_extensions_service.go
+++ b/api/vm_extensions_service.go
@@ -34,6 +34,10 @@ func (a Api) CreateStagedVMExtension(input CreateVMExtension) error {
 	}
 	defer resp.Body.Close()
 
+	if err = validateStatusOK(resp); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -43,6 +47,10 @@ func (a Api) ListStagedVMExtensions() ([]VMExtension, error) {
 		return nil, err // un-tested
 	}
 	defer resp.Body.Close()
+
+	if err = validateStatusOK(resp); err != nil {
+		return nil, err
+	}
 
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
@@ -57,6 +65,10 @@ func (a Api) ListStagedVMExtensions() ([]VMExtension, error) {
 }
 
 func (a Api) DeleteVMExtension(name string) error {
-	_, err := a.sendAPIRequest("DELETE", fmt.Sprintf("/api/v0/staged/vm_extensions/%s", name), nil)
+	resp, err := a.sendAPIRequest("DELETE", fmt.Sprintf("/api/v0/staged/vm_extensions/%s", name), nil)
+	if err = validateStatusOK(resp); err != nil {
+		return err
+	}
+
 	return err
 }


### PR DESCRIPTION
This is my attempt to pull the validation of http response status (200 in most cases) back up to the api layer. Previously, this functionality was embedded inside of the method `sendAPIRequest`.

This refactor had a couple of goals:

1) follow the established pattern for http response checking in golang (you either get response or you get error, not both)
2) give `sendAPIRequest` a single responsibility (it only is in charge of sending not validating the response)
3) remove checks of `http.StatusCode` inside of error situations
4) case statement most of the multi status-code validations for easier review at the source
5) enable the current http response handling to be changed on an adhoc basis (now that centralized response validation is out of the picture).

I'd be glad to discuss this change and the goals above.