### PR TITLE
delete installation now requires force flag

### DIFF
--- a/acceptance/delete_installation_test.go
+++ b/acceptance/delete_installation_test.go
@@ -82,7 +82,8 @@ var _ = Describe("delete-installation command", func() {
 			"--username", "some-username",
 			"--password", "some-password",
 			"--skip-ssl-validation",
-			"delete-installation")
+			"delete-installation",
+			"--force")
 
 		session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
 		Expect(err).NotTo(HaveOccurred())

--- a/main.go
+++ b/main.go
@@ -164,7 +164,7 @@ func main() {
 	commandSet["credentials"] = commands.NewCredentials(api, presenter, stdout)
 	commandSet["curl"] = commands.NewCurl(api, stdout, stderr)
 	commandSet["delete-certificate-authority"] = commands.NewDeleteCertificateAuthority(api, stdout)
-	commandSet["delete-installation"] = commands.NewDeleteInstallation(api, logWriter, stdout, applySleepDuration)
+	commandSet["delete-installation"] = commands.NewDeleteInstallation(api, logWriter, stdout, os.Stdin, applySleepDuration)
 	commandSet["delete-ssl-certificate"] = commands.NewDeleteSSLCertificate(api, stdout)
 	commandSet["delete-product"] = commands.NewDeleteProduct(api)
 	commandSet["delete-unused-products"] = commands.NewDeleteUnusedProducts(api, stdout)


### PR DESCRIPTION
Let me know if the design around this does not work! I think the aesthetics are ok.

Gentle reminder, as I always forget this, change is backwards incompatible and requires a major revision of `om` when released (as we've changed the way the delete-installation command works by default).

fixes #341 
