### PR TITLE
Make `om bosh-diff` return with exit code 2

### DIFF
--- a/commands/bosh_diff.go
+++ b/commands/bosh_diff.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -17,9 +18,11 @@ type BoshDiff struct {
 	Options struct {
 		Product  []string `long:"product-name" short:"p" description:"Product to get diff for. Pass repeatedly for multiple products. If excluded, all staged non-director products will be shown."`
 		Director bool     `long:"director" short:"d" description:"Include director diffs. Can be combined with --product-name."`
-		Check    bool     `long:"check" description:"Exit 1 if there are any differences. Useful for validating that Ops Manager is in a clean state."`
+		Check    bool     `long:"check" description:"Exit 2 if there are any differences. Useful for validating that Ops Manager is in a clean state."`
 	}
 }
+
+var ErrBoshDiffChangesExist = errors.New("Differences exist between the staged and deployed versions of the requested products")
 
 //counterfeiter:generate -o ./fakes/diff_service.go --fake-name BoshDiffService . boshDiffService
 type boshDiffService interface {
@@ -97,7 +100,7 @@ func (c BoshDiff) Execute(args []string) error {
 	}
 
 	if c.Options.Check && thereAreDiffs {
-		return fmt.Errorf("Differences exist between the staged and deployed versions of the requested products")
+		return ErrBoshDiffChangesExist
 	}
 
 	return nil

--- a/main.go
+++ b/main.go
@@ -1,20 +1,26 @@
 package main
 
 import (
-	"github.com/pivotal-cf/om/cmd"
-	_ "github.com/pivotal-cf/om/download_clients"
+	"errors"
 	"log"
 	"os"
+
+	"github.com/pivotal-cf/om/cmd"
+	"github.com/pivotal-cf/om/commands"
+	_ "github.com/pivotal-cf/om/download_clients"
 )
 
 var version = "unknown"
 
-var applySleepDurationString  = "10s"
-
+var applySleepDurationString = "10s"
 
 func main() {
 	err := cmd.Main(os.Stdout, os.Stderr, version, applySleepDurationString, os.Args)
 	if err != nil {
+		if errors.Is(err, commands.ErrBoshDiffChangesExist) {
+			log.Print(err)
+			os.Exit(2)
+		}
 		log.Fatal(err)
 	}
 }


### PR DESCRIPTION
Return 2 if `--check` is specified and there are differences instead
of 1 for all other errors.

Co-Authored-By: Amber Salome <asalome@vmware.com>