### PR TITLE
updated reference command to correct flag

### DIFF
--- a/docs/EXAMPLE.md
+++ b/docs/EXAMPLE.md
@@ -37,7 +37,7 @@ More documentation for the `configure-director` command along with IAAS-specific
 ```shell
 om \
   --target https://opsman.example.com \
-  --user my-user \
+  --username my-user \
   --password my-password \
     configure-director \
       --config director.yml


### PR DESCRIPTION
OM CLI uses --username instead of --user for configure-authentication command. this update corrects the documentation to show proper flag