### PR TITLE
Update om/docs/EXAMPLE.md

### DIFF
--- a/docs/EXAMPLE.md
+++ b/docs/EXAMPLE.md
@@ -173,6 +173,7 @@ om \
   --user my-user \
   --password my-password \
     configure-product \
+      --product-name some-product \
       --config product.yml
 ```
 


### PR DESCRIPTION
The example of using `om configure-product` was incorrect. It did not use `--product-name` which is a required argument, so you get an error when following the doc's example.