### PR TITLE
Add --ignore-verification-warnings flag

### DIFF
--- a/api/director_service.go
+++ b/api/director_service.go
@@ -53,7 +53,7 @@ type NetworkAndAZConfiguration struct {
 
 type DirectorProperties json.RawMessage
 
-func (a Api) UpdateStagedDirectorAvailabilityZones(input AvailabilityZoneInput) error {
+func (a Api) UpdateStagedDirectorAvailabilityZones(input AvailabilityZoneInput, ignoreVerifierWarnings bool) error {
 	azs := AvailabilityZones{}
 	err := yaml.Unmarshal(input.AvailabilityZones, &azs.AvailabilityZones)
 	if err != nil {
@@ -87,7 +87,7 @@ func (a Api) UpdateStagedDirectorAvailabilityZones(input AvailabilityZoneInput) 
 	}
 	defer resp.Body.Close()
 
-	if err = validateStatusOK(resp); err != nil {
+	if err = validateStatusOKOrVerificationWarning(resp, ignoreVerifierWarnings); err != nil {
 		return err
 	}
 

--- a/api/validation.go
+++ b/api/validation.go
@@ -20,3 +20,10 @@ func validateStatusOK(resp *http.Response) error {
 
 	return nil
 }
+
+func validateStatusOKOrVerificationWarning(resp *http.Response, ignoreVerifierWarnings bool) error {
+	if ignoreVerifierWarnings && resp.StatusCode == http.StatusMultiStatus {
+		return nil
+	}
+	return validateStatusOK(resp)
+}

--- a/commands/configure_director.go
+++ b/commands/configure_director.go
@@ -16,10 +16,11 @@ type ConfigureDirector struct {
 	service     configureDirectorService
 	logger      logger
 	Options     struct {
-		ConfigFile string   `short:"c" long:"config" description:"path to yml file containing all config fields (see docs/configure-director/README.md for format)" required:"true"`
-		VarsFile   []string `long:"vars-file"  description:"Load variables from a YAML file"`
-		VarsEnv    []string `long:"vars-env"   description:"Load variables from environment variables (e.g.: 'MY' to load MY_var=value)"`
-		OpsFile    []string `long:"ops-file"  description:"YAML operations file"`
+		IgnoreVerifierWarnings bool     `long:"ignore-verifier-warnings" description:"option to ignore verifier warnings. NOT RECOMMENDED UNLESS DISABLED IN OPS MANAGER"`
+		ConfigFile             string   `short:"c" long:"config" description:"path to yml file containing all config fields (see docs/configure-director/README.md for format)" required:"true"`
+		VarsFile               []string `long:"vars-file" description:"Load variables from a YAML file"`
+		VarsEnv                []string `long:"vars-env" description:"Load variables from environment variables (e.g.: 'MY' to load MY_var=value)"`
+		OpsFile                []string `long:"ops-file" description:"YAML operations file"`
 	}
 }
 
@@ -43,7 +44,7 @@ type configureDirectorService interface {
 	ListInstallations() ([]api.InstallationsServiceOutput, error)
 	ListStagedProductJobs(string) (map[string]string, error)
 	ListStagedVMExtensions() ([]api.VMExtension, error)
-	UpdateStagedDirectorAvailabilityZones(api.AvailabilityZoneInput) error
+	UpdateStagedDirectorAvailabilityZones(api.AvailabilityZoneInput, bool) error
 	UpdateStagedDirectorNetworkAndAZ(api.NetworkAndAZConfiguration) error
 	UpdateStagedDirectorNetworks(api.NetworkInput) error
 	UpdateStagedDirectorProperties(api.DirectorProperties) error
@@ -223,7 +224,7 @@ func (c ConfigureDirector) configureAvailabilityZones(config *directorConfig) er
 
 		err = c.service.UpdateStagedDirectorAvailabilityZones(api.AvailabilityZoneInput{
 			AvailabilityZones: json.RawMessage(azs),
-		})
+		}, c.Options.IgnoreVerifierWarnings)
 		if err != nil {
 			return fmt.Errorf("availability zones configuration could not be applied: %s", err)
 		}

--- a/commands/fakes/configure_director_service.go
+++ b/commands/fakes/configure_director_service.go
@@ -107,10 +107,11 @@ type ConfigureDirectorService struct {
 		result1 []api.VMExtension
 		result2 error
 	}
-	UpdateStagedDirectorAvailabilityZonesStub        func(api.AvailabilityZoneInput) error
+	UpdateStagedDirectorAvailabilityZonesStub        func(api.AvailabilityZoneInput, bool) error
 	updateStagedDirectorAvailabilityZonesMutex       sync.RWMutex
 	updateStagedDirectorAvailabilityZonesArgsForCall []struct {
 		arg1 api.AvailabilityZoneInput
+		arg2 bool
 	}
 	updateStagedDirectorAvailabilityZonesReturns struct {
 		result1 error
@@ -651,16 +652,17 @@ func (fake *ConfigureDirectorService) ListStagedVMExtensionsReturnsOnCall(i int,
 	}{result1, result2}
 }
 
-func (fake *ConfigureDirectorService) UpdateStagedDirectorAvailabilityZones(arg1 api.AvailabilityZoneInput) error {
+func (fake *ConfigureDirectorService) UpdateStagedDirectorAvailabilityZones(arg1 api.AvailabilityZoneInput, arg2 bool) error {
 	fake.updateStagedDirectorAvailabilityZonesMutex.Lock()
 	ret, specificReturn := fake.updateStagedDirectorAvailabilityZonesReturnsOnCall[len(fake.updateStagedDirectorAvailabilityZonesArgsForCall)]
 	fake.updateStagedDirectorAvailabilityZonesArgsForCall = append(fake.updateStagedDirectorAvailabilityZonesArgsForCall, struct {
 		arg1 api.AvailabilityZoneInput
-	}{arg1})
-	fake.recordInvocation("UpdateStagedDirectorAvailabilityZones", []interface{}{arg1})
+		arg2 bool
+	}{arg1, arg2})
+	fake.recordInvocation("UpdateStagedDirectorAvailabilityZones", []interface{}{arg1, arg2})
 	fake.updateStagedDirectorAvailabilityZonesMutex.Unlock()
 	if fake.UpdateStagedDirectorAvailabilityZonesStub != nil {
-		return fake.UpdateStagedDirectorAvailabilityZonesStub(arg1)
+		return fake.UpdateStagedDirectorAvailabilityZonesStub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
@@ -675,17 +677,17 @@ func (fake *ConfigureDirectorService) UpdateStagedDirectorAvailabilityZonesCallC
 	return len(fake.updateStagedDirectorAvailabilityZonesArgsForCall)
 }
 
-func (fake *ConfigureDirectorService) UpdateStagedDirectorAvailabilityZonesCalls(stub func(api.AvailabilityZoneInput) error) {
+func (fake *ConfigureDirectorService) UpdateStagedDirectorAvailabilityZonesCalls(stub func(api.AvailabilityZoneInput, bool) error) {
 	fake.updateStagedDirectorAvailabilityZonesMutex.Lock()
 	defer fake.updateStagedDirectorAvailabilityZonesMutex.Unlock()
 	fake.UpdateStagedDirectorAvailabilityZonesStub = stub
 }
 
-func (fake *ConfigureDirectorService) UpdateStagedDirectorAvailabilityZonesArgsForCall(i int) api.AvailabilityZoneInput {
+func (fake *ConfigureDirectorService) UpdateStagedDirectorAvailabilityZonesArgsForCall(i int) (api.AvailabilityZoneInput, bool) {
 	fake.updateStagedDirectorAvailabilityZonesMutex.RLock()
 	defer fake.updateStagedDirectorAvailabilityZonesMutex.RUnlock()
 	argsForCall := fake.updateStagedDirectorAvailabilityZonesArgsForCall[i]
-	return argsForCall.arg1
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *ConfigureDirectorService) UpdateStagedDirectorAvailabilityZonesReturns(result1 error) {


### PR DESCRIPTION
- Ops Manager returns HTTP 207 in some cases to signal a verification warning
- This is different from a verification error, which is a 422

Relevant issue #335