### PR TITLE
Add --check flag to set pending-changes to fail if there are pending changes

### DIFF
--- a/commands/pending_changes.go
+++ b/commands/pending_changes.go
@@ -12,6 +12,7 @@ type PendingChanges struct {
 	service   pendingChangesService
 	presenter presenters.FormattedPresenter
 	Options   struct {
+		Check  bool   `long:"check" description:"Exit 1 if there are any pending changes.\nUseful for validating that Ops Mananager is in a clean state." default:"false"`
 		Format string `long:"format" short:"f" default:"table" description:"Format to print as (options: table,json)"`
 	}
 }
@@ -36,6 +37,10 @@ func (pc PendingChanges) Execute(args []string) error {
 	output, err := pc.service.ListStagedPendingChanges()
 	if err != nil {
 		return fmt.Errorf("failed to retrieve pending changes %s", err)
+	}
+
+	if output.ChangeList[0].Action != "unchanged" && pc.Options.Check {
+		return fmt.Errorf("there are pending changes!")
 	}
 
 	pc.presenter.SetFormat(pc.Options.Format)

--- a/commands/pending_changes.go
+++ b/commands/pending_changes.go
@@ -12,7 +12,7 @@ type PendingChanges struct {
 	service   pendingChangesService
 	presenter presenters.FormattedPresenter
 	Options   struct {
-		Check  bool   `long:"check" description:"Exit 1 if there are any pending changes.\nUseful for validating that Ops Mananager is in a clean state." default:"false"`
+		Check  bool   `long:"check" description:"Exit 1 if there are any pending changes. Useful for validating that Ops Mananager is in a clean state."`
 		Format string `long:"format" short:"f" default:"table" description:"Format to print as (options: table,json)"`
 	}
 }

--- a/commands/pending_changes.go
+++ b/commands/pending_changes.go
@@ -39,8 +39,12 @@ func (pc PendingChanges) Execute(args []string) error {
 		return fmt.Errorf("failed to retrieve pending changes %s", err)
 	}
 
-	if output.ChangeList[0].Action != "unchanged" && pc.Options.Check {
-		return fmt.Errorf("there are pending changes!")
+	if pc.Options.Check {
+		for _, ProductChange := range output.ChangeList {
+			if ProductChange.Action != "unchanged" {
+				return fmt.Errorf("there are pending changes")
+			}
+		}
 	}
 
 	pc.presenter.SetFormat(pc.Options.Format)

--- a/commands/pending_changes.go
+++ b/commands/pending_changes.go
@@ -39,6 +39,9 @@ func (pc PendingChanges) Execute(args []string) error {
 		return fmt.Errorf("failed to retrieve pending changes %s", err)
 	}
 
+	pc.presenter.SetFormat(pc.Options.Format)
+	pc.presenter.PresentPendingChanges(output.ChangeList)
+
 	if pc.Options.Check {
 		for _, ProductChange := range output.ChangeList {
 			if ProductChange.Action != "unchanged" {
@@ -46,10 +49,6 @@ func (pc PendingChanges) Execute(args []string) error {
 			}
 		}
 	}
-
-	pc.presenter.SetFormat(pc.Options.Format)
-	pc.presenter.PresentPendingChanges(output.ChangeList)
-
 	return nil
 }
 

--- a/commands/pending_changes_test.go
+++ b/commands/pending_changes_test.go
@@ -71,7 +71,7 @@ var _ = Describe("PendingChanges", func() {
 			})
 		})
 
-		Context("failure cases", func() {
+		Describe("failure cases", func() {
 			Context("when an unknown flag is passed", func() {
 				It("returns an error", func() {
 					err := command.Execute([]string{"--unknown-flag"})

--- a/commands/pending_changes_test.go
+++ b/commands/pending_changes_test.go
@@ -118,8 +118,9 @@ var _ = Describe("PendingChanges", func() {
 					}, nil)
 				})
 
-				It("returns an error", func() {
+				It("lists change information for all products and returns an error", func() {
 					err := command.Execute(options)
+					Expect(presenter.PresentPendingChangesCallCount()).To(Equal(1))
 					Expect(err).To(HaveOccurred())
 				})
 			})
@@ -135,8 +136,9 @@ var _ = Describe("PendingChanges", func() {
 						},
 					}, nil)
 				})
-				It("does not return an error", func() {
+				It("lists change information for all products and does not return an error", func() {
 					err := command.Execute(options)
+					Expect(presenter.PresentPendingChangesCallCount()).To(Equal(1))
 					Expect(err).NotTo(HaveOccurred())
 				})
 			})

--- a/commands/pending_changes_test.go
+++ b/commands/pending_changes_test.go
@@ -62,6 +62,55 @@ var _ = Describe("PendingChanges", func() {
 			Expect(presenter.PresentPendingChangesCallCount()).To(Equal(1))
 		})
 
+		Context("when the check flag is provided", func() {
+      var options []string
+
+			BeforeEach(func(){
+				options = []string{"--check"}
+			})
+			When("there are pending changes", func() {
+				// No setup yet because this is the way the top level Describe sets it
+				It("returns an error", func(){
+					err := command.Execute(options)
+					Expect(err).To(HaveOccurred())
+				})
+			})
+
+			When("there are no pending changes", func(){
+				BeforeEach(func(){
+					pcService.ListStagedPendingChangesReturns(api.PendingChangesOutput{
+						ChangeList: []api.ProductChange{
+							{
+								GUID:   "some-product",
+								Action: "unchanged",
+								Errands: []api.Errand{
+									{
+										Name:       "some-errand",
+										PostDeploy: "on",
+										PreDelete:  "false",
+									},
+									{
+										Name:       "some-errand-2",
+										PostDeploy: "when-change",
+										PreDelete:  "false",
+									},
+								},
+							},
+							{
+								GUID:    "some-product-without-errand",
+								Action:  "install",
+								Errands: []api.Errand{},
+							},
+						},
+					}, nil)
+				})
+				It("does not return an error", func(){
+					err := command.Execute(options)
+					Expect(err).NotTo(HaveOccurred())
+				})
+			})
+		})
+
 		Context("when the format flag is provided", func() {
 			It("sets the format on the presenter", func() {
 				err := command.Execute([]string{"--format", "json"})


### PR DESCRIPTION
This flag should be useful for validating that an environment is in a "clean" state when it is expected to be.

Signed-off-by: Jesse Alford <jalford@pivotal.io>
