### PR TITLE
Clean up OM_* env vars before testing

### DIFF
--- a/acceptance/init_test.go
+++ b/acceptance/init_test.go
@@ -7,7 +7,10 @@ import (
 	"github.com/onsi/gomega/ghttp"
 	"io/ioutil"
 	"net/http"
+	"os"
 	"os/exec"
+	"regexp"
+	"strings"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -45,6 +48,15 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	return []byte(omPath)
 }, func(data []byte) {
 	pathToMain = string(data)
+
+	// Clear any OM env vars so as to not pollute the tests
+	re := regexp.MustCompile(`OM_*`)
+	for _, pair := range os.Environ() {
+		split := strings.Split(pair, "=")
+		if re.MatchString(split[0]) {
+			Expect(os.Unsetenv(split[0])).NotTo(HaveOccurred())
+		}
+	}
 })
 
 var _ = SynchronizedAfterSuite(func() {

--- a/commands/init_test.go
+++ b/commands/init_test.go
@@ -4,8 +4,11 @@ import (
 	"github.com/fatih/color"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"io/ioutil"
 
+	"io/ioutil"
+	"regexp"
+	"strings"
+	"os"
 	"testing"
 )
 
@@ -29,4 +32,13 @@ var _ = BeforeSuite(func() {
 	//which ginkgo uses when running in parallel,
 	//so we have to override it)
 	color.NoColor = false
+
+	// Clear any OM env vars so as to not pollute the tests
+	re := regexp.MustCompile(`OM_*`)
+	for _, pair := range os.Environ() {
+		split := strings.Split(pair, "=")
+		if re.MatchString(split[0]) {
+			Expect(os.Unsetenv(split[0])).NotTo(HaveOccurred())
+		}
+	}
 })


### PR DESCRIPTION
If you have OM_* env vars set in your local env before running the test suite, some of the tests fail. I ran into this when working on the previous PR. This small fix just unsets all of the OM_* env variables before running the tests in the commands and acceptance test suites.