### PR TITLE
Do not require the id arg for certificate-authority if there is only one CA to choose from

### DIFF
--- a/commands/certificate_authority.go
+++ b/commands/certificate_authority.go
@@ -43,7 +43,7 @@ func (c CertificateAuthority) Execute(args []string) error {
 		displayCA = cas.CAs[0]
 	} else {
 		if len(cas.CAs) > 1 && c.Options.ID == "" {
-			return fmt.Errorf("--id is required when there are multiple CAs, and there are %d", len(cas.CAs))
+			return fmt.Errorf("More than one certificate authority found. Please use --id flag to specify. IDs can be found using the certificate-authorities command")
 		}
 		for _, ca := range cas.CAs {
 			if ca.GUID == c.Options.ID {

--- a/commands/certificate_authority.go
+++ b/commands/certificate_authority.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 
@@ -43,7 +44,7 @@ func (c CertificateAuthority) Execute(args []string) error {
 		displayCA = cas.CAs[0]
 	} else {
 		if len(cas.CAs) > 1 && c.Options.ID == "" {
-			return fmt.Errorf("More than one certificate authority found. Please use --id flag to specify. IDs can be found using the certificate-authorities command")
+			return errors.New("More than one certificate authority found. Please use --id flag to specify. IDs can be found using the certificate-authorities command")
 		}
 		for _, ca := range cas.CAs {
 			if ca.GUID == c.Options.ID {

--- a/commands/certificate_authority_test.go
+++ b/commands/certificate_authority_test.go
@@ -167,7 +167,7 @@ var _ = Describe("Certificate Authority", func() {
 			When("the --id flag is missing", func() {
 				It("returns an error", func() {
 					err := certificateAuthority.Execute([]string{})
-					Expect(err).To(MatchError(`--id is required when there are multiple CAs, and there are 2`))
+					Expect(err).To(MatchError("More than one certificate authority found. Please use --id flag to specify. IDs can be found using the certificate-authorities command"))
 				})
 			})
 			When("the request certificate authority is not found", func() {


### PR DESCRIPTION
It feels extraneous to have to run `om certificate-authorities` to get the CA's ID if there's only one. This changes that behavior, but preserves existing behavior in all other cases