### PR TITLE
bosh-env command does not resolve private key

### DIFF
--- a/commands/bosh_environment.go
+++ b/commands/bosh_environment.go
@@ -2,6 +2,8 @@ package commands
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -98,7 +100,7 @@ func (be BoshEnvironment) Execute(args []string) error {
 	variables["CREDHUB_CA_CERT"] = boshCACerts
 
 	if be.Options.SSHPrivateKey != "" {
-		variables["BOSH_ALL_PROXY"] = fmt.Sprintf("ssh+socks5://ubuntu@%s:22?private-key=%s", be.Target(), be.Options.SSHPrivateKey)
+		variables["BOSH_ALL_PROXY"] = fmt.Sprintf("ssh+socks5://ubuntu@%s:22?private-key=%s", be.Target(), getKeyFilePath(be.Options.SSHPrivateKey))
 		variables["CREDHUB_PROXY"] = variables["BOSH_ALL_PROXY"]
 	}
 	be.renderVariables(renderer, variables)
@@ -118,4 +120,20 @@ func (be BoshEnvironment) renderVariables(renderer renderers.Renderer, variables
 	for k, v := range variables {
 		be.logger.Println(renderer.RenderEnvironmentVariable(k, v))
 	}
+}
+
+// Get the absolute path of a key file. Because we currently do no checking to see if the private key exists, if it doesn't, emulate existing behavior.
+func getKeyFilePath(s string) string {
+	f, err := os.Open(s)
+	if err != nil {
+		return s
+	}
+	defer f.Close()
+
+	p, err := filepath.Abs(f.Name())
+	if err != nil {
+		return s
+	}
+
+	return p
 }

--- a/commands/bosh_environment_test.go
+++ b/commands/bosh_environment_test.go
@@ -2,6 +2,9 @@ package commands_test
 
 import (
 	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/pivotal-cf/jhanda"
@@ -80,12 +83,60 @@ var _ = Describe("bosh-env", func() {
 			fakeRendererFactory.CreateReturns(renderers.NewPosix(), nil)
 		})
 
-		Describe("Execute without ssh key", func() {
+		Describe("Execute with a nonexistent ssh key", func() {
 			It("executes the API call", func() {
 				err := command.Execute([]string{"-i", "somepath.pem"})
 
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(stdout.PrintlnCallCount()).To(Equal(10))
+				for i := 0; i < 10; i++ {
+					value := fmt.Sprintf("%v", stdout.PrintlnArgsForCall(i))
+					if strings.Contains(value, "BOSH_ALL_PROXY") {
+						Expect(value).To(Equal("[export BOSH_ALL_PROXY=ssh+socks5://ubuntu@opsman.pivotal.io:22?private-key=somepath.pem]"))
+					}
+				}
+			})
+		})
+
+		Describe("Execute with a real ssh key", func() {
+			var keyFile string
+			var f *os.File
+			var err error
+
+			BeforeEach(func() {
+				os.Mkdir("./tmp", os.ModePerm)
+				f, err = ioutil.TempFile("./tmp", "opsmankey-*.pem")
+				Expect(err).NotTo(HaveOccurred())
+
+				keyFile, err = filepath.Abs(f.Name())
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			AfterEach(func() {
+				os.RemoveAll("./tmp")
+			})
+
+			It("Resolves to the absolute path", func() {
+				wd, err := os.Getwd()
+				Expect(err).NotTo(HaveOccurred())
+				defer func() {
+					err = os.Chdir(wd)
+					Expect(err).NotTo(HaveOccurred())
+				}()
+
+				err = os.Chdir("./tmp")
+				Expect(err).NotTo(HaveOccurred())
+
+				err = command.Execute([]string{"-i", filepath.Base(keyFile)})
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(stdout.PrintlnCallCount()).To(Equal(10))
+				for i := 0; i < 10; i++ {
+					value := fmt.Sprintf("%v", stdout.PrintlnArgsForCall(i))
+					if strings.Contains(value, "BOSH_ALL_PROXY") {
+						Expect(value).To(Equal(fmt.Sprintf("[export BOSH_ALL_PROXY=ssh+socks5://ubuntu@opsman.pivotal.io:22?private-key=%s]", keyFile)))
+					}
+				}
+
 			})
 		})
 


### PR DESCRIPTION
Right now, `om bosh-env -i keyname` does no checking if a private key
is valid or not. That, in and of itself, is not a big deal, but it also
doesn't create an absolute path to the key. This PR addresses that. When
specifying a key via `-i` it will attempt to open the file, and if it
is successful, will use its absolute path in `BOSH_ALL_PROXY` and
`CREDHUB_PROXY`. If the file is not openable, it uses just the provided
string, to provide backwards behavior compatibility.