### PR TITLE
Skip subdirectories when locating metadata file

### DIFF
--- a/extractor/metadata_extractor.go
+++ b/extractor/metadata_extractor.go
@@ -27,7 +27,7 @@ func (me MetadataExtractor) ExtractMetadata(productPath string) (Metadata, error
 	defer zipReader.Close()
 
 	for _, file := range zipReader.File {
-		metadataRegexp := regexp.MustCompile(`metadata/.*\.yml`)
+		metadataRegexp := regexp.MustCompile(`^(\.\/)?metadata/.*\.yml`)
 		matched := metadataRegexp.MatchString(file.Name)
 
 		if matched {


### PR DESCRIPTION
This issue was seen in the wild when a tile was created by zipping up
files on a Mac OSX system where it grabbed  a `__MACOSX` directory of hidden files.

`om` found the `__MACOSX/metadata/._metadata.yml` before it found the
`metadata/metadata.yml` and returned the error when `upload-product` was called:

```
could not execute "upload-product": failed to extract product metadata: could not extract product metadata: yaml: control characters are not allowed
```

This change to the regex changes `om` so that metadata files are only found
in `metadata/` or `./metadata`