### PR TITLE
Pivnet Token optional when using download source

### DIFF
--- a/acceptance/download_product_test.go
+++ b/acceptance/download_product_test.go
@@ -52,7 +52,6 @@ var _ = Describe("download-product command", func() {
 				tmpDir, err := ioutil.TempDir("", "")
 				Expect(err).ToNot(HaveOccurred())
 				command := exec.Command(pathToMain, "download-product",
-					"--pivnet-api-token", "token",
 					"--pivnet-file-glob", "example-product.pivotal",
 					"--pivnet-product-slug", "pivnet-example-slug",
 					"--product-version", "1.10.1",
@@ -85,7 +84,6 @@ var _ = Describe("download-product command", func() {
 
 				By("running the command again, it uses the cache")
 				command = exec.Command(pathToMain, "download-product",
-					"--pivnet-api-token", "token",
 					"--pivnet-file-glob", "*.pivotal",
 					"--pivnet-product-slug", "pivnet-example-slug",
 					"--product-version", "1.10.1",
@@ -118,7 +116,6 @@ var _ = Describe("download-product command", func() {
 				tmpDir, err := ioutil.TempDir("", "")
 				Expect(err).ToNot(HaveOccurred())
 				command := exec.Command(pathToMain, "download-product",
-					"--pivnet-api-token", "token",
 					"--pivnet-file-glob", "*.yml",
 					"--pivnet-product-slug", "example-product",
 					"--product-version", "1.10.1",
@@ -145,7 +142,6 @@ var _ = Describe("download-product command", func() {
 				tmpDir, err := ioutil.TempDir("", "")
 				Expect(err).ToNot(HaveOccurred())
 				command := exec.Command(pathToMain, "download-product",
-					"--pivnet-api-token", "token",
 					"--pivnet-file-glob", "*.yml",
 					"--pivnet-product-slug", "example-product",
 					"--product-version", "1.10.1",
@@ -170,7 +166,6 @@ var _ = Describe("download-product command", func() {
 				tmpDir, err := ioutil.TempDir("", "")
 				Expect(err).ToNot(HaveOccurred())
 				command := exec.Command(pathToMain, "download-product",
-					"--pivnet-api-token", "token",
 					"--pivnet-file-glob", "*.yml",
 					"--pivnet-product-slug", "example-product",
 					"--product-version", "1.10.1",
@@ -196,7 +191,6 @@ var _ = Describe("download-product command", func() {
 				tmpDir, err := ioutil.TempDir("", "")
 				Expect(err).ToNot(HaveOccurred())
 				command := exec.Command(pathToMain, "download-product",
-					"--pivnet-api-token", "token",
 					"--pivnet-file-glob", "*.yml",
 					"--pivnet-product-slug", "example-product",
 					"--product-version", "1.10.1",
@@ -228,7 +222,6 @@ var _ = Describe("download-product command", func() {
 				tmpDir, err := ioutil.TempDir("", "")
 				Expect(err).ToNot(HaveOccurred())
 				command := exec.Command(pathToMain, "download-product",
-					"--pivnet-api-token", "token",
 					"--pivnet-file-glob", "*.yml",
 					"--pivnet-product-slug", "example-product",
 					"--product-version", "1.10.1",
@@ -258,7 +251,6 @@ var _ = Describe("download-product command", func() {
 				tmpDir, err := ioutil.TempDir("", "")
 				Expect(err).ToNot(HaveOccurred())
 				command := exec.Command(pathToMain, "download-product",
-					"--pivnet-api-token", "token",
 					"--pivnet-file-glob", "*.yml",
 					"--pivnet-product-slug", "example-product",
 					"--product-version", "1.10.1",
@@ -297,7 +289,6 @@ var _ = Describe("download-product command", func() {
 				tmpDir, err := ioutil.TempDir("", "")
 				Expect(err).ToNot(HaveOccurred())
 				command := exec.Command(pathToMain, "download-product",
-					"--pivnet-api-token", "token",
 					"--pivnet-file-glob", "*.yml",
 					"--pivnet-product-slug", "example-product",
 					"--product-version", "1.10.1",
@@ -327,7 +318,6 @@ var _ = Describe("download-product command", func() {
 				tmpDir, err := ioutil.TempDir("", "")
 				Expect(err).ToNot(HaveOccurred())
 				command := exec.Command(pathToMain, "download-product",
-					"--pivnet-api-token", "token",
 					"--pivnet-file-glob", "*.yml",
 					"--pivnet-product-slug", "example-product",
 					"--product-version-regex", "1.*",

--- a/commands/download_product.go
+++ b/commands/download_product.go
@@ -44,7 +44,7 @@ type DownloadProductOptions struct {
 	PivnetFileGlob      string   `long:"pivnet-file-glob"      short:"f"  description:"glob to match files within Pivotal Network product to be downloaded." required:"true"`
 	PivnetProductSlug   string   `long:"pivnet-product-slug"   short:"p"  description:"path to product" required:"true"`
 	PivnetDisableSSL    bool     `long:"pivnet-disable-ssl"               description:"whether to disable ssl validation when contacting the Pivotal Network"`
-	PivnetToken         string   `long:"pivnet-api-token"      short:"t"  description:"API token to use when interacting with Pivnet. Can be retrieved from your profile page in Pivnet." required:"true"`
+	PivnetToken         string   `long:"pivnet-api-token"      short:"t"  description:"API token to use when interacting with Pivnet. Can be retrieved from your profile page in Pivnet."`
 	ProductVersion      string   `long:"product-version"       short:"v"  description:"version of the product-slug to download files from. Incompatible with --product-version-regex flag."`
 	ProductVersionRegex string   `long:"product-version-regex" short:"r"  description:"regex pattern matching versions of the product-slug to download files from. Highest-versioned match will be used. Incompatible with --product-version flag."`
 	S3Bucket            string   `long:"s3-bucket"                        description:"bucket name where the product resides in the s3 compatible blobstore"`
@@ -225,6 +225,10 @@ func (c *DownloadProduct) validate() error {
 	if c.Options.ProductVersionRegex == "" && c.Options.ProductVersion == "" {
 		return fmt.Errorf("no version information provided; please provide either --product-version or --product-version-regex")
 	}
+	if c.Options.PivnetToken == "" && c.Options.Source == "" {
+		return fmt.Errorf(`could not execute "download-product": could not parse download-product flags: missing required flag "--pivnet-api-token"`)
+	}
+
 	return nil
 }
 

--- a/commands/download_product_test.go
+++ b/commands/download_product_test.go
@@ -654,6 +654,21 @@ output-directory: %s
 			})
 		})
 
+		Context("when pivnet-api-token is missing while no source is set", func() {
+			It("returns an error", func() {
+				tempDir, err := ioutil.TempDir("", "om-tests-")
+				Expect(err).NotTo(HaveOccurred())
+
+				err = command.Execute([]string{
+					"--pivnet-file-glob", "*.pivotal",
+					"--pivnet-product-slug", "mayhem-crew",
+					"--product-version", `2.0.0`,
+					"--output-directory", tempDir,
+				})
+				Expect(err).To(MatchError(`could not execute "download-product": could not parse download-product flags: missing required flag "--pivnet-api-token"`))
+			})
+		})
+
 		Context("when both product-version and product-version-regex are set", func() {
 			It("fails with an error saying that the user must pick one or the other", func() {
 				tempDir, err := ioutil.TempDir("", "om-tests-")


### PR DESCRIPTION
Fixed #371 

* add validation to make `--pivnet-api-token` required if `source` is not specified and created test for it
* removed `--pivnet-api-token` from s3 download product acceptance test