### PR TITLE
Fix broken link to Platform Automation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ You can find them at
 
 **NOTE**: Additional documentation for om commands
 used in Pivotal Platform Automation
-can be found in [Pivotal Documentation](docs.pivotal.io/platform-automation).
+can be found in [Pivotal Documentation](https://docs.pivotal.io/platform-automation).
 
 ## Versioning
 


### PR DESCRIPTION
Also, why is this caveat even here? Can we document all the commands in one place? Is Platform Automation is not updating this list of commands with commands they add? Are the commands that aren’t used by platform automation unvalidated WIP? Can we delete the list?