### PR TITLE
Modify behavior of om interpolate's interactions with config files and stdin

### DIFF
--- a/commands/interpolate.go
+++ b/commands/interpolate.go
@@ -65,7 +65,7 @@ func (c Interpolate) Execute(args []string) error {
 
 		c.Options.ConfigFile = tempFile.Name()
 
-	} else if len(c.Options.ConfigFile) == 0 {
+	} else if len(c.Options.ConfigFile) == 0 || c.Options.ConfigFile == "-" {
 		return fmt.Errorf("no file or STDIN input provided. Please provide a valid --config file or use a pipe to get STDIN")
 	}
 

--- a/commands/interpolate_test.go
+++ b/commands/interpolate_test.go
@@ -253,6 +253,15 @@ hello: world`))
 			})
 		})
 
+		When("no stdin provided and --config -", func() {
+			It("errors", func() {
+				command = commands.NewInterpolate(func() []string { return nil }, logger, os.Stdin)
+				err := command.Execute([]string{"--config", "-"})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("no file or STDIN input provided."))
+			})
+		})
+
 		When("the config is passed via stdin with no config flag", func() {
 			It("uses stdin", func() {
 				err := command.Execute([]string{})

--- a/main.go
+++ b/main.go
@@ -190,7 +190,7 @@ func main() {
 	commandSet["import-installation"] = commands.NewImportInstallation(form, api, global.DecryptionPassphrase, stdout)
 	commandSet["installation-log"] = commands.NewInstallationLog(api, stdout)
 	commandSet["installations"] = commands.NewInstallations(api, presenter)
-	commandSet["interpolate"] = commands.NewInterpolate(os.Environ, stdout)
+	commandSet["interpolate"] = commands.NewInterpolate(os.Environ, stdout, os.Stdin)
 	commandSet["pending-changes"] = commands.NewPendingChanges(presenter, api)
 	commandSet["pre-deploy-check"] = commands.NewPreDeployCheck(presenter, api, stdout)
 	commandSet["regenerate-certificates"] = commands.NewRegenerateCertificates(api, stdout)


### PR DESCRIPTION
This PR resolves #418 in the method described in the issue. The behavior now is as listed below in order of precedence:

| `--config` | `stdin` | behavior |
| --- | --- | --- |
| regular file | any | `--config` parameter is used |
| `-` | present | `stdin` is used |
| not present | present | `stdin` is used |
| `-` | not present | error |
| not present | not present | error |