### PR TITLE
Add `exclude-version` flag to `config-template`

### DIFF
--- a/commands/config_template.go
+++ b/commands/config_template.go
@@ -2,22 +2,24 @@ package commands
 
 import (
 	"fmt"
+	"os"
+
 	"github.com/pivotal-cf/go-pivnet"
 	"github.com/pivotal-cf/jhanda"
 	"github.com/pivotal-cf/om/configtemplate/generator"
 	"github.com/pivotal-cf/om/configtemplate/metadata"
-	"os"
 )
 
 type ConfigTemplate struct {
 	environFunc   func() []string
 	buildProvider buildProvider
 	Options       struct {
-		OutputDirectory   string `long:"output-directory" required:"true"`
-		PivnetApiToken    string `long:"pivnet-api-token" required:"true"`
-		PivnetProductSlug string `long:"pivnet-product-slug" required:"true"`
-		ProductVersion    string `long:"product-version" required:"true"`
-		ProductFileGlob   string `long:"product-file-glob" default:"*.pivotal"`
+		OutputDirectory   string `long:"output-directory"    description:"a directory to create templates under. must already exist."                       required:"true"`
+		PivnetApiToken    string `long:"pivnet-api-token"                                                                                                   required:"true"`
+		PivnetProductSlug string `long:"pivnet-product-slug" description:"the product name in pivnet"                                                       required:"true"`
+		ProductVersion    string `long:"product-version"     description:"the version of the product from which to generate a template"                     required:"true"`
+		ProductFileGlob   string `long:"product-file-glob"   description:"a glob to match exactly one file in the pivnet product slug"  default:"*.pivotal" `
+		ExcludeVersion    bool   `long:"exclude-version"     description:"if set, will not output a version-specific directory"`
 	}
 }
 
@@ -72,7 +74,7 @@ func (c *ConfigTemplate) Execute(args []string) error {
 	return generator.NewExecutor(
 		metadataBytes,
 		c.Options.OutputDirectory,
-		false,
+		c.Options.ExcludeVersion,
 		true,
 	).Generate()
 }

--- a/commands/expiring_certificates_test.go
+++ b/commands/expiring_certificates_test.go
@@ -3,11 +3,12 @@ package commands_test
 import (
 	"errors"
 	"fmt"
-	"github.com/pivotal-cf/jhanda"
 	"log"
 	"regexp"
 	"strings"
 	"time"
+
+	"github.com/pivotal-cf/jhanda"
 
 	"github.com/pivotal-cf/om/api"
 	"github.com/pivotal-cf/om/commands"
@@ -177,7 +178,7 @@ var _ = Describe("ExpiringCertificates", func() {
 			Expect(service.ListExpiringCertificatesArgsForCall(0)).To(Equal("5w"))
 		})
 
-		FIt("validates the ExpiresWithin value as d,w,m,or y when passed", func() {
+		It("validates the ExpiresWithin value as d,w,m,or y when passed", func() {
 			command := commands.NewExpiringCertificates(service, logger)
 			err := command.Execute([]string{
 				"--expires-within",

--- a/configtemplate/generator/execute.go
+++ b/configtemplate/generator/execute.go
@@ -38,9 +38,9 @@ func (e *Executor) Generate() error {
 
 	productName := metadata.ProductName()
 
-	targetDirectory := e.baseDirectory
-	if !e.doNotIncludeProductVersion { //always happens
-		targetDirectory = path.Join(e.baseDirectory, productName, productVersion)
+	targetDirectory := path.Join(e.baseDirectory, productName)
+	if !e.doNotIncludeProductVersion {
+		targetDirectory = path.Join(targetDirectory, productVersion)
 	}
 	if err = e.createDirectory(targetDirectory); err != nil {
 		return err


### PR DESCRIPTION
Resolves #391. Adds `--exclude-version` to `config-template` which
will result in a config template being generated in `/basedir/product-name`
instead of `/basedir/product-name/version`.

In addition, fe0d3f6 removes a `FIt` test that was accidentally checked in with the previous commit