### PR TITLE
update pivnet-cli + go-pivnet

### DIFF
--- a/configtemplate/metadata/pivnet.go
+++ b/configtemplate/metadata/pivnet.go
@@ -30,7 +30,11 @@ func NewPivnetProvider(host, token, slug, version, glob string) Provider {
 	ts := pivnetapi.NewAccessTokenOrLegacyToken(token, config.Host, config.UserAgent)
 	ls := logshim.NewLogShim(logger, logger, false)
 	client := pivnetapi.NewClient(ts, config, ls)
-	pivnetAuthClient := AuthenticatedPivnetClient{ClientConfig: config, HTTPClient: client.HTTP}
+	pivnetAuthClient := AuthenticatedPivnetClient{
+		TokenService: ts,
+		ClientConfig: config,
+		HTTPClient:   client.HTTP,
+	}
 	return &PivnetProvider{
 		client:           client,
 		pivnetAuthClient: pivnetAuthClient,

--- a/download_clients/pivnet_client_test.go
+++ b/download_clients/pivnet_client_test.go
@@ -3,6 +3,8 @@ package download_clients_test
 import (
 	"errors"
 	"fmt"
+	"io/ioutil"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/pivotal-cf/go-pivnet"
@@ -11,7 +13,6 @@ import (
 	"github.com/pivotal-cf/om/commands"
 	"github.com/pivotal-cf/om/download_clients"
 	"github.com/pivotal-cf/om/download_clients/fakes"
-	"io/ioutil"
 )
 
 var _ = Describe("PivnetClient", func() {
@@ -32,7 +33,7 @@ var _ = Describe("PivnetClient", func() {
 				createRelease("2.0.0"),
 			}, nil)
 
-			fakePivnetFactory := func(config pivnet.ClientConfig, logger log.Logger) download_clients.PivnetDownloader {
+			fakePivnetFactory := func(ts pivnet.AccessTokenService, config pivnet.ClientConfig, logger log.Logger) download_clients.PivnetDownloader {
 				return fakePivnetDownloader
 			}
 
@@ -51,13 +52,13 @@ var _ = Describe("PivnetClient", func() {
 			fakePivnetDownloader *fakes.PivnetDownloader
 			fakePivnetFilter     *fakes.PivnetFilter
 			logger               = &loggerfakes.FakeLogger{}
-			fakePivnetFactory    func(config pivnet.ClientConfig, logger log.Logger) download_clients.PivnetDownloader
+			fakePivnetFactory    func(ts pivnet.AccessTokenService, config pivnet.ClientConfig, logger log.Logger) download_clients.PivnetDownloader
 		)
 
 		BeforeEach(func() {
 			fakePivnetDownloader = &fakes.PivnetDownloader{}
 			fakePivnetFilter = &fakes.PivnetFilter{}
-			fakePivnetFactory = func(config pivnet.ClientConfig, logger log.Logger) download_clients.PivnetDownloader {
+			fakePivnetFactory = func(ts pivnet.AccessTokenService, config pivnet.ClientConfig, logger log.Logger) download_clients.PivnetDownloader {
 				return fakePivnetDownloader
 			}
 		})
@@ -152,13 +153,13 @@ var _ = Describe("PivnetClient", func() {
 			fakePivnetDownloader *fakes.PivnetDownloader
 			fakePivnetFilter     *fakes.PivnetFilter
 			logger               = &loggerfakes.FakeLogger{}
-			fakePivnetFactory    func(config pivnet.ClientConfig, logger log.Logger) download_clients.PivnetDownloader
+			fakePivnetFactory    func(ts pivnet.AccessTokenService, config pivnet.ClientConfig, logger log.Logger) download_clients.PivnetDownloader
 		)
 
 		BeforeEach(func() {
 			fakePivnetDownloader = &fakes.PivnetDownloader{}
 			fakePivnetFilter = &fakes.PivnetFilter{}
-			fakePivnetFactory = func(config pivnet.ClientConfig, logger log.Logger) download_clients.PivnetDownloader {
+			fakePivnetFactory = func(ts pivnet.AccessTokenService, config pivnet.ClientConfig, logger log.Logger) download_clients.PivnetDownloader {
 				return fakePivnetDownloader
 			}
 		})
@@ -191,14 +192,14 @@ var _ = Describe("PivnetClient", func() {
 			fakePivnetDownloader     *fakes.PivnetDownloader
 			fakePivnetFilter         *fakes.PivnetFilter
 			logger                   = &loggerfakes.FakeLogger{}
-			fakePivnetFactory        func(config pivnet.ClientConfig, logger log.Logger) download_clients.PivnetDownloader
+			fakePivnetFactory        func(ts pivnet.AccessTokenService, config pivnet.ClientConfig, logger log.Logger) download_clients.PivnetDownloader
 			errorTemplateForStemcell = "versioning of stemcell dependency in unexpected format: \"major.minor\" or \"major\". the following version could not be parsed: %s"
 		)
 
 		BeforeEach(func() {
 			fakePivnetDownloader = &fakes.PivnetDownloader{}
 			fakePivnetFilter = &fakes.PivnetFilter{}
-			fakePivnetFactory = func(config pivnet.ClientConfig, logger log.Logger) download_clients.PivnetDownloader {
+			fakePivnetFactory = func(ts pivnet.AccessTokenService, config pivnet.ClientConfig, logger log.Logger) download_clients.PivnetDownloader {
 				return fakePivnetDownloader
 			}
 		})

--- a/go.mod
+++ b/go.mod
@@ -26,10 +26,10 @@ require (
 	github.com/olekukonko/tablewriter v0.0.0-20180912035003-be2c049b30cc
 	github.com/onsi/ginkgo v1.8.0
 	github.com/onsi/gomega v1.4.2
-	github.com/pivotal-cf/go-pivnet v0.0.53
+	github.com/pivotal-cf/go-pivnet v1.0.3
 	github.com/pivotal-cf/jhanda v0.0.0-20180509215011-1b5ae1681a45
 	github.com/pivotal-cf/kiln v0.0.0-20180329191310-9c0f5ac8553d
-	github.com/pivotal-cf/pivnet-cli v0.0.56
+	github.com/pivotal-cf/pivnet-cli v0.0.59
 	github.com/pivotal/uilive v0.0.0-20181204013807-921d4ab784bd
 	github.com/pkg/errors v0.8.0
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -93,6 +93,9 @@ github.com/pivotal-cf/go-pivnet v0.0.50 h1:E7MIsoKyIQcyH6vXd9cWDZRBeDdRhmqEWicZc
 github.com/pivotal-cf/go-pivnet v0.0.50/go.mod h1:rvEzWli4NJQhX7Z3z0DiEQXsPwC+uE//eIKcpl7S1as=
 github.com/pivotal-cf/go-pivnet v0.0.53 h1:m2hFasKAI66MGKQzCGUP7oaG7xFClni2ruxmMLvkjP8=
 github.com/pivotal-cf/go-pivnet v0.0.53/go.mod h1:rvEzWli4NJQhX7Z3z0DiEQXsPwC+uE//eIKcpl7S1as=
+github.com/pivotal-cf/go-pivnet v1.0.2/go.mod h1:rvEzWli4NJQhX7Z3z0DiEQXsPwC+uE//eIKcpl7S1as=
+github.com/pivotal-cf/go-pivnet v1.0.3 h1:rbv/u22FQHMpYy5CQPrCdlqNi+76WyZLGTieAJPl/wM=
+github.com/pivotal-cf/go-pivnet v1.0.3/go.mod h1:rvEzWli4NJQhX7Z3z0DiEQXsPwC+uE//eIKcpl7S1as=
 github.com/pivotal-cf/jhanda v0.0.0-20180509215011-1b5ae1681a45 h1:XV6cKoKxmQVtsAZ1HDaWve4zBKeIkcDDE6Y891nN5Cs=
 github.com/pivotal-cf/jhanda v0.0.0-20180509215011-1b5ae1681a45/go.mod h1:GNr2RBRX0Gs2FaJRi4KUrfQV32EhnjQ3Fj+nw87cx08=
 github.com/pivotal-cf/kiln v0.0.0-20180329191310-9c0f5ac8553d h1:Hv1DF96jUOtFUy5mrPAm23veIRtHkKzqlMMKFwBfni0=
@@ -101,12 +104,15 @@ github.com/pivotal-cf/pivnet-cli v0.0.55 h1:R8mnLHUVb9DWuVqHdmkLCltG7bUTJq9nj5Oe
 github.com/pivotal-cf/pivnet-cli v0.0.55/go.mod h1:GIenTUfi8rXtvDXnOuUMfQ+ZofegQ+7XG2Hby3jB0+4=
 github.com/pivotal-cf/pivnet-cli v0.0.56 h1:cws7R1kQAbsbYxs4MYBE8Fy129H9ZPsVjucO/sgQ6QI=
 github.com/pivotal-cf/pivnet-cli v0.0.56/go.mod h1:7hHhYsGEpg7AqcEzBI7ASPjtnkgcVcaTyjw7JDLKoMM=
+github.com/pivotal-cf/pivnet-cli v0.0.59 h1:kebrE5/E6LjzTPKocQn34z+kuuim8OiH7o1tvVxDqOA=
+github.com/pivotal-cf/pivnet-cli v0.0.59/go.mod h1:CbzDLuWiX1kDWOrQR9cDhuI4f4+rtvaE+Bqwtu30TyQ=
 github.com/pivotal/uilive v0.0.0-20181204013807-921d4ab784bd h1:naqv5wnPWCvb6o2nYbygTQZlhetOm3e6RTPueq4AFX4=
 github.com/pivotal/uilive v0.0.0-20181204013807-921d4ab784bd/go.mod h1:j8LyeJ7/0GbbwookzCmmFyCoRKp1WBwV/xxlebLz9UM=
 github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/robdimsdale/sanitizer v0.0.0-20160522134901-ab2334cb7539 h1:h3AVw1v3JIE9Y1HyjYyiPTG73ywlF4754oiIjkxPjNk=
 github.com/robdimsdale/sanitizer v0.0.0-20160522134901-ab2334cb7539/go.mod h1:tqCODtkKV+9Tfvt9JURvKCTxJ69bA/OU/QhsaQLK/rc=
 github.com/shirou/gopsutil v0.0.0-20180927124308-a11c78ba2c13 h1:hzFIj+Ky1KX599VGAVY//20nam1rYKwQwNVix1sYhXo=
 github.com/shirou/gopsutil v0.0.0-20180927124308-a11c78ba2c13/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=


### PR DESCRIPTION
This PR updates go-pivnet which resulted in a pivnet-cli update.
The motivation for this PR is to have https://github.com/pivotal-cf/go-pivnet/pull/26 available. 