### PR TITLE
Add --bosh and --credhub options for bosh-env command

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -16,7 +16,7 @@ for this product.
 | [assign-stemcell](assign-stemcell/README.md) | assigns an uploaded stemcell to a product in the targeted Ops Manager |
 | [available-products](available-products/README.md) | **DEPRECATED** lists available products. Use 'products --available' instead. |
 | [bosh-diff](bosh-diff/README.md) | displays BOSH manifest diff for the director and products |
-| [bosh-env](bosh-env/README.md) | prints bosh environment variables |
+| [bosh-env](bosh-env/README.md) | prints environment variables for BOSH and Credhub |
 | [certificate-authorities](certificate-authorities/README.md) | lists certificates managed by Ops Manager |
 | [certificate-authority](certificate-authority/README.md) | prints requested certificate authority |
 | [config-template](config-template/README.md) | generates a config template from a Pivnet product |

--- a/docs/bosh-env/README.md
+++ b/docs/bosh-env/README.md
@@ -8,7 +8,7 @@ The `bosh-env` command setup environment variables to target bosh director and/o
 ## Command Usage
 ```
 
-This prints bosh environment variables to target bosh director. You can invoke it directly to see its output, or use it directly with an evaluate-type command:
+This prints environment variables to target the BOSH director and Credhub. You can invoke it directly to see its output, or use it directly with an evaluate-type command:
 On posix system: eval "$(om bosh-env)"
 On powershell: iex $(om bosh-env | Out-String)
 
@@ -16,6 +16,8 @@ Usage:
   om [options] bosh-env [<args>]
 
 Flags:
+  --bosh, -b             bool    Prints the BOSH director environment variables (default: false)
+  --credhub, -c          bool    Prints the Credhub environment variables (default: false)
   --shell-type           string  Prints for the given shell (posix|powershell)
   --ssh-private-key, -i  string  Location of ssh private key to use to tunnel through the Ops Manager VM. Only necessary if bosh director is not reachable without a tunnel.
 

--- a/docs/upload-stemcell/README.md
+++ b/docs/upload-stemcell/README.md
@@ -19,7 +19,7 @@ Flags:
   --floating               string             assigns the stemcell to all compatible products  (default: true)
   --force, -f              bool               upload stemcell even if it already exists on the target Ops Manager
   --shasum                 string             shasum of the provided product file to be used for validation
-  --stemcell, -s           string (required)  path to stemcell (NOTE: use absolute path)
+  --stemcell, -s           string (required)  path to stemcell
   --var, -v                string (variadic)  load variable from the command line. Format: VAR=VAL
   --vars-env, OM_VARS_ENV  string (variadic)  load variables from environment variables matching the provided prefix (e.g.: 'MY' to load MY_var=value)
   --vars-file, -l          string (variadic)  load variables from a YAML file


### PR DESCRIPTION
- Allows for printing of only the BOSH or Credhub environment variables

Resolves #458