### PR TITLE
Allow custom VM types to be specified in director config

### DIFF
--- a/api/vm_types_service.go
+++ b/api/vm_types_service.go
@@ -65,7 +65,30 @@ func (c *CreateVMType) UnmarshalJSON(b []byte) error {
 
 			c.EphemeralDisk = uint(u)
 		default:
-			c.ExtraProperties[key] = value
+			if key != "builtin" {
+				c.ExtraProperties[key] = value
+			}
+		}
+	}
+
+	return nil
+}
+
+func (v *VMType) UnmarshalJSON(b []byte) error {
+	var raw map[string]interface{}
+
+	c := CreateVMType{}
+	c.UnmarshalJSON(b)
+
+	v.CreateVMType = c
+
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+
+	if builtin, ok := raw["builtin"]; ok {
+		if _, assertOk := builtin.(bool); assertOk {
+			v.BuiltIn = builtin.(bool)
 		}
 	}
 

--- a/api/vm_types_service.go
+++ b/api/vm_types_service.go
@@ -1,0 +1,137 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+
+	"github.com/pkg/errors"
+)
+
+type CreateVMTypes struct {
+	VMTypes []CreateVMType `json:"vm_types" yaml:"vm_types"`
+}
+
+type VMTypesResponse struct {
+	VMTypes []VMType `json:"vm_types"`
+}
+
+type CreateVMType struct {
+	RAM             uint                   `yaml:"ram"`
+	Name            string                 `yaml:"name"`
+	CPU             uint                   `yaml:"cpu"`
+	EphemeralDisk   uint                   `yaml:"ephemeral_disk"`
+	ExtraProperties map[string]interface{} `yaml:",inline"`
+}
+
+type VMType struct {
+	CreateVMType
+	BuiltIn bool `json:"builtin" yaml:"builtin"`
+}
+
+func (c *CreateVMType) UnmarshalJSON(b []byte) error {
+	var raw map[string]interface{}
+	c.ExtraProperties = make(map[string]interface{})
+
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+
+	for key, value := range raw {
+		var u float64
+		var ok bool
+		switch key {
+		case "name":
+			c.Name = fmt.Sprintf("%v", value)
+
+		case "ram":
+			if u, ok = value.(float64); !ok {
+				return fmt.Errorf("could not marshal ram into uint")
+			}
+
+			c.RAM = uint(u)
+
+		case "cpu":
+			if u, ok = value.(float64); !ok {
+				return fmt.Errorf("could not marshal cpu into uint")
+			}
+
+			c.CPU = uint(u)
+
+		case "ephemeral_disk":
+			if u, ok = value.(float64); !ok {
+				return fmt.Errorf("could not marshal ephemeral_disk into uint")
+			}
+
+			c.EphemeralDisk = uint(u)
+		default:
+			c.ExtraProperties[key] = value
+		}
+	}
+
+	return nil
+}
+
+func (c CreateVMType) MarshalJSON() ([]byte, error) {
+	raw := make(map[string]interface{})
+	raw["name"] = c.Name
+	raw["ram"] = c.RAM
+	raw["cpu"] = c.CPU
+	raw["ephemeral_disk"] = c.EphemeralDisk
+	for k, v := range c.ExtraProperties {
+		raw[k] = v
+	}
+
+	return json.Marshal(raw)
+}
+
+func (a Api) CreateCustomVMTypes(input CreateVMTypes) error {
+	jsonData, err := json.Marshal(&input)
+	if err != nil {
+		return errors.Wrap(err, "could not marshal json")
+	}
+
+	resp, err := a.sendAPIRequest("PUT", "/api/v0/vm_types", jsonData)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if err = validateStatusOK(resp); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (a Api) ListVMTypes() ([]VMType, error) {
+	resp, err := a.sendAPIRequest("GET", "/api/v0/vm_types", nil)
+	if err != nil {
+		return nil, err // un-tested
+	}
+	defer resp.Body.Close()
+
+	if err = validateStatusOK(resp); err != nil {
+		return nil, err
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	var vmTypes VMTypesResponse
+	if err = json.Unmarshal(body, &vmTypes); err != nil {
+		return nil, errors.Wrap(err, "could not parse json")
+	}
+
+	return vmTypes.VMTypes, nil
+}
+
+func (a Api) DeleteCustomVMTypes() error {
+	resp, err := a.sendAPIRequest("DELETE", "/api/v0/vm_types", nil)
+	if err = validateStatusOK(resp); err != nil {
+		return err
+	}
+
+	return err
+}

--- a/api/vm_types_service_test.go
+++ b/api/vm_types_service_test.go
@@ -1,0 +1,203 @@
+package api_test
+
+import (
+	"errors"
+	"io/ioutil"
+	"net/http"
+	"strings"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/pivotal-cf/om/api"
+	"github.com/pivotal-cf/om/api/fakes"
+)
+
+var _ = Describe("VMTypes", func() {
+	var (
+		client  *fakes.HttpClient
+		service api.Api
+	)
+
+	BeforeEach(func() {
+		client = &fakes.HttpClient{}
+		service = api.New(api.ApiInput{
+			Client: client,
+		})
+		client.DoStub = func(req *http.Request) (*http.Response, error) {
+			if req.Method == "GET" {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body: ioutil.NopCloser(strings.NewReader(
+						`{
+					"vm_types": [
+						{
+						"name": "t2.micro",
+						"ram": 1024,
+						"cpu": 1,
+						"ephemeral_disk": 8192,
+						"raw_instance_storage": false,
+						"builtin": true
+						},
+						{
+						"name": "t2.small",
+						"ram": 2048,
+						"cpu": 1,
+						"ephemeral_disk": 8192,
+						"raw_instance_storage": false,
+						"builtin": true
+						},
+						{
+						"name": "t2.medium",
+						"ram": 3840,
+						"cpu": 1,
+						"ephemeral_disk": 32768,
+						"raw_instance_storage": true,
+						"builtin": true
+						},
+						{
+						"name": "c4.large",
+						"ram": 3840,
+						"cpu": 2,
+						"ephemeral_disk": 32768,
+						"raw_instance_storage": false,
+						"builtin": true
+						}
+					]
+					}
+					`))}, nil
+			} else {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       ioutil.NopCloser(strings.NewReader(`{}`))}, nil
+			}
+		}
+	})
+
+	It("creates a VM Type", func() {
+		err := service.CreateCustomVMTypes(api.CreateVMTypes{
+			VMTypes: []api.CreateVMType{
+				api.CreateVMType{
+					Name:          "my-vm-type",
+					RAM:           3840,
+					CPU:           2,
+					EphemeralDisk: 32768,
+				},
+				api.CreateVMType{Name: "my-vm-type2",
+					RAM:             3842,
+					CPU:             2,
+					EphemeralDisk:   32790,
+					ExtraProperties: map[string]interface{}{"raw_instance_storage": true},
+				},
+			},
+		})
+
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(client.DoCallCount()).To(Equal(1))
+		req := client.DoArgsForCall(0)
+
+		Expect(req.Method).To(Equal("PUT"))
+		Expect(req.URL.Path).To(Equal("/api/v0/vm_types"))
+		Expect(req.Header.Get("Content-Type")).To(Equal("application/json"))
+
+		jsonBody, err := ioutil.ReadAll(req.Body)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(jsonBody).To(MatchJSON(`{ 
+		"vm_types": [ 
+			{
+			"name": "my-vm-type",
+			"ram": 3840,
+			"cpu": 2,
+			"ephemeral_disk": 32768    
+			},
+			{
+			"name": "my-vm-type2",
+			"ram": 3842,
+			"cpu": 2,
+			"ephemeral_disk": 32790,
+			"raw_instance_storage": true
+			}
+	  	] 
+	  }`))
+	})
+
+	It("lists VM Types", func() {
+		vmtypes, err := service.ListVMTypes()
+
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(client.DoCallCount()).To(Equal(1))
+		req := client.DoArgsForCall(0)
+
+		Expect(req.Method).To(Equal("GET"))
+		Expect(req.URL.Path).To(Equal("/api/v0/vm_types"))
+		Expect(req.Header.Get("Content-Type")).To(Equal("application/json"))
+
+		Expect(len(vmtypes)).Should(Equal(4))
+		Expect(vmtypes[0].Name).Should(Equal("t2.micro"))
+		Expect(vmtypes[1].Name).Should(Equal("t2.small"))
+	})
+
+	It("deletes VM Types", func() {
+		err := service.DeleteCustomVMTypes()
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(client.DoCallCount()).To(Equal(1))
+		req := client.DoArgsForCall(0)
+
+		Expect(req.Method).To(Equal("DELETE"))
+		Expect(req.URL.Path).To(Equal("/api/v0/vm_types"))
+		Expect(req.Header.Get("Content-Type")).To(Equal("application/json"))
+	})
+
+	Context("failure cases", func() {
+		It("returns an error when the http status is non-200", func() {
+
+			client.DoReturns(&http.Response{
+				StatusCode: http.StatusInternalServerError,
+				Body:       ioutil.NopCloser(strings.NewReader(`{}`))}, nil)
+
+			err := service.CreateCustomVMTypes(api.CreateVMTypes{
+				VMTypes: []api.CreateVMType{
+					api.CreateVMType{Name: "foo"},
+				},
+			})
+
+			Expect(err).To(MatchError(ContainSubstring("500 Internal Server Error")))
+		})
+		It("returns an error when the http status is non-200 for listing vm extensions", func() {
+
+			client.DoReturns(&http.Response{
+				StatusCode: http.StatusInternalServerError,
+				Body:       ioutil.NopCloser(strings.NewReader(`{}`))}, nil)
+
+			_, err := service.ListVMTypes()
+
+			Expect(err).To(MatchError(ContainSubstring("500 Internal Server Error")))
+		})
+		It("returns an error when the http status is non-200 for deleting vm extensions", func() {
+
+			client.DoReturns(&http.Response{
+				StatusCode: http.StatusInternalServerError,
+				Body:       ioutil.NopCloser(strings.NewReader(`{}`))}, nil)
+
+			err := service.DeleteCustomVMTypes()
+			Expect(err).To(MatchError(ContainSubstring("500 Internal Server Error")))
+		})
+
+		It("returns an error when the api endpoint fails", func() {
+			client.DoReturns(&http.Response{
+				StatusCode: http.StatusOK,
+				Body:       ioutil.NopCloser(strings.NewReader(`{}`))}, errors.New("api endpoint failed"))
+
+			err := service.CreateCustomVMTypes(api.CreateVMTypes{
+				VMTypes: []api.CreateVMType{
+					api.CreateVMType{Name: "foo"},
+				},
+			})
+
+			Expect(err).To(MatchError("could not send api request to PUT /api/v0/vm_types: api endpoint failed"))
+		})
+	})
+})

--- a/api/vm_types_service_test.go
+++ b/api/vm_types_service_test.go
@@ -1,6 +1,7 @@
 package api_test
 
 import (
+	"encoding/json"
 	"errors"
 	"io/ioutil"
 	"net/http"
@@ -198,6 +199,18 @@ var _ = Describe("VMTypes", func() {
 			})
 
 			Expect(err).To(MatchError("could not send api request to PUT /api/v0/vm_types: api endpoint failed"))
+		})
+	})
+
+	Context("JSON marshalling", func() {
+		It("does not include the builtin key in the ExtraPropeties map of a CreateVMType", func() {
+			typeJson := `{"name": "type1", "ram": 2048, "cpu": 2, "ephemeral_disk": 10240, "raw_instance_storage": true, "builtin": true}`
+
+			var vmType api.VMType
+			err := json.Unmarshal([]byte(typeJson), &vmType)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(vmType.BuiltIn).To(BeTrue())
+			Expect(vmType.CreateVMType.ExtraProperties).NotTo(HaveKey("builtin"))
 		})
 	})
 })

--- a/commands/configure_director.go
+++ b/commands/configure_director.go
@@ -25,8 +25,8 @@ type ConfigureDirector struct {
 }
 
 type VMTypesConfiguration struct {
-	CustomTypesOnly bool               `yaml:"custom_only" json:"custom_only"`
-	VMTypes         []api.CreateVMType `yaml:"vm_types" json:"vm_types"`
+	CustomTypesOnly bool               `yaml:"custom_only,omitempty" json:"custom_only,omitempty"`
+	VMTypes         []api.CreateVMType `yaml:"vm_types,omitempty" json:"vm_types,omitempty"`
 }
 
 type directorConfig struct {

--- a/commands/configure_director.go
+++ b/commands/configure_director.go
@@ -24,6 +24,11 @@ type ConfigureDirector struct {
 	}
 }
 
+type VMTypesConfiguration struct {
+	CustomTypesOnly bool               `yaml:"custom_only" json:"custom_only"`
+	VMTypes         []api.CreateVMType `yaml:"vm_types" json:"vm_types"`
+}
+
 type directorConfig struct {
 	NetworkAssignment       interface{}            `yaml:"network-assignment"`
 	AZConfiguration         interface{}            `yaml:"az-configuration"`
@@ -32,12 +37,15 @@ type directorConfig struct {
 	IAASConfigurations      interface{}            `yaml:"iaas-configurations"`
 	ResourceConfiguration   map[string]interface{} `yaml:"resource-configuration"`
 	VMExtensions            interface{}            `yaml:"vmextensions-configuration"`
+	VMTypes                 VMTypesConfiguration   `yaml:"vmtypes-configuration"`
 	Field                   map[string]interface{} `yaml:",inline"`
 }
 
 //go:generate counterfeiter -o ./fakes/configure_director_service.go --fake-name ConfigureDirectorService . configureDirectorService
 type configureDirectorService interface {
+	CreateCustomVMTypes(api.CreateVMTypes) error
 	CreateStagedVMExtension(api.CreateVMExtension) error
+	DeleteCustomVMTypes() error
 	DeleteVMExtension(name string) error
 	GetStagedProductByName(name string) (api.StagedProductsFindOutput, error)
 	GetStagedProductJobResourceConfig(string, string) (api.JobProperties, error)
@@ -46,6 +54,7 @@ type configureDirectorService interface {
 	ListInstallations() ([]api.InstallationsServiceOutput, error)
 	ListStagedProductJobs(string) (map[string]string, error)
 	ListStagedVMExtensions() ([]api.VMExtension, error)
+	ListVMTypes() ([]api.VMType, error)
 	UpdateStagedDirectorIAASConfigurations(api.IAASConfigurationsInput) error
 	UpdateStagedDirectorAvailabilityZones(api.AvailabilityZoneInput, bool) error
 	UpdateStagedDirectorNetworkAndAZ(api.NetworkAndAZConfiguration) error
@@ -121,6 +130,11 @@ func (c ConfigureDirector) Execute(args []string) error {
 	}
 
 	err = c.configureVMExtensions(config)
+	if err != nil {
+		return err
+	}
+
+	err = c.configureVMTypes(config)
 	if err != nil {
 		return err
 	}
@@ -458,6 +472,57 @@ func (c ConfigureDirector) configureVMExtensions(config *directorConfig) error {
 		c.logger.Printf("finished configuring vm extensions")
 	}
 	return nil
+}
+
+func (c ConfigureDirector) configureVMTypes(config *directorConfig) error {
+	if len(config.VMTypes.VMTypes) == 0 {
+		if config.VMTypes.CustomTypesOnly {
+			return fmt.Errorf("if custom_types = true, vm_types must not be empty")
+		}
+
+		return nil
+	}
+
+	c.logger.Printf("creating custom vm types")
+
+	vmTypesToCreate := make([]api.CreateVMType, 0)
+	existingVMTypes := make([]api.VMType, 0)
+
+	var err error
+	if !config.VMTypes.CustomTypesOnly {
+		// delete all custom VM types
+		if err = c.service.DeleteCustomVMTypes(); err != nil {
+			return err
+		}
+
+		existingVMTypes, err = c.service.ListVMTypes()
+		if err != nil {
+			return err
+		}
+	}
+
+	for i := range existingVMTypes {
+		vmTypesToCreate = append(vmTypesToCreate, existingVMTypes[i].CreateVMType)
+	}
+
+	for i := range config.VMTypes.VMTypes {
+		overwriting := false
+		for j := range vmTypesToCreate {
+			if config.VMTypes.VMTypes[i].Name == vmTypesToCreate[j].Name {
+				vmTypesToCreate[j] = config.VMTypes.VMTypes[i]
+				overwriting = true
+				break
+			}
+		}
+
+		if !overwriting {
+			vmTypesToCreate = append(vmTypesToCreate, config.VMTypes.VMTypes[i])
+		}
+	}
+
+	return c.service.CreateCustomVMTypes(api.CreateVMTypes{
+		VMTypes: vmTypesToCreate,
+	})
 }
 
 func (c ConfigureDirector) getProductGUID() (string, error) {

--- a/commands/fakes/configure_director_service.go
+++ b/commands/fakes/configure_director_service.go
@@ -8,6 +8,17 @@ import (
 )
 
 type ConfigureDirectorService struct {
+	CreateCustomVMTypesStub        func(api.CreateVMTypes) error
+	createCustomVMTypesMutex       sync.RWMutex
+	createCustomVMTypesArgsForCall []struct {
+		arg1 api.CreateVMTypes
+	}
+	createCustomVMTypesReturns struct {
+		result1 error
+	}
+	createCustomVMTypesReturnsOnCall map[int]struct {
+		result1 error
+	}
 	CreateStagedVMExtensionStub        func(api.CreateVMExtension) error
 	createStagedVMExtensionMutex       sync.RWMutex
 	createStagedVMExtensionArgsForCall []struct {
@@ -17,6 +28,16 @@ type ConfigureDirectorService struct {
 		result1 error
 	}
 	createStagedVMExtensionReturnsOnCall map[int]struct {
+		result1 error
+	}
+	DeleteCustomVMTypesStub        func() error
+	deleteCustomVMTypesMutex       sync.RWMutex
+	deleteCustomVMTypesArgsForCall []struct {
+	}
+	deleteCustomVMTypesReturns struct {
+		result1 error
+	}
+	deleteCustomVMTypesReturnsOnCall map[int]struct {
 		result1 error
 	}
 	DeleteVMExtensionStub        func(string) error
@@ -119,6 +140,18 @@ type ConfigureDirectorService struct {
 		result1 []api.VMExtension
 		result2 error
 	}
+	ListVMTypesStub        func() ([]api.VMType, error)
+	listVMTypesMutex       sync.RWMutex
+	listVMTypesArgsForCall []struct {
+	}
+	listVMTypesReturns struct {
+		result1 []api.VMType
+		result2 error
+	}
+	listVMTypesReturnsOnCall map[int]struct {
+		result1 []api.VMType
+		result2 error
+	}
 	UpdateStagedDirectorAvailabilityZonesStub        func(api.AvailabilityZoneInput, bool) error
 	updateStagedDirectorAvailabilityZonesMutex       sync.RWMutex
 	updateStagedDirectorAvailabilityZonesArgsForCall []struct {
@@ -192,6 +225,66 @@ type ConfigureDirectorService struct {
 	invocationsMutex sync.RWMutex
 }
 
+func (fake *ConfigureDirectorService) CreateCustomVMTypes(arg1 api.CreateVMTypes) error {
+	fake.createCustomVMTypesMutex.Lock()
+	ret, specificReturn := fake.createCustomVMTypesReturnsOnCall[len(fake.createCustomVMTypesArgsForCall)]
+	fake.createCustomVMTypesArgsForCall = append(fake.createCustomVMTypesArgsForCall, struct {
+		arg1 api.CreateVMTypes
+	}{arg1})
+	fake.recordInvocation("CreateCustomVMTypes", []interface{}{arg1})
+	fake.createCustomVMTypesMutex.Unlock()
+	if fake.CreateCustomVMTypesStub != nil {
+		return fake.CreateCustomVMTypesStub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.createCustomVMTypesReturns
+	return fakeReturns.result1
+}
+
+func (fake *ConfigureDirectorService) CreateCustomVMTypesCallCount() int {
+	fake.createCustomVMTypesMutex.RLock()
+	defer fake.createCustomVMTypesMutex.RUnlock()
+	return len(fake.createCustomVMTypesArgsForCall)
+}
+
+func (fake *ConfigureDirectorService) CreateCustomVMTypesCalls(stub func(api.CreateVMTypes) error) {
+	fake.createCustomVMTypesMutex.Lock()
+	defer fake.createCustomVMTypesMutex.Unlock()
+	fake.CreateCustomVMTypesStub = stub
+}
+
+func (fake *ConfigureDirectorService) CreateCustomVMTypesArgsForCall(i int) api.CreateVMTypes {
+	fake.createCustomVMTypesMutex.RLock()
+	defer fake.createCustomVMTypesMutex.RUnlock()
+	argsForCall := fake.createCustomVMTypesArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *ConfigureDirectorService) CreateCustomVMTypesReturns(result1 error) {
+	fake.createCustomVMTypesMutex.Lock()
+	defer fake.createCustomVMTypesMutex.Unlock()
+	fake.CreateCustomVMTypesStub = nil
+	fake.createCustomVMTypesReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *ConfigureDirectorService) CreateCustomVMTypesReturnsOnCall(i int, result1 error) {
+	fake.createCustomVMTypesMutex.Lock()
+	defer fake.createCustomVMTypesMutex.Unlock()
+	fake.CreateCustomVMTypesStub = nil
+	if fake.createCustomVMTypesReturnsOnCall == nil {
+		fake.createCustomVMTypesReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.createCustomVMTypesReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *ConfigureDirectorService) CreateStagedVMExtension(arg1 api.CreateVMExtension) error {
 	fake.createStagedVMExtensionMutex.Lock()
 	ret, specificReturn := fake.createStagedVMExtensionReturnsOnCall[len(fake.createStagedVMExtensionArgsForCall)]
@@ -248,6 +341,58 @@ func (fake *ConfigureDirectorService) CreateStagedVMExtensionReturnsOnCall(i int
 		})
 	}
 	fake.createStagedVMExtensionReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *ConfigureDirectorService) DeleteCustomVMTypes() error {
+	fake.deleteCustomVMTypesMutex.Lock()
+	ret, specificReturn := fake.deleteCustomVMTypesReturnsOnCall[len(fake.deleteCustomVMTypesArgsForCall)]
+	fake.deleteCustomVMTypesArgsForCall = append(fake.deleteCustomVMTypesArgsForCall, struct {
+	}{})
+	fake.recordInvocation("DeleteCustomVMTypes", []interface{}{})
+	fake.deleteCustomVMTypesMutex.Unlock()
+	if fake.DeleteCustomVMTypesStub != nil {
+		return fake.DeleteCustomVMTypesStub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.deleteCustomVMTypesReturns
+	return fakeReturns.result1
+}
+
+func (fake *ConfigureDirectorService) DeleteCustomVMTypesCallCount() int {
+	fake.deleteCustomVMTypesMutex.RLock()
+	defer fake.deleteCustomVMTypesMutex.RUnlock()
+	return len(fake.deleteCustomVMTypesArgsForCall)
+}
+
+func (fake *ConfigureDirectorService) DeleteCustomVMTypesCalls(stub func() error) {
+	fake.deleteCustomVMTypesMutex.Lock()
+	defer fake.deleteCustomVMTypesMutex.Unlock()
+	fake.DeleteCustomVMTypesStub = stub
+}
+
+func (fake *ConfigureDirectorService) DeleteCustomVMTypesReturns(result1 error) {
+	fake.deleteCustomVMTypesMutex.Lock()
+	defer fake.deleteCustomVMTypesMutex.Unlock()
+	fake.DeleteCustomVMTypesStub = nil
+	fake.deleteCustomVMTypesReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *ConfigureDirectorService) DeleteCustomVMTypesReturnsOnCall(i int, result1 error) {
+	fake.deleteCustomVMTypesMutex.Lock()
+	defer fake.deleteCustomVMTypesMutex.Unlock()
+	fake.DeleteCustomVMTypesStub = nil
+	if fake.deleteCustomVMTypesReturnsOnCall == nil {
+		fake.deleteCustomVMTypesReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.deleteCustomVMTypesReturnsOnCall[i] = struct {
 		result1 error
 	}{result1}
 }
@@ -730,6 +875,61 @@ func (fake *ConfigureDirectorService) ListStagedVMExtensionsReturnsOnCall(i int,
 	}{result1, result2}
 }
 
+func (fake *ConfigureDirectorService) ListVMTypes() ([]api.VMType, error) {
+	fake.listVMTypesMutex.Lock()
+	ret, specificReturn := fake.listVMTypesReturnsOnCall[len(fake.listVMTypesArgsForCall)]
+	fake.listVMTypesArgsForCall = append(fake.listVMTypesArgsForCall, struct {
+	}{})
+	fake.recordInvocation("ListVMTypes", []interface{}{})
+	fake.listVMTypesMutex.Unlock()
+	if fake.ListVMTypesStub != nil {
+		return fake.ListVMTypesStub()
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.listVMTypesReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *ConfigureDirectorService) ListVMTypesCallCount() int {
+	fake.listVMTypesMutex.RLock()
+	defer fake.listVMTypesMutex.RUnlock()
+	return len(fake.listVMTypesArgsForCall)
+}
+
+func (fake *ConfigureDirectorService) ListVMTypesCalls(stub func() ([]api.VMType, error)) {
+	fake.listVMTypesMutex.Lock()
+	defer fake.listVMTypesMutex.Unlock()
+	fake.ListVMTypesStub = stub
+}
+
+func (fake *ConfigureDirectorService) ListVMTypesReturns(result1 []api.VMType, result2 error) {
+	fake.listVMTypesMutex.Lock()
+	defer fake.listVMTypesMutex.Unlock()
+	fake.ListVMTypesStub = nil
+	fake.listVMTypesReturns = struct {
+		result1 []api.VMType
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *ConfigureDirectorService) ListVMTypesReturnsOnCall(i int, result1 []api.VMType, result2 error) {
+	fake.listVMTypesMutex.Lock()
+	defer fake.listVMTypesMutex.Unlock()
+	fake.ListVMTypesStub = nil
+	if fake.listVMTypesReturnsOnCall == nil {
+		fake.listVMTypesReturnsOnCall = make(map[int]struct {
+			result1 []api.VMType
+			result2 error
+		})
+	}
+	fake.listVMTypesReturnsOnCall[i] = struct {
+		result1 []api.VMType
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *ConfigureDirectorService) UpdateStagedDirectorAvailabilityZones(arg1 api.AvailabilityZoneInput, arg2 bool) error {
 	fake.updateStagedDirectorAvailabilityZonesMutex.Lock()
 	ret, specificReturn := fake.updateStagedDirectorAvailabilityZonesReturnsOnCall[len(fake.updateStagedDirectorAvailabilityZonesArgsForCall)]
@@ -1096,8 +1296,12 @@ func (fake *ConfigureDirectorService) UpdateStagedProductJobResourceConfigReturn
 func (fake *ConfigureDirectorService) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
+	fake.createCustomVMTypesMutex.RLock()
+	defer fake.createCustomVMTypesMutex.RUnlock()
 	fake.createStagedVMExtensionMutex.RLock()
 	defer fake.createStagedVMExtensionMutex.RUnlock()
+	fake.deleteCustomVMTypesMutex.RLock()
+	defer fake.deleteCustomVMTypesMutex.RUnlock()
 	fake.deleteVMExtensionMutex.RLock()
 	defer fake.deleteVMExtensionMutex.RUnlock()
 	fake.getStagedProductByNameMutex.RLock()
@@ -1114,6 +1318,8 @@ func (fake *ConfigureDirectorService) Invocations() map[string][][]interface{} {
 	defer fake.listStagedProductJobsMutex.RUnlock()
 	fake.listStagedVMExtensionsMutex.RLock()
 	defer fake.listStagedVMExtensionsMutex.RUnlock()
+	fake.listVMTypesMutex.RLock()
+	defer fake.listVMTypesMutex.RUnlock()
 	fake.updateStagedDirectorAvailabilityZonesMutex.RLock()
 	defer fake.updateStagedDirectorAvailabilityZonesMutex.RUnlock()
 	fake.updateStagedDirectorIAASConfigurationsMutex.RLock()

--- a/commands/fakes/staged_director_config_service.go
+++ b/commands/fakes/staged_director_config_service.go
@@ -123,6 +123,18 @@ type StagedDirectorConfigService struct {
 		result1 []api.VMExtension
 		result2 error
 	}
+	ListVMTypesStub        func() ([]api.VMType, error)
+	listVMTypesMutex       sync.RWMutex
+	listVMTypesArgsForCall []struct {
+	}
+	listVMTypesReturns struct {
+		result1 []api.VMType
+		result2 error
+	}
+	listVMTypesReturnsOnCall map[int]struct {
+		result1 []api.VMType
+		result2 error
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
@@ -671,6 +683,61 @@ func (fake *StagedDirectorConfigService) ListStagedVMExtensionsReturnsOnCall(i i
 	}{result1, result2}
 }
 
+func (fake *StagedDirectorConfigService) ListVMTypes() ([]api.VMType, error) {
+	fake.listVMTypesMutex.Lock()
+	ret, specificReturn := fake.listVMTypesReturnsOnCall[len(fake.listVMTypesArgsForCall)]
+	fake.listVMTypesArgsForCall = append(fake.listVMTypesArgsForCall, struct {
+	}{})
+	fake.recordInvocation("ListVMTypes", []interface{}{})
+	fake.listVMTypesMutex.Unlock()
+	if fake.ListVMTypesStub != nil {
+		return fake.ListVMTypesStub()
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.listVMTypesReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *StagedDirectorConfigService) ListVMTypesCallCount() int {
+	fake.listVMTypesMutex.RLock()
+	defer fake.listVMTypesMutex.RUnlock()
+	return len(fake.listVMTypesArgsForCall)
+}
+
+func (fake *StagedDirectorConfigService) ListVMTypesCalls(stub func() ([]api.VMType, error)) {
+	fake.listVMTypesMutex.Lock()
+	defer fake.listVMTypesMutex.Unlock()
+	fake.ListVMTypesStub = stub
+}
+
+func (fake *StagedDirectorConfigService) ListVMTypesReturns(result1 []api.VMType, result2 error) {
+	fake.listVMTypesMutex.Lock()
+	defer fake.listVMTypesMutex.Unlock()
+	fake.ListVMTypesStub = nil
+	fake.listVMTypesReturns = struct {
+		result1 []api.VMType
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *StagedDirectorConfigService) ListVMTypesReturnsOnCall(i int, result1 []api.VMType, result2 error) {
+	fake.listVMTypesMutex.Lock()
+	defer fake.listVMTypesMutex.Unlock()
+	fake.ListVMTypesStub = nil
+	if fake.listVMTypesReturnsOnCall == nil {
+		fake.listVMTypesReturnsOnCall = make(map[int]struct {
+			result1 []api.VMType
+			result2 error
+		})
+	}
+	fake.listVMTypesReturnsOnCall[i] = struct {
+		result1 []api.VMType
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *StagedDirectorConfigService) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
@@ -692,6 +759,8 @@ func (fake *StagedDirectorConfigService) Invocations() map[string][][]interface{
 	defer fake.listStagedProductJobsMutex.RUnlock()
 	fake.listStagedVMExtensionsMutex.RLock()
 	defer fake.listStagedVMExtensionsMutex.RUnlock()
+	fake.listVMTypesMutex.RLock()
+	defer fake.listVMTypesMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/docs/configure-director/README.md
+++ b/docs/configure-director/README.md
@@ -75,6 +75,44 @@ vmextensions-configuration:
 - name: another_vm_extension
   cloud_properties:
     foo: bar
+vmtypes-configuration:
+  custom_only: false
+  vm_types:
+  - name: a1.large
+    cpu: 4
+    ram: 8192
+    ephemeral_disk: 10240
+  - name: t2.small
+    cpu: 1
+    ram: 512
+    ephemeral_disk: 1024
+```
+
+#### vmtypes-configuration:
+
+Will set or update custom VM types on the director. If `custom_only` is `true`, 
+the VM types specified in your configuration will be the **entire** list of
+available VM types in the Ops Manager. If `false` or omitted, it will add the 
+listed VM types to the list of default VM types for your IaaS. If a specified
+VM type is named the same as a predefined VM type, it will overwrite the predefined
+type. If multiple specified VM types have the same name, the one specified last
+will be created. In either case, existing custom VM types do not persist across
+`configure-director` calls, and it should be expected that the entire list of custom
+VM types is specified in the director configuration.
+
+##### Minimal example
+```yaml
+vmtypes-configuration:
+  custom_only: false
+  vm_types:
+  - name: x1.large
+    cpu: 8
+    ram: 8192
+    ephemeral_disk: 10240
+  - name: mycustomvmtype
+    cpu: 4
+    ram: 16384
+    ephemeral_disk: 4096
 ```
 
 #### Variables


### PR DESCRIPTION
Resolves #337 and replaces #369, which ended up being a bad PR. 

Allows users to specify custom VM types in the director config, with an option to replace the predefined vm types completely (current API behavior) or to add to the list of default VM types (better UX, in my opinion)