### PR TITLE
fix grammatical error

### DIFF
--- a/api/director_service.go
+++ b/api/director_service.go
@@ -228,7 +228,7 @@ func (a Api) addGUIDToExistingAZs(azs AvailabilityZones) (AvailabilityZones, err
 
 	switch {
 	case existingAzsResponse.StatusCode == http.StatusOK:
-		a.logger.Println("successfully fetched AZ's, continuing")
+		a.logger.Println("successfully fetched AZs, continuing")
 	case existingAzsResponse.StatusCode == http.StatusNotFound:
 		a.logger.Println("unable to retrieve existing AZ configuration, attempting to configure anyway")
 		return azs, nil

--- a/api/director_service_test.go
+++ b/api/director_service_test.go
@@ -62,7 +62,7 @@ var _ = Describe("Director", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(stderr.Invocations()).To(HaveLen(1))
 			message := stderr.PrintlnArgsForCall(0)
-			Expect(message[0]).To(Equal("successfully fetched AZ's, continuing"))
+			Expect(message[0]).To(Equal("successfully fetched AZs, continuing"))
 
 			Expect(client.DoCallCount()).To(Equal(2))
 


### PR DESCRIPTION
The plural form of AZ should be AZs, not AZ's.