### PR TITLE
Document that stemcell-iaas can be a glob

### DIFF
--- a/commands/download_product.go
+++ b/commands/download_product.go
@@ -71,7 +71,7 @@ type DownloadProductOptions struct {
 	AzureKey            string `long:"azure-storage-key"     description:"the access key for the storage account"`
 
 	Stemcell     bool   `long:"download-stemcell" description:"no-op for backwards compatibility"`
-	StemcellIaas string `long:"stemcell-iaas"     description:"download the latest available stemcell for the product for the specified iaas. for example 'vsphere' or 'vcloud' or 'openstack' or 'google' or 'azure' or 'aws'"`
+	StemcellIaas string `long:"stemcell-iaas"     description:"download the latest available stemcell for the product for the specified iaas. for example 'vsphere' or 'vcloud' or 'openstack' or 'google' or 'azure' or 'aws'. Can contain globbing patterns to match specific files in a stemcell release on Pivnet"`
 }
 
 type DownloadProduct struct {

--- a/docs/download-product/README.md
+++ b/docs/download-product/README.md
@@ -44,7 +44,7 @@ Flags:
   --s3-region-name             string             bucket region in the s3 compatible blobstore. If not using AWS, this value is 'region'
   --s3-secret-access-key       string             secret key for the s3 compatible blobstore
   --source, -s                 string             enables download from external sources when set to [s3|gcs|azure|pivnet] (default: pivnet)
-  --stemcell-iaas              string             download the latest available stemcell for the product for the specified iaas. for example 'vsphere' or 'vcloud' or 'openstack' or 'google' or 'azure' or 'aws'
+  --stemcell-iaas              string             download the latest available stemcell for the product for the specified iaas. for example 'vsphere' or 'vcloud' or 'openstack' or 'google' or 'azure' or 'aws'. Can contain globbing patterns to match specific files in a stemcell release on Pivnet
   --var                        string (variadic)  Load variable from the command line. Format: VAR=VAL
   --vars-env, OM_VARS_ENV      string (variadic)  **EXPERIMENTAL** load variables from environment variables matching the provided prefix (e.g.: 'MY' to load MY_var=value)
   --vars-file, -l              string (variadic)  load variables from a YAML file


### PR DESCRIPTION
I ran into an issue today when trying to download the latest 250.x stemcell alongside PAS using the download-product task in Platform Automation. My config.yml specifies: `stemcell-iaas: aws` which used to work but now I get the error:

```
$ om download-product --config config/download-configs/pas.yml --source pivnet
...
Downloading stemcell
could not execute "download-product": could not download stemcell: for product version 250.185: the glob '*aws*' matches multiple files. Write your glob to match exactly one of the following:
  light-bosh-stemcell-250.185-aws-xen-hvm-ubuntu-xenial-go_agent.tgz
  bosh-stemcell-250.185-aws-xen-hvm-ubuntu-xenial-go_agent.tgz
No stemcell identified on on PivNet. Remove -stemcell-iaas and/or contact support
```

Looking at pivnet I see that 250.185 now has both the light stemcell and the full "heavy" stemcell listed which both match `*aws*` resulting in this error.

I discovered that using `stemcell-iaas: light-bosh-stemcell-*-aws` in the config works properly.

This PR documents this feature. I'm open to suggestions on how to phrase it better.