### PR TITLE
Add tests for om update-ssl-certificate with config/vars

### DIFF
--- a/commands/loadConfigFile.go
+++ b/commands/loadConfigFile.go
@@ -2,11 +2,12 @@ package commands
 
 import (
 	"fmt"
+	"reflect"
+	"strconv"
+
 	"github.com/pivotal-cf/jhanda"
 	"github.com/pivotal-cf/om/interpolate"
 	"gopkg.in/yaml.v2"
-	"reflect"
-	"strconv"
 )
 
 // Load the config file, (optionally) load the vars file, vars env as well

--- a/commands/update_ssl_certificate.go
+++ b/commands/update_ssl_certificate.go
@@ -1,59 +1,59 @@
 package commands
 
 import (
-    "fmt"
-    "os"
+	"fmt"
 
-    "github.com/pivotal-cf/jhanda"
-    "github.com/pivotal-cf/om/api"
+	"github.com/pivotal-cf/jhanda"
+	"github.com/pivotal-cf/om/api"
 )
 
 type UpdateSSLCertificate struct {
-    service updateSSLCertificateService
-    logger  logger
-    Options struct {
-        CertPem    string   `long:"certificate-pem" required:"true" description:"certificate"`
-        PrivateKey string   `long:"private-key-pem" required:"true" description:"private key"`
-        ConfigFile string   `long:"config"                short:"c"                    description:"path to yml file for configuration (keys must match the following command line flags)"`
-        VarsEnv    []string `long:"vars-env" env:"OM_VARS_ENV" experimental:"true"     description:"load vars from environment variables by specifying a prefix (e.g.: 'MY' to load MY_var=value)"`
-        VarsFile   []string `long:"vars-file"                                          description:"Load variables from a YAML file"`
-        Vars       []string `long:"var"                                                description:"Load variable from the command line. Format: VAR=VAL"`
-    }
+	service     updateSSLCertificateService
+	logger      logger
+	environFunc func() []string
+	Options     struct {
+		CertPem    string   `long:"certificate-pem" required:"true" description:"certificate text"`
+		PrivateKey string   `long:"private-key-pem" required:"true" description:"private key text"`
+		ConfigFile string   `long:"config"                short:"c"                    description:"path to yml file for configuration (keys must match the following command line flags)"`
+		VarsEnv    []string `long:"vars-env" env:"OM_VARS_ENV" experimental:"true"     description:"load vars from environment variables by specifying a prefix (e.g.: 'MY' to load MY_var=value)"`
+		VarsFile   []string `long:"vars-file"                                          description:"Load variables from a YAML file"`
+		Vars       []string `long:"var"                                                description:"Load variable from the command line. Format: VAR=VAL"`
+	}
 }
 
 //counterfeiter:generate -o ./fakes/update_ssl_certificate_service.go --fake-name UpdateSSLCertificateService . updateSSLCertificateService
 type updateSSLCertificateService interface {
-    UpdateSSLCertificate(api.SSLCertificateInput) error
+	UpdateSSLCertificate(api.SSLCertificateInput) error
 }
 
-func NewUpdateSSLCertificate(service updateSSLCertificateService, logger logger) UpdateSSLCertificate {
-    return UpdateSSLCertificate{service: service, logger: logger}
+func NewUpdateSSLCertificate(environFunc func() []string, service updateSSLCertificateService, logger logger) UpdateSSLCertificate {
+	return UpdateSSLCertificate{environFunc: environFunc, service: service, logger: logger}
 }
 
 func (c UpdateSSLCertificate) Execute(args []string) error {
-    err := loadConfigFile(args, &c.Options, os.Environ)
-    if err != nil {
-        return fmt.Errorf("could not parse update-ssl-certificate flags: %s", err)
-    }
+	err := loadConfigFile(args, &c.Options, c.environFunc)
+	if err != nil {
+		return fmt.Errorf("could not parse update-ssl-certificate flags: %s", err)
+	}
 
-    err = c.service.UpdateSSLCertificate(api.SSLCertificateInput{
-        CertPem:       c.Options.CertPem,
-        PrivateKeyPem: c.Options.PrivateKey,
-    })
-    if err != nil {
-        return err
-    }
+	err = c.service.UpdateSSLCertificate(api.SSLCertificateInput{
+		CertPem:       c.Options.CertPem,
+		PrivateKeyPem: c.Options.PrivateKey,
+	})
+	if err != nil {
+		return err
+	}
 
-    c.logger.Printf("Successfully applied custom SSL Certificate.\n")
-    c.logger.Printf("Please allow about 1 min for the new certificate to take effect.\n")
+	c.logger.Printf("Successfully applied custom SSL Certificate.\n")
+	c.logger.Printf("Please allow about 1 min for the new certificate to take effect.\n")
 
-    return nil
+	return nil
 }
 
 func (c UpdateSSLCertificate) Usage() jhanda.Usage {
-    return jhanda.Usage{
-        Description:      "This authenticated command updates the SSL Certificate on the Ops Manager with the given cert and key",
-        ShortDescription: "updates the SSL Certificate on the Ops Manager",
-        Flags:            c.Options,
-    }
+	return jhanda.Usage{
+		Description:      "This authenticated command updates the SSL Certificate on the Ops Manager with the given cert and key",
+		ShortDescription: "updates the SSL Certificate on the Ops Manager",
+		Flags:            c.Options,
+	}
 }

--- a/main.go
+++ b/main.go
@@ -205,7 +205,7 @@ func main() {
 	commandSet["staged-products"] = commands.NewStagedProducts(presenter, api)
 	commandSet["tile-metadata"] = commands.NewDeprecatedProductMetadata(stdout)
 	commandSet["unstage-product"] = commands.NewUnstageProduct(api, stdout)
-	commandSet["update-ssl-certificate"] = commands.NewUpdateSSLCertificate(api, stdout)
+	commandSet["update-ssl-certificate"] = commands.NewUpdateSSLCertificate(os.Environ, api, stdout)
 	commandSet["upload-product"] = commands.NewUploadProduct(form, metadataExtractor, api, stdout)
 	commandSet["upload-stemcell"] = commands.NewUploadStemcell(form, api, stdout)
 	commandSet["version"] = commands.NewVersion(version, os.Stdout)


### PR DESCRIPTION
This closes #463. The code to implement this was included in commit 1995e93cda087451d3330f31756b1e21283931ea but tests were not, so this should cover them.