### PR TITLE
Handle collections containing secrets when finding existing property GUIDs 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ can be found in [Pivotal Documentation](docs.pivotal.io/platform-automation).
 ### Bug Fixes
 - `configure-product` will no longer assign a new guid for unnamed collections
    - that haven't changed but contain non-configurable properties
+   - that haven't changed but contain secret/credential properties
 
 ## 6.1.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,12 @@ can be found in [Pivotal Documentation](docs.pivotal.io/platform-automation).
   This ensures that commands are not kept in `bash` history.
   The environment variable `OM_PASSWORD` will overwrite the password value in `env.yml`.
 
+## 6.1.3
+
+### Bug Fixes
+- `configure-product` will no longer assign a new guid for unnamed collections
+   - that haven't changed but contain non-configurable properties
+
 ## 6.1.2
 
 ### Bug Fixes

--- a/api/staged_products_property_collection_guid_assigner.go
+++ b/api/staged_products_property_collection_guid_assigner.go
@@ -115,6 +115,10 @@ func (item responsePropertyCollectionItem) getFieldValuesExceptGUID() map[interf
 		if key == "guid" {
 			continue
 		}
+		isNotConfigurable := !valueObj.(map[interface{}]interface{})["configurable"].(bool)
+		if isNotConfigurable {
+			continue
+		}
 		extractedValues[key] = valueObj.(map[interface{}]interface{})["value"]
 	}
 

--- a/api/staged_products_property_collection_guid_assigner_test.go.go
+++ b/api/staged_products_property_collection_guid_assigner_test.go.go
@@ -302,5 +302,43 @@ var _ = Describe("ResponsePropertyCollection", func() {
 			Expect(ok).To(BeTrue())
 			Expect(guid).To(Equal("28bab1d3-4a4b-48d5-8dac-two"))
 		})
+		It("ignores non-configurable properties when finding items that are equivalent", func() {
+			existingCollection, err := parseResponsePropertyCollection(unmarshalJSONLikeApiGetStagedProductProperties(`[
+				{
+					"guid": {
+						"type": "uuid",
+						"configurable": false,
+						"credential": false,
+						"value": "28bab1d3-4a4b-with-non-configurable-properties",
+						"optional": false
+					},
+					"non_configurable_property": {
+						"type": "string",
+						"configurable": false,
+						"credential": false,
+						"value": "this property can't be configured",
+						"optional": false
+					},
+					"configurable_property": {
+						"type": "string",
+						"configurable": true,
+						"credential": false,
+						"value": "this property can be configured",
+						"optional": false
+					}
+				}
+			]`))
+			Expect(err).To(BeNil())
+			updatedCollection, err := parseUpdatedPropertyCollection(unmarshalJSON(`{ "value":[
+				{
+					"configurable_property": "this property can be configured"
+				}
+			]}`))
+			Expect(err).To(BeNil())
+
+			guid, ok := existingCollection.findGUIDForEquivalentlItem(updatedCollection[0])
+			Expect(ok).To(BeTrue())
+			Expect(guid).To(Equal("28bab1d3-4a4b-with-non-configurable-properties"))
+		})
 	})
 })

--- a/api/staged_products_property_collection_guid_assigner_test.go.go
+++ b/api/staged_products_property_collection_guid_assigner_test.go.go
@@ -10,13 +10,13 @@ import (
 )
 
 var _ = Describe("ResponsePropertyCollection", func() {
-	unmarshalJSONLikeApiGetStagedProductProperties := func(json string) interface{} {
+	unmarshalJSONLikeApiGetStagedProductProperties := func(json string) ResponseProperty {
 		var rawCollection interface{}
 		err := yaml.Unmarshal([]byte(json), &rawCollection)
 		if err != nil {
 			panic(fmt.Errorf("Failed to parse json: %w", err))
 		}
-		return rawCollection
+		return ResponseProperty{Value: rawCollection}
 	}
 	unmarshalJSON := func(rawJSON string) interface{} {
 		var rawCollection interface{}
@@ -28,7 +28,8 @@ var _ = Describe("ResponsePropertyCollection", func() {
 	}
 	When("parseResponsePropertyCollection", func() {
 		It("parses all the elements in the collection", func() {
-			collection, err := parseResponsePropertyCollection(unmarshalJSONLikeApiGetStagedProductProperties(`[
+			collection, err := parseResponsePropertyCollection(associateExistingCollectionGUIDsInput{
+				ExistingProperty: unmarshalJSONLikeApiGetStagedProductProperties(`[
 				{
 					"guid": {
 						"type": "uuid",
@@ -68,14 +69,15 @@ var _ = Describe("ResponsePropertyCollection", func() {
 						"optional": false
 					}
 				}
-			]`))
+			]`)})
 			Expect(err).To(BeNil())
 			Expect(len(collection)).To(Equal(2))
 		})
 	})
 	When("extracting field values", func() {
 		It("correctly extracts guids", func() {
-			collection, err := parseResponsePropertyCollection(unmarshalJSONLikeApiGetStagedProductProperties(`[
+			collection, err := parseResponsePropertyCollection(associateExistingCollectionGUIDsInput{
+				ExistingProperty: unmarshalJSONLikeApiGetStagedProductProperties(`[
 				{
 					"guid": {
 						"type": "uuid",
@@ -99,12 +101,13 @@ var _ = Describe("ResponsePropertyCollection", func() {
 						"optional": false
 					}
 				}
-			]`))
+			]`)})
 			Expect(err).To(BeNil())
 			Expect(collection[0].getFieldValue("guid")).To(Equal("28bab1d3-4a4b-48d5-8dac-two"))
 		})
 		It("correctly extracts strings", func() {
-			collection, err := parseResponsePropertyCollection(unmarshalJSONLikeApiGetStagedProductProperties(`[
+			collection, err := parseResponsePropertyCollection(associateExistingCollectionGUIDsInput{
+				ExistingProperty: unmarshalJSONLikeApiGetStagedProductProperties(`[
 				{
 					"guid": {
 						"type": "uuid",
@@ -128,7 +131,7 @@ var _ = Describe("ResponsePropertyCollection", func() {
 						"optional": false
 					}
 				}
-			]`))
+			]`)})
 			Expect(err).To(BeNil())
 			Expect(collection[0].getFieldValue("name")).To(Equal("the_name"))
 		})
@@ -202,7 +205,8 @@ var _ = Describe("ResponsePropertyCollection", func() {
 	})
 	When("matching based on item contents", func() {
 		It("finds items that are identical", func() {
-			existingCollection, err := parseResponsePropertyCollection(unmarshalJSONLikeApiGetStagedProductProperties(`[
+			existingCollection, err := parseResponsePropertyCollection(associateExistingCollectionGUIDsInput{
+				ExistingProperty: unmarshalJSONLikeApiGetStagedProductProperties(`[
 				{
 					"guid": {
 						"type": "uuid",
@@ -249,7 +253,7 @@ var _ = Describe("ResponsePropertyCollection", func() {
 						"optional": false
 					}
 				}
-			]`))
+			]`)})
 			Expect(err).To(BeNil())
 			updatedCollection, err := parseUpdatedPropertyCollection(unmarshalJSON(`{ "value":[
 				{
@@ -264,7 +268,8 @@ var _ = Describe("ResponsePropertyCollection", func() {
 			Expect(guid).To(Equal("28bab1d3-4a4b-48d5-8dac-two"))
 		})
 		It("finds items that are equivalent but have a different key order", func() {
-			existingCollection, err := parseResponsePropertyCollection(unmarshalJSONLikeApiGetStagedProductProperties(`[
+			existingCollection, err := parseResponsePropertyCollection(associateExistingCollectionGUIDsInput{
+				ExistingProperty: unmarshalJSONLikeApiGetStagedProductProperties(`[
 				{
 					"guid": {
 						"type": "uuid",
@@ -288,7 +293,7 @@ var _ = Describe("ResponsePropertyCollection", func() {
 						"optional": false
 					}
 				}
-			]`))
+			]`)})
 			Expect(err).To(BeNil())
 			updatedCollection, err := parseUpdatedPropertyCollection(unmarshalJSON(`{ "value":[
 				{
@@ -303,7 +308,8 @@ var _ = Describe("ResponsePropertyCollection", func() {
 			Expect(guid).To(Equal("28bab1d3-4a4b-48d5-8dac-two"))
 		})
 		It("ignores non-configurable properties when finding items that are equivalent", func() {
-			existingCollection, err := parseResponsePropertyCollection(unmarshalJSONLikeApiGetStagedProductProperties(`[
+			existingCollection, err := parseResponsePropertyCollection(associateExistingCollectionGUIDsInput{
+				ExistingProperty: unmarshalJSONLikeApiGetStagedProductProperties(`[
 				{
 					"guid": {
 						"type": "uuid",
@@ -327,7 +333,7 @@ var _ = Describe("ResponsePropertyCollection", func() {
 						"optional": false
 					}
 				}
-			]`))
+			]`)})
 			Expect(err).To(BeNil())
 			updatedCollection, err := parseUpdatedPropertyCollection(unmarshalJSON(`{ "value":[
 				{

--- a/api/staged_products_service.go
+++ b/api/staged_products_service.go
@@ -215,7 +215,12 @@ func (a Api) UpdateStagedProductProperties(input UpdateStagedProductPropertiesIn
 	for propertyName, property := range newProperties {
 		configuredProperty := currentConfiguredProperties[propertyName]
 		if configuredProperty.isCollection() {
-			err := associateExistingCollectionGUIDs(property, configuredProperty)
+			err := associateExistingCollectionGUIDs(associateExistingCollectionGUIDsInput{
+				APIService:       a,
+				ProductGUID:      input.GUID,
+				PropertyName:     propertyName,
+				UpdatedProperty:  property,
+				ExistingProperty: configuredProperty})
 			if err != nil {
 				return fmt.Errorf("failed to associate guids for property %#v because:\n%v", propertyName, err)
 			}


### PR DESCRIPTION
Addresses one of the known issues for collection GUID assignment addressed in #207:
 
* [GUID association does not work for collections items that have a secret field AND no logical key field](https://github.com/pivotal-cf/om/issues/207#issuecomment-672827665)

