### PR TITLE
Move the upload-product 'available versions' check into the retry loop

### DIFF
--- a/commands/upload_product.go
+++ b/commands/upload_product.go
@@ -87,17 +87,18 @@ func (up UploadProduct) Execute(args []string) error {
 		up.logger.Printf("expected version matches product version.")
 	}
 
-	prodAvailable, err := up.service.CheckProductAvailability(metadata.Name, metadata.Version)
-	if err != nil {
-		return fmt.Errorf("failed to check product availability: %s", err)
-	}
-
-	if prodAvailable {
-		up.logger.Printf("product %s %s is already uploaded, nothing to be done.", metadata.Name, metadata.Version)
-		return nil
-	}
-
 	for i := 0; i <= maxProductUploadRetries; i++ {
+		var prodAvailable bool
+		prodAvailable, err = up.service.CheckProductAvailability(metadata.Name, metadata.Version)
+		if err != nil {
+			return fmt.Errorf("failed to check product availability: %s", err)
+		}
+
+		if prodAvailable {
+			up.logger.Printf("product %s %s is already uploaded, nothing to be done.", metadata.Name, metadata.Version)
+			return nil
+		}
+
 		up.logger.Printf("processing product")
 
 		err = up.multipart.AddFile("product[file]", up.Options.Product)


### PR DESCRIPTION
Covers the case where the first upload succeeds but times out on validation. Previously it would retry and fail. Now if the product validated, the retry can be skipped.

Co-authored-by: Pete Wall <pwall@pivotal.io>