### PR TITLE
Use equivalent item values to find existing property GUIDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,14 @@ can be found in [Pivotal Documentation](docs.pivotal.io/platform-automation).
 ## 6.2.0
 
 ### Features
-- `configure-product`'s _decorating collection with guid based on `name` logical key_ logic has been extended to also use `key` or fields ending in `name` as logical keys.  Resolves [#207](https://github.com/pivotal-cf/om/issues/207)
+- `configure-product`'s _decorating collection with guid_ logic has been extended to associate existing collection item guids based on (in order)
+  - equivalent item values
+  - equal logical keys (in order; ie. 'name' will be used over 'Filename' if both exist)
+    - `name`
+    - `key`
+    - fields ending in `name` (eg: `sqlServerName`)
+
+  This addresses [#207](https://github.com/pivotal-cf/om/issues/207); improving GitOps style workflows
 
 ## 6.1.0
 

--- a/api/staged_products_property_collection_guid_assigner_test.go.go
+++ b/api/staged_products_property_collection_guid_assigner_test.go.go
@@ -133,33 +133,14 @@ var _ = Describe("ResponsePropertyCollection", func() {
 			Expect(collection[0].getFieldValue("name")).To(Equal("the_name"))
 		})
 	})
-	When("finding the logical key field", func() {
+	When("parseUpdatedPropertyCollection: finding the logical key field", func() {
 		It("finds a 'name' logical key", func() {
-			collection, err := parseResponsePropertyCollection(unmarshalJSONLikeApiGetStagedProductProperties(`[
+			collection, err := parseUpdatedPropertyCollection(unmarshalJSON(`{ "value":[
 				{
-					"guid": {
-						"type": "uuid",
-						"configurable": false,
-						"credential": false,
-						"value": "28bab1d3-4a4b-48d5-8dac-two",
-						"optional": false
-					},
-					"name": {
-						"type": "string",
-						"configurable": true,
-						"credential": false,
-						"value": "the_name",
-						"optional": false
-					},
-					"yet_another_property": {
-						"type": "boolean",
-						"configurable": true,
-						"credential": false,
-						"value": false,
-						"optional": false
-					}
+					"name": "the_name",
+					"yet_another_property": false
 				}
-			]`))
+			]}`))
 			Expect(err).To(BeNil())
 
 			key, ok := collection[0].findLogicalKeyField()
@@ -167,24 +148,11 @@ var _ = Describe("ResponsePropertyCollection", func() {
 			Expect(key).To(Equal("name"))
 		})
 		It("fails to find a logical key when there isn't one", func() {
-			collection, err := parseResponsePropertyCollection(unmarshalJSONLikeApiGetStagedProductProperties(`[
+			collection, err := parseUpdatedPropertyCollection(unmarshalJSON(`{ "value":[
 				{
-					"guid": {
-						"type": "uuid",
-						"configurable": false,
-						"credential": false,
-						"value": "28bab1d3-4a4b-48d5-8dac-one",
-						"optional": false
-					},
-					"some_property": {
-						"type": "boolean",
-						"configurable": true,
-						"credential": false,
-						"value": "true",
-						"optional": false
-					}
+					"some_property": false
 				}
-			]`))
+			]}`))
 			Expect(err).To(BeNil())
 
 			key, ok := collection[0].findLogicalKeyField()
@@ -193,31 +161,12 @@ var _ = Describe("ResponsePropertyCollection", func() {
 		})
 
 		It("finds a 'key' logical key", func() {
-			collection, err := parseResponsePropertyCollection(unmarshalJSONLikeApiGetStagedProductProperties(`[
+			collection, err := parseUpdatedPropertyCollection(unmarshalJSON(`{ "value":[
 				{
-					"guid": {
-						"type": "uuid",
-						"configurable": false,
-						"credential": false,
-						"value": "28bab1d3-4a4b-48d5-8dac-three",
-						"optional": false
-					},
-					"key": {
-						"type": "string",
-						"configurable": true,
-						"credential": false,
-						"value": "the_key",
-						"optional": false
-					},
-					"some_additional_property": {
-						"type": "boolean",
-						"configurable": true,
-						"credential": false,
-						"value": false,
-						"optional": false
-					}
+					"key": "the_key",
+					"some_additional_property": false
 				}
-			]`))
+			]}`))
 			Expect(err).To(BeNil())
 
 			key, ok := collection[0].findLogicalKeyField()
@@ -225,31 +174,12 @@ var _ = Describe("ResponsePropertyCollection", func() {
 			Expect(key).To(Equal("key"))
 		})
 		It("finds a logical key ending in 'name'", func() {
-			collection, err := parseResponsePropertyCollection(unmarshalJSONLikeApiGetStagedProductProperties(`[
+			collection, err := parseUpdatedPropertyCollection(unmarshalJSON(`{ "value":[
 				{
-					"guid": {
-						"type": "uuid",
-						"configurable": false,
-						"credential": false,
-						"value": "28bab1d3-4a4b-48d5-8dac-four",
-						"optional": false
-					},
-					"sqlServerName": {
-						"type": "string",
-						"configurable": true,
-						"credential": false,
-						"value": "the_sqlserver_name",
-						"optional": false
-					},
-					"some_additional_property": {
-						"type": "boolean",
-						"configurable": true,
-						"credential": false,
-						"value": false,
-						"optional": false
-					}
+					"sqlServerName": "the_sqlserver_name",
+					"some_additional_property": false
 				}
-			]`))
+			]}`))
 			Expect(err).To(BeNil())
 
 			key, ok := collection[0].findLogicalKeyField()
@@ -257,31 +187,12 @@ var _ = Describe("ResponsePropertyCollection", func() {
 			Expect(key).To(Equal("sqlServerName"))
 		})
 		It("picks 'name' as the logical key when there is a 'name' field AND a field that ends in 'name' (eg: Filename)", func() {
-			collection, err := parseResponsePropertyCollection(unmarshalJSONLikeApiGetStagedProductProperties(`[
+			collection, err := parseUpdatedPropertyCollection(unmarshalJSON(`{ "value":[
 				{
-					"guid": {
-						"type": "uuid",
-						"configurable": false,
-						"credential": false,
-						"value": "28bab1d3-4a4b-48d5-8dac-five",
-						"optional": false
-					},
-					"name": {
-						"type": "string",
-						"configurable": true,
-						"credential": false,
-						"value": "the_name",
-						"optional": false
-					},
-					"Filename": {
-						"type": "string",
-						"configurable": true,
-						"credential": false,
-						"value": "important_data.tgz",
-						"optional": false
-					}
+					"name": "the_name",
+					"Filename": "important_data.tgz"
 				}
-			]`))
+			]}`))
 			Expect(err).To(BeNil())
 
 			key, ok := collection[0].findLogicalKeyField()

--- a/api/staged_products_property_collection_guid_assigner_test.go.go
+++ b/api/staged_products_property_collection_guid_assigner_test.go.go
@@ -348,7 +348,7 @@ var _ = Describe("ResponsePropertyCollection", func() {
 			]}`))
 			Expect(err).To(BeNil())
 
-			guid, ok := existingCollection.findGUIDForIEquivalentlItem(updatedCollection[0])
+			guid, ok := existingCollection.findGUIDForEquivalentlItem(updatedCollection[0])
 			Expect(ok).To(BeTrue())
 			Expect(guid).To(Equal("28bab1d3-4a4b-48d5-8dac-two"))
 		})
@@ -387,7 +387,7 @@ var _ = Describe("ResponsePropertyCollection", func() {
 			]}`))
 			Expect(err).To(BeNil())
 
-			guid, ok := existingCollection.findGUIDForIEquivalentlItem(updatedCollection[0])
+			guid, ok := existingCollection.findGUIDForEquivalentlItem(updatedCollection[0])
 			Expect(ok).To(BeTrue())
 			Expect(guid).To(Equal("28bab1d3-4a4b-48d5-8dac-two"))
 		})

--- a/api/staged_products_service_test.go
+++ b/api/staged_products_service_test.go
@@ -485,11 +485,11 @@ valid options configurations include percentages ('50%'), counts ('2'), and 'def
 										"value": "28bab1d3-4a4b-48d5-8dac-796adf078100",
 										"optional": false
 									},
-									"name": {
+									"label": {
 										"type": "string",
 										"configurable": true,
 										"credential": false,
-										"value": "the_name",
+										"value": "the_label",
 										"optional": false
 									},
 									"some_property": {
@@ -619,7 +619,7 @@ valid options configurations include percentages ('50%'), counts ('2'), and 'def
 		})
 
 		Context("configure product contains collection", func() {
-			It("adds the guid for elements that exist", func() {
+			It("adds the guid for elements that exist and haven't changed, but don't have a logical key field", func() {
 				client.AppendHandlers(
 					ghttp.CombineHandlers(
 						ghttp.VerifyRequest("PUT", "/api/v0/staged/products/some-product-guid/properties"),
@@ -629,8 +629,8 @@ valid options configurations include percentages ('50%'), counts ('2'), and 'def
 								"key": "value",
 								"some_collection": {
 									"value": [{
-										"name": "the_name",
-										"some_property": "property_value",
+										"label": "the_label",
+										"some_property": true,
 										"guid": "28bab1d3-4a4b-48d5-8dac-796adf078100"
 									}]
 								}
@@ -647,8 +647,8 @@ valid options configurations include percentages ('50%'), counts ('2'), and 'def
 						"some_collection": {
 							"value": [
 								{
-									"name": "the_name",
-									"some_property": "property_value"
+									"some_property": true,
+									"label": "the_label"
 								}
 							]
 						}

--- a/api/staged_products_service_test.go
+++ b/api/staged_products_service_test.go
@@ -522,10 +522,32 @@ valid options configurations include percentages ('50%'), counts ('2'), and 'def
 										"optional": false
 									},
 									"some_property": {
-										"type": "boolean",
+										"type": "string",
 										"configurable": true,
 										"credential": false,
-										"value": true,
+										"value": "some property value",
+										"optional": false
+									}
+								},{
+									"guid": {
+										"type": "uuid",
+										"configurable": false,
+										"credential": false,
+										"value": "28bab1d3-4a4b-48d5-8dac-with-name-two",
+										"optional": false
+									},
+									"name": {
+										"type": "string",
+										"configurable": true,
+										"credential": false,
+										"value": "the_name_two",
+										"optional": false
+									},
+									"some_property": {
+										"type": "string",
+										"configurable": true,
+										"credential": false,
+										"value": "some property value two",
 										"optional": false
 									}
 								}],
@@ -760,6 +782,50 @@ valid options configurations include percentages ('50%'), counts ('2'), and 'def
 								{
 									"sqlServerName": "the_sql_server",
 									"some_property": "new_property_value"
+								}
+							]
+						}
+					}`,
+				})
+				Expect(err).ToNot(HaveOccurred())
+			})
+			It("adds the guid using different strategies for different items in the same collection", func() {
+				client.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("PUT", "/api/v0/staged/products/some-product-guid/properties"),
+						ghttp.VerifyContentType("application/json"),
+						ghttp.VerifyJSON(`{
+							"properties": {
+								"key": "value",
+								"collection_with_name": {
+									"value": [{
+										"name": "the_name",
+										"some_property": "some property value",
+										"guid": "28bab1d3-4a4b-48d5-8dac-with-name"
+									},{
+										"name": "the_name_two",
+										"some_property": "changed, so should find guid based on logical key rather than equivalence",
+										"guid": "28bab1d3-4a4b-48d5-8dac-with-name-two"
+									}]
+								}
+							}
+						}`),
+						ghttp.RespondWith(http.StatusOK, `{}`),
+					),
+				)
+
+				err := service.UpdateStagedProductProperties(api.UpdateStagedProductPropertiesInput{
+					GUID: "some-product-guid",
+					Properties: `{
+						"key": "value",
+						"collection_with_name": {
+							"value": [
+								{
+									"name": "the_name",
+									"some_property": "some property value"
+								},{
+									"name": "the_name_two",
+									"some_property": "changed, so should find guid based on logical key rather than equivalence"
 								}
 							]
 						}


### PR DESCRIPTION
Related to #502, this addition extends the _decorating collection with guid_ logic to associate collection item guids with items that have equivalent item.

For example (see [test](https://github.com/pivotal-cf/om/blob/8a43e6df7a8ce99414c59e2513e951d73832f691/api/staged_products_service_test.go#L644)); if the following item exists in an OpsMgr Property Collection:

```
  { 
    "guid": "28bab1d3-4a4b-48d5-8dac-two",
    "another_property": true,
    "a_property": "\"value\" of 'second' item"
  }
```

And an operator uses `om configure-product` to "update" that property with no changes (as might be the case in a GitOps workflow):

```
  { 
    "a_property": "\"value\" of 'second' item"
    "another_property": true,
  }
```

`om configure-product` will decorate the updated property with the `guid` of the existing equivalent item (ignoring key order); which would register (correctly) as a `no-op` change by the `om bosh-diff` functionality; preserving the existing item `guid`

This partially addresses #207

_Known issues_
* Does not associate GUIDs for collections that have a secret field AND no logical key