### PR TITLE
add product_version in download-file.json

### DIFF
--- a/acceptance/download_product_test.go
+++ b/acceptance/download_product_test.go
@@ -278,7 +278,8 @@ var _ = Describe("download-product command", func() {
 
 				Expect(fileContents(tmpDir, "download-file.json")).To(MatchJSON(fmt.Sprintf(`{
 					"product_slug": "example-product",
-					"product_path": "%s/[example-product,1.10.1]product.yml"
+					"product_path": "%s/[example-product,1.10.1]product.yml",
+					"product_version": "1.10.1"
 				}`, tmpDir)))
 				Expect(fileContents(tmpDir, "[example-product,1.10.1]product.yml")).To(MatchYAML(fmt.Sprintf(`{
 					"nothing": "to see here"
@@ -344,7 +345,8 @@ var _ = Describe("download-product command", func() {
 				Eventually(session, "10s").Should(gexec.Exit(0))
 				Expect(fileContents(tmpDir, "download-file.json")).To(MatchJSON(fmt.Sprintf(`{
 					"product_slug": "example-product",
-					"product_path": "%s/[example-product,1.10.2]product-456.yml"
+					"product_path": "%s/[example-product,1.10.2]product-456.yml",
+					"product_version": "1.10.2"
 				}`, tmpDir)))
 				Expect(fileContents(tmpDir, "[example-product,1.10.2]product-456.yml")).To(MatchYAML(fmt.Sprintf(`{
 					"nothing": "to see here"

--- a/commands/download_product.go
+++ b/commands/download_product.go
@@ -126,7 +126,7 @@ func (c *DownloadProduct) Execute(args []string) error {
 	}
 
 	if c.Options.StemcellIaas == "" {
-		return c.writeDownloadProductOutput(productFileName, "", "")
+		return c.writeDownloadProductOutput(productFileName, productVersion, "", "")
 	}
 
 	c.stderr.Printf("Downloading stemcell")
@@ -152,7 +152,7 @@ func (c *DownloadProduct) Execute(args []string) error {
 		return fmt.Errorf("could not download stemcell: %s", err)
 	}
 
-	err = c.writeDownloadProductOutput(productFileName, stemcellFileName, stemcell.Version())
+	err = c.writeDownloadProductOutput(productFileName, productVersion, stemcellFileName, stemcell.Version())
 	if err != nil {
 		return err
 	}
@@ -227,18 +227,20 @@ func (c *DownloadProduct) validate() error {
 	return nil
 }
 
-func (c DownloadProduct) writeDownloadProductOutput(productFileName string, stemcellFileName string, stemcellVersion string) error {
+func (c DownloadProduct) writeDownloadProductOutput(productFileName string, productVersion string, stemcellFileName string, stemcellVersion string) error {
 	downloadProductFilename := "download-file.json"
 	c.stderr.Printf("Writing a list of downloaded artifact to %s", downloadProductFilename)
 	downloadProductPayload := struct {
 		ProductPath     string `json:"product_path,omitempty"`
 		ProductSlug     string `json:"product_slug,omitempty"`
+		ProductVersion  string `json:"product_version,omitempty"`
 		StemcellPath    string `json:"stemcell_path,omitempty"`
 		StemcellVersion string `json:"stemcell_version,omitempty"`
 	}{
 		ProductPath:     productFileName,
 		StemcellPath:    stemcellFileName,
 		ProductSlug:     c.Options.PivnetProductSlug,
+		ProductVersion:  productVersion,
 		StemcellVersion: stemcellVersion,
 	}
 

--- a/commands/download_product_test.go
+++ b/commands/download_product_test.go
@@ -289,6 +289,7 @@ var _ = Describe("DownloadProduct", func() {
 							{
 								"product_path": "%s",
 								"product_slug": "elastic-runtime",
+								"product_version": "2.0.0",
 								"stemcell_path": "%s",
 								"stemcell_version": "97.190"
 							}`, downloadedFilePath, pf.Name())))
@@ -576,7 +577,7 @@ output-directory: %s
 					Expect(err).NotTo(HaveOccurred())
 					Expect(downloadReportFileName).To(BeAnExistingFile())
 					prefixedFileName := path.Join(tempDir, "[mayhem-crew,2.0.0]my-great-product.pivotal")
-					Expect(string(fileContent)).To(MatchJSON(fmt.Sprintf(`{"product_path": "%s", "product_slug": "mayhem-crew" }`, prefixedFileName)))
+					Expect(string(fileContent)).To(MatchJSON(fmt.Sprintf(`{"product_path": "%s", "product_slug": "mayhem-crew", "product_version": "2.0.0" }`, prefixedFileName)))
 				})
 			})
 
@@ -621,7 +622,7 @@ output-directory: %s
 					Expect(err).NotTo(HaveOccurred())
 					Expect(downloadReportFileName).To(BeAnExistingFile())
 					unPrefixedFileName := path.Join(tempDir, "my-great-product.pivotal")
-					Expect(string(fileContent)).To(MatchJSON(fmt.Sprintf(`{"product_path": "%s", "product_slug": "mayhem-crew" }`, unPrefixedFileName)))
+					Expect(string(fileContent)).To(MatchJSON(fmt.Sprintf(`{"product_path": "%s", "product_slug": "mayhem-crew", "product_version": "2.0.0" }`, unPrefixedFileName)))
 				})
 			})
 


### PR DESCRIPTION
as discussed in #360 this adds `product_version` to the `download-file.json`file.
I've tested it with downloading opsman, a tile and a stemcell.