### PR TITLE
Add --force-vm-extensions to configure-product

### DIFF
--- a/api/jobs_service.go
+++ b/api/jobs_service.go
@@ -19,7 +19,7 @@ type JobProperties struct {
 	Pre27NSXSecurityGroups []string     `json:"nsx_security_groups,omitempty" yaml:"nsx_security_groups,omitempty"`
 	Pre27NSXLBS            []Pre27NSXLB `json:"nsx_lbs,omitempty" yaml:"nsx_lbs,omitempty"`
 	FloatingIPs            string       `json:"floating_ips,omitempty" yaml:"floating_ips,omitempty"`
-	AdditionalVMExtensions []string     `json:"additional_vm_extensions,omitempty" yaml:"additional_vm_extensions,omitempty"`
+	AdditionalVMExtensions interface{}  `json:"additional_vm_extensions,omitempty" yaml:"additional_vm_extensions,omitempty"`
 }
 
 type NSX struct {

--- a/commands/expiring_certificates_test.go
+++ b/commands/expiring_certificates_test.go
@@ -3,11 +3,12 @@ package commands_test
 import (
 	"errors"
 	"fmt"
-	"github.com/pivotal-cf/jhanda"
 	"log"
 	"regexp"
 	"strings"
 	"time"
+
+	"github.com/pivotal-cf/jhanda"
 
 	"github.com/pivotal-cf/om/api"
 	"github.com/pivotal-cf/om/commands"
@@ -139,7 +140,15 @@ var _ = Describe("ExpiringCertificates", func() {
 			err = command.Execute([]string{})
 			Expect(err).To(HaveOccurred())
 
+			// Regexp to remove ANSI color codes taken from https://superuser.com/a/380778
+			decolorize, err := regexp.Compile(`\x1b[[0-9;]*m`)
+			Expect(err).NotTo(HaveOccurred())
+
 			contents := strings.Split(string(stdout.Contents()), "\n")
+			for i := range contents {
+				contents[i] = decolorize.ReplaceAllLiteralString(contents[i], "")
+			}
+
 			Expect(contents).To(ConsistOf(
 				"Getting expiring certificates...",
 				"[X] Credhub Location",

--- a/docs/configure-product/README.md
+++ b/docs/configure-product/README.md
@@ -25,6 +25,7 @@ Usage: om [options] configure-product [<args>]
 
 Command Arguments:
   --config, -c              string             path to yml file containing all config fields (see docs/configure-product/README.md for format)
+  --force-vm-extensions     bool               If additional_vm_extensions is set to [] in a job's resource configuration, all VM extensions will be deleted from the job
   --ops-file, -o            string (variadic)  YAML operations file
   --vars-env                string (variadic)  Load variables from environment variables (e.g.: 'MY' to load MY_var=value)
   --vars-file, -l           string (variadic)  Load variables from a YAML file
@@ -132,3 +133,12 @@ for use with Ops Manager 2.5 and after, or you will see this error:
 ```json
 {"errors":["Availability zones cannot find availability zone with name null"]}
 ```
+
+#### Using `--force-vm-extensions` to remove VM extensions from a job
+
+By default, if `additional_vm_extensions` is omitted or set to an empty list on a given job's resource configuration, 
+the VM extensions will not be altered. However, in all other cases, you are expected to pass a complete list of VM extensions
+to a job, and any extensions that exist on the job but not in the configuration will be deleted.
+
+If you specify `--force-vm-extensions` in your `configure-product` command AND the job's resource config has `additional_vm_extensions: []`,
+it will delete all extensions from the job. If `additional_vm_extensions` is omitted, extensions will not be changed.


### PR DESCRIPTION
If set, this flag will delete all VM extensions from a given job's resource config, if additional_vm_extensions` is explicitly set to `[]`. If the flag or `additional_vm_extensions` is missing, then the existing VM Extensions will not be affected.

Resolves #400.