### PR TITLE
Add shell completion script

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,3 +129,8 @@ Commands:
   version                         prints the om release version
 
 ```
+
+## Shell completion
+If you use `bash` or `zsh` on MacOS or Linux, and would like to take advantage of
+those shells' auto-complete functionality, you can use the script in the
+[shell_completion](./shell_completion) directory.

--- a/shell_completion/README.md
+++ b/shell_completion/README.md
@@ -1,0 +1,55 @@
+## Shell Completion for `om`
+
+`om-completion.sh` provides command completion for the `om` utility and works in
+both `bash` and `zsh`. Like most command completion, type `om` and either press tab
+twice or begin typing a command and press tab and it will give you the available
+options.
+
+### Examples
+
+```sh
+$ om <tab><tab>
+activate-certificate-authority  create-certificate-authority    errands                         stage-product
+apply-changes                   create-vm-extension             export-installation             staged-config
+assign-stemcell                 credential-references           generate-certificate            staged-director-config
+available-products              credentials                     generate-certificate-authority  staged-manifest
+bosh-env                        curl                            help                            staged-products
+certificate-authorities         delete-certificate-authority    import-installation             tile-metadata
+certificate-authority           delete-installation             installation-log                unstage-product
+config-template                 delete-product                  installations                   update-ssl-certificate
+configure-authentication        delete-ssl-certificate          interpolate                     upload-product
+configure-director              delete-unused-products          pending-changes                 upload-stemcell
+configure-ldap-authentication   deployed-manifest               regenerate-certificates         version
+configure-product               deployed-products               revert-staged-changes
+configure-saml-authentication   download-product                ssl-certificate
+```
+
+```sh
+$ om c<tab><tab>
+certificate-authorities        configure-director             create-certificate-authority   curl
+certificate-authority          configure-ldap-authentication  create-vm-extension
+config-template                configure-product              credential-references
+configure-authentication       configure-saml-authentication  credentials
+```
+### Usage
+
+#### `bash`
+If you already use bash completion, drop this file in `/etc/bash_completion.d` and
+it will likely be taken care of. If not, add this file to your `~/.bash_profile`
+script:
+
+```
+source /path/to/om-completion.sh
+```
+
+#### `zsh`
+Similarly to `bash`, if you use `zsh`, place the autocomplete script where you
+usually keep them, and it should mostly be taken care of. If you don't, put it in
+a useful place to you, and add the `source` command to your `.zshrc` file. In either
+case, you *must* make sure that the following two lines are executed *before* 
+`om-completion.sh` is sourced:
+
+```sh
+autoload -U +X compinit && compinit
+autoload -U +X bashcompinit && bashcompinit
+```

--- a/shell_completion/om-completion.sh
+++ b/shell_completion/om-completion.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+_om_completions() {
+  COMPREPLY=($(compgen -W "$(om 2>/dev/null | grep -e '^[[:space:]][[:space:]]*[[:alnum:]]' | sed -e 's/^[[:space:]]*//' | awk '{print $1}')" -- "${COMP_WORDS[1]}"))
+}
+
+complete -F _om_completions om


### PR DESCRIPTION
This PR adds a `bash` and `zsh`* compatible tab-completion script. I put it in its own directory so it should create no merge conflicts. It is largely self-contained, but a major change to the way that the help text is displayed _could_ cause a break. However, since it does not affect `om` functionality directly, I consider that a minor concern and could be fixed after the fact.

* `zsh` support requires a bit of extra work that's documented in the folder's `README`