### PR TITLE
Enforce minimum TLS version of 1.2

### DIFF
--- a/network/oauth_client.go
+++ b/network/oauth_client.go
@@ -47,6 +47,7 @@ func NewOAuthClient(target, username, password string, clientID, clientSecret st
 			Proxy: http.ProxyFromEnvironment,
 			TLSClientConfig: &tls.Config{
 				InsecureSkipVerify: insecureSkipVerify,
+				MinVersion: tls.VersionTLS12,
 			},
 			Dial: (&net.Dialer{
 				Timeout:   connectTimeout,


### PR DESCRIPTION
- current Ops Manager implementations should support TLS 1.2