### PR TITLE
Add check flag to bosh-diff so it can be used in automation

### DIFF
--- a/commands/bosh_diff_test.go
+++ b/commands/bosh_diff_test.go
@@ -2,6 +2,8 @@ package commands_test
 
 import (
 	"fmt"
+	"log"
+
 	"github.com/fatih/color"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -9,7 +11,6 @@ import (
 	"github.com/pivotal-cf/om/api"
 	"github.com/pivotal-cf/om/commands"
 	"github.com/pivotal-cf/om/commands/fakes"
-	"log"
 )
 
 var _ = Describe("BoshDiff", func() {
@@ -84,6 +85,12 @@ var _ = Describe("BoshDiff", func() {
 				Expect(logBuffer).To(gbytes.Say("properties:"))
 				Expect(bufferContents).To(ContainSubstring(color.GreenString("+  property: new-cpi-value")))
 				Expect(bufferContents).To(ContainSubstring(color.RedString("-  property: old-cpi-value")))
+			})
+
+			It("Errors if --check is enabled", func() {
+				diff := commands.NewBoshDiff(service, logger)
+				err = diff.Execute([]string{"--director", "--check"})
+				Expect(err).To(HaveOccurred())
 			})
 		})
 	})
@@ -262,6 +269,16 @@ var _ = Describe("BoshDiff", func() {
 			It("says there are no manifest differences and no runtime config diffs", func() {
 				diff := commands.NewBoshDiff(service, logger)
 				err = diff.Execute([]string{"--product-name", "example-product"})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(logBuffer).To(gbytes.Say("## Product Manifest"))
+				Expect(logBuffer).To(gbytes.Say("no changes"))
+				Expect(logBuffer).To(gbytes.Say("## Runtime Configs"))
+				Expect(logBuffer).To(gbytes.Say("no changes"))
+			})
+
+			It("does not error if --check is passed", func() {
+				diff := commands.NewBoshDiff(service, logger)
+				err = diff.Execute([]string{"--product-name", "example-product", "--check"})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(logBuffer).To(gbytes.Say("## Product Manifest"))
 				Expect(logBuffer).To(gbytes.Say("no changes"))

--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,6 @@ require (
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
 	golang.org/x/sys v0.0.0-20200413165638-669c56c373c4 // indirect
 	google.golang.org/api v0.20.0
-	google.golang.org/appengine v1.6.5 // indirect
 	google.golang.org/genproto v0.0.0-20200311144346-b662892dd51b // indirect
 	google.golang.org/grpc v1.28.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect


### PR DESCRIPTION
This implements the feature requested in #488 

Allow users to specify the `--check` command when using `om bosh-diff` to get a non-zero exit code when changes exist, like linux `diff` and `om pending-changes`. This will allow automation users to take action depending on whether or not changes exist.