### PR TITLE
Add max in flight to config-template

### DIFF
--- a/configtemplate/generator/resource_config.go
+++ b/configtemplate/generator/resource_config.go
@@ -9,6 +9,7 @@ type Resource struct {
 	InstanceType   InstanceType    `yaml:"instance_type,omitempty"`
 	Instances      interface{}     `yaml:"instances,omitempty"`
 	PersistentDisk *PersistentDisk `yaml:"persistent_disk,omitempty"`
+	MaxInFlight    interface{}     `yaml:"max_in_flight"`
 }
 
 type InstanceType struct {
@@ -47,8 +48,9 @@ func CreateResource(jobName string, job jobtype) Resource {
 		resource.PersistentDisk = &PersistentDisk{
 			Size: fmt.Sprintf("((%s_persistent_disk_size))", jobName),
 		}
-
 	}
+	resource.MaxInFlight = fmt.Sprintf("((%s_max_in_flight))", jobName)
+
 	return resource
 }
 
@@ -71,6 +73,7 @@ func AddResourceVars(jobName string, job jobtype, vars map[string]interface{}) {
 	if job.HasPersistentDisk() {
 		vars[fmt.Sprintf("%s_persistent_disk_size", jobName)] = "automatic"
 	}
+	vars[fmt.Sprintf("%s_max_in_flight", jobName)] = 1
 }
 
 func determineJobName(jobName string) string {

--- a/configtemplate/generator/resource_config.go
+++ b/configtemplate/generator/resource_config.go
@@ -73,7 +73,7 @@ func AddResourceVars(jobName string, job jobtype, vars map[string]interface{}) {
 	if job.HasPersistentDisk() {
 		vars[fmt.Sprintf("%s_persistent_disk_size", jobName)] = "automatic"
 	}
-	vars[fmt.Sprintf("%s_max_in_flight", jobName)] = 1
+	vars[fmt.Sprintf("%s_max_in_flight", jobName)] = "default"
 }
 
 func determineJobName(jobName string) string {

--- a/configtemplate/generator/resource_config_test.go
+++ b/configtemplate/generator/resource_config_test.go
@@ -12,11 +12,13 @@ var withPersistentDisk = `instance_type:
   id: ((myjob_instance_type))
 instances: ((myjob_instances))
 persistent_disk:
-  size_mb: ((myjob_persistent_disk_size))`
+  size_mb: ((myjob_persistent_disk_size))
+max_in_flight: ((myjob_max_in_flight))`
 
 var withoutPersistentDisk = `instance_type:
   id: ((myjob_instance_type))
-instances: ((myjob_instances))`
+instances: ((myjob_instances))
+max_in_flight: ((myjob_max_in_flight))`
 
 var _ = Describe("Resource Config", func() {
 	Context("CreateResourceConfig", func() {
@@ -37,7 +39,9 @@ var _ = Describe("Resource Config", func() {
 			Expect(resourceConfig).ToNot(BeNil())
 			Expect(len(resourceConfig)).Should(Equal(2))
 			Expect(resourceConfig).Should(HaveKey("job1"))
+			Expect(resourceConfig["job1"].MaxInFlight).Should(Not(BeNil()))
 			Expect(resourceConfig).Should(HaveKey("job2"))
+			Expect(resourceConfig["job2"].MaxInFlight).Should(Not(BeNil()))
 		})
 	})
 	Context("CreateResource", func() {


### PR DESCRIPTION
Because `staged-config` returns `max_in_flight` settings now on the `resource-config`, `config-template` should as well.