### PR TITLE
configure-opsman: allow updating the UAA tokens expiration

### DIFF
--- a/api/configure_opsman_service.go
+++ b/api/configure_opsman_service.go
@@ -35,6 +35,12 @@ type PivnetSettings struct {
 	APIToken string `json:"api_token" yaml:"api_token"`
 }
 
+type TokensExpiration struct {
+	AccessTokenExpiration  int `json:"access_token_expiration,omitempty" yaml:"access_token_expiration"`
+	RefreshTokenExpiration int `json:"refresh_token_expiration,omitempty" yaml:"refresh_token_expiration"`
+	SessionIdleTimeout     int `json:"session_idle_timeout,omitempty" yaml:"session_idle_timeout"`
+}
+
 type SyslogSettings struct {
 	Enabled             string `json:"enabled,omitempty" yaml:"enabled"`
 	Address             string `json:"address,omitempty" yaml:"address"`
@@ -103,7 +109,7 @@ func (a Api) UpdateSSLCertificate(certBody SSLCertificateSettings) error {
 	}
 
 	body := strings.NewReader(string(payload))
-	return a.updateSettings(body, "ssl_certificate")
+	return a.updateSettings(body, "settings/ssl_certificate")
 }
 
 func (a Api) UpdatePivnetToken(pivnetSettings PivnetSettings) error {
@@ -114,7 +120,7 @@ func (a Api) UpdatePivnetToken(pivnetSettings PivnetSettings) error {
 
 	body := strings.NewReader(fmt.Sprintf(
 		`{ "pivotal_network_settings": %s}`, payload))
-	return a.updateSettings(body, "pivotal_network_settings")
+	return a.updateSettings(body, "settings/pivotal_network_settings")
 }
 
 func (a Api) EnableRBAC(rbacSettings RBACSettings) error {
@@ -124,7 +130,7 @@ func (a Api) EnableRBAC(rbacSettings RBACSettings) error {
 	}
 
 	body := strings.NewReader(string(payload))
-	return a.updateSettings(body, "rbac")
+	return a.updateSettings(body, "settings/rbac")
 }
 
 func (a Api) UpdateBanner(bannerSettings BannerSettings) error {
@@ -134,7 +140,7 @@ func (a Api) UpdateBanner(bannerSettings BannerSettings) error {
 	}
 
 	body := strings.NewReader(string(payload))
-	return a.updateSettings(body, "banner")
+	return a.updateSettings(body, "settings/banner")
 }
 
 func (a Api) UpdateSyslogSettings(syslogSettings SyslogSettings) error {
@@ -145,12 +151,23 @@ func (a Api) UpdateSyslogSettings(syslogSettings SyslogSettings) error {
 
 	body := strings.NewReader(fmt.Sprintf(
 		`{ "syslog": %s}`, payload))
-	return a.updateSettings(body, "syslog")
+	return a.updateSettings(body, "settings/syslog")
+}
+
+func (a Api) UpdateTokensExpiration(tokenExpirations TokensExpiration) error {
+	payload, err := json.Marshal(tokenExpirations)
+	if err != nil {
+		return err // not tested
+	}
+
+	body := strings.NewReader(fmt.Sprintf(
+		`{ "tokens_expiration": %s}`, payload))
+	return a.updateSettings(body, "uaa/tokens_expiration")
 }
 
 func (a Api) updateSettings(body *strings.Reader, endpoint string) error {
 
-	apiPath := fmt.Sprintf("/api/v0/settings/%s", endpoint)
+	apiPath := fmt.Sprintf("/api/v0/%s", endpoint)
 	req, err := http.NewRequest("PUT", apiPath, body)
 	if err != nil {
 		return err // not tested

--- a/commands/configure_opsman.go
+++ b/commands/configure_opsman.go
@@ -39,6 +39,9 @@ type opsmanConfig struct {
 	Syslog *struct {
 		Settings api.SyslogSettings `yaml:",inline"`
 	} `yaml:"syslog-settings"`
+	TokenExpirations *struct {
+		Settings api.TokensExpiration `yaml:",inline"`
+	} `yaml:"tokens-expiration"`
 	Field map[string]interface{} `yaml:",inline"`
 }
 
@@ -49,6 +52,7 @@ type configureOpsmanService interface {
 	UpdatePivnetToken(settings api.PivnetSettings) error
 	EnableRBAC(rbacSettings api.RBACSettings) error
 	UpdateSyslogSettings(syslogSettings api.SyslogSettings) error
+	UpdateTokensExpiration(tokenExpirations api.TokensExpiration) error
 }
 
 func NewConfigureOpsman(environFunc func() []string, service configureOpsmanService, logger logger) *ConfigureOpsman {
@@ -116,6 +120,17 @@ func (c ConfigureOpsman) Execute(args []string) error {
 		}
 		c.logger.Printf("Successfully applied Syslog.\n")
 	}
+
+	if config.TokenExpirations != nil {
+		c.logger.Printf("Updating tokens expiration...\n")
+		payload := config.TokenExpirations.Settings
+		err = c.service.UpdateTokensExpiration(payload)
+		if err != nil {
+			return err
+		}
+		c.logger.Printf("Successfully updated tokens expiration.\n")
+	}
+
 	return nil
 }
 

--- a/commands/configure_opsman_test.go
+++ b/commands/configure_opsman_test.go
@@ -176,6 +176,34 @@ syslog-settings:
 			Expect(fakeService.UpdatePivnetTokenCallCount()).To(Equal(0))
 		})
 
+		It("updates the UAA refresh token settings when given the proper keys", func() {
+			uaaConfig := `
+tokens-expiration:
+  access_token_expiration: 100
+  refresh_token_expiration: 1200
+  session_idle_timeout: 50
+`
+			configFileName := writeTestConfigFile(uaaConfig)
+
+			err := executeCommand(command, []string{
+				"--config", configFileName,
+			})
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(fakeService.UpdateTokensExpirationCallCount()).To(Equal(1))
+			Expect(fakeService.UpdateTokensExpirationArgsForCall(0)).To(Equal(api.TokensExpiration{
+				AccessTokenExpiration:  100,
+				RefreshTokenExpiration: 1200,
+				SessionIdleTimeout:     50,
+			}))
+
+			Expect(fakeService.UpdateSSLCertificateCallCount()).To(Equal(0))
+			Expect(fakeService.UpdateSyslogSettingsCallCount()).To(Equal(0))
+			Expect(fakeService.UpdateBannerCallCount()).To(Equal(0))
+			Expect(fakeService.EnableRBACCallCount()).To(Equal(0))
+			Expect(fakeService.UpdatePivnetTokenCallCount()).To(Equal(0))
+		})
+
 		It("returns an error if both ldap and saml keys provided", func() {
 			rbacConfig := `
 rbac-settings:

--- a/commands/fakes/configure_opsman_service.go
+++ b/commands/fakes/configure_opsman_service.go
@@ -63,6 +63,17 @@ type ConfigureOpsmanService struct {
 	updateSyslogSettingsReturnsOnCall map[int]struct {
 		result1 error
 	}
+	UpdateTokensExpirationStub        func(api.TokensExpiration) error
+	updateTokensExpirationMutex       sync.RWMutex
+	updateTokensExpirationArgsForCall []struct {
+		arg1 api.TokensExpiration
+	}
+	updateTokensExpirationReturns struct {
+		result1 error
+	}
+	updateTokensExpirationReturnsOnCall map[int]struct {
+		result1 error
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
@@ -367,6 +378,66 @@ func (fake *ConfigureOpsmanService) UpdateSyslogSettingsReturnsOnCall(i int, res
 	}{result1}
 }
 
+func (fake *ConfigureOpsmanService) UpdateTokensExpiration(arg1 api.TokensExpiration) error {
+	fake.updateTokensExpirationMutex.Lock()
+	ret, specificReturn := fake.updateTokensExpirationReturnsOnCall[len(fake.updateTokensExpirationArgsForCall)]
+	fake.updateTokensExpirationArgsForCall = append(fake.updateTokensExpirationArgsForCall, struct {
+		arg1 api.TokensExpiration
+	}{arg1})
+	fake.recordInvocation("UpdateTokensExpiration", []interface{}{arg1})
+	fake.updateTokensExpirationMutex.Unlock()
+	if fake.UpdateTokensExpirationStub != nil {
+		return fake.UpdateTokensExpirationStub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.updateTokensExpirationReturns
+	return fakeReturns.result1
+}
+
+func (fake *ConfigureOpsmanService) UpdateTokensExpirationCallCount() int {
+	fake.updateTokensExpirationMutex.RLock()
+	defer fake.updateTokensExpirationMutex.RUnlock()
+	return len(fake.updateTokensExpirationArgsForCall)
+}
+
+func (fake *ConfigureOpsmanService) UpdateTokensExpirationCalls(stub func(api.TokensExpiration) error) {
+	fake.updateTokensExpirationMutex.Lock()
+	defer fake.updateTokensExpirationMutex.Unlock()
+	fake.UpdateTokensExpirationStub = stub
+}
+
+func (fake *ConfigureOpsmanService) UpdateTokensExpirationArgsForCall(i int) api.TokensExpiration {
+	fake.updateTokensExpirationMutex.RLock()
+	defer fake.updateTokensExpirationMutex.RUnlock()
+	argsForCall := fake.updateTokensExpirationArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *ConfigureOpsmanService) UpdateTokensExpirationReturns(result1 error) {
+	fake.updateTokensExpirationMutex.Lock()
+	defer fake.updateTokensExpirationMutex.Unlock()
+	fake.UpdateTokensExpirationStub = nil
+	fake.updateTokensExpirationReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *ConfigureOpsmanService) UpdateTokensExpirationReturnsOnCall(i int, result1 error) {
+	fake.updateTokensExpirationMutex.Lock()
+	defer fake.updateTokensExpirationMutex.Unlock()
+	fake.UpdateTokensExpirationStub = nil
+	if fake.updateTokensExpirationReturnsOnCall == nil {
+		fake.updateTokensExpirationReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.updateTokensExpirationReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *ConfigureOpsmanService) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
@@ -380,6 +451,8 @@ func (fake *ConfigureOpsmanService) Invocations() map[string][][]interface{} {
 	defer fake.updateSSLCertificateMutex.RUnlock()
 	fake.updateSyslogSettingsMutex.RLock()
 	defer fake.updateSyslogSettingsMutex.RUnlock()
+	fake.updateTokensExpirationMutex.RLock()
+	defer fake.updateTokensExpirationMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/docs/configure-opsman/README.md
+++ b/docs/configure-opsman/README.md
@@ -71,6 +71,7 @@ Settings that can be set using this command include:
 - Pivotal Network Settings (pending)
 - Custom Banner (pending)
 - Syslog (pending)
+- UAA tokens expiration
 - Role Based Access Control (if enabled) (pending)
 
 An example config file for updating settings 
@@ -105,6 +106,10 @@ syslog-settings:
   queue_size: 100000
   forward_debug_logs: false
   custom_rsyslog_configuration: if $message contains 'test' then stop
+tokens-expiration:
+  access_token_expiration: 100
+  refresh_token_expiration: 1200
+  session_idle_timeout: 50
 rbac-settings: # if your RBAC is SAML, use these settings
   rbac_saml_admin_group: example_group_name
   rbac_saml_groups_attribute: example_attribute_name

--- a/docsgenerator/templates/configure-opsman/ADDITIONAL_INFO.md
+++ b/docsgenerator/templates/configure-opsman/ADDITIONAL_INFO.md
@@ -6,6 +6,7 @@ Settings that can be set using this command include:
 - Pivotal Network Settings (pending)
 - Custom Banner (pending)
 - Syslog (pending)
+- UAA tokens expiration
 - Role Based Access Control (if enabled) (pending)
 
 An example config file for updating settings 
@@ -40,6 +41,10 @@ syslog-settings:
   queue_size: 100000
   forward_debug_logs: false
   custom_rsyslog_configuration: if $message contains 'test' then stop
+tokens-expiration:
+  access_token_expiration: 100
+  refresh_token_expiration: 1200
+  session_idle_timeout: 50
 rbac-settings: # if your RBAC is SAML, use these settings
   rbac_saml_admin_group: example_group_name
   rbac_saml_groups_attribute: example_attribute_name


### PR DESCRIPTION
This PR allows users to update the UAA tokens expiration using the `configure-opsman` subcommand.  This change is useful for environments with strict compliance requirements such that the default access token and refresh token expiration are too long.