### PR TITLE
Add SimpleFloat type to config-template

### DIFF
--- a/configtemplate/generator/collection_property_metadata.go
+++ b/configtemplate/generator/collection_property_metadata.go
@@ -29,6 +29,10 @@ func DefaultsArrayToCollectionArray(propertyName string, defaultValue interface{
 					arrayProperties[keyAsString] = SimpleBoolean(v)
 				case int:
 					arrayProperties[keyAsString] = SimpleInteger(v)
+				case float32:
+					arrayProperties[keyAsString] = SimpleFloat(v)
+				case float64:
+					arrayProperties[keyAsString] = SimpleFloat(v)
 
 				default:
 					return nil, fmt.Errorf("value %v is not known", reflect.TypeOf(value))

--- a/configtemplate/generator/collection_property_metadata_test.go
+++ b/configtemplate/generator/collection_property_metadata_test.go
@@ -95,6 +95,28 @@ var _ = Describe("CollectionPropertyMetadata", func() {
 			Expect(err).Should(MatchError("value int64 is not known"))
 			Expect(len(collectionArray)).Should(Equal(0))
 		})
+
+		It("contains float32 types", func() {
+			defaults := make([]interface{}, 1)
+			defaults[0] = map[interface{}]interface{}{
+				"simple": float32(0),
+			}
+			collectionArray, err := generator.DefaultsArrayToCollectionArray("foo", defaults, nil)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(collectionArray)).Should(Equal(1))
+			Expect(collectionArray[0]["simple"]).Should(Equal(generator.SimpleFloat(0.0)))
+		})
+
+		It("contains float64 types", func() {
+			defaults := make([]interface{}, 1)
+			defaults[0] = map[interface{}]interface{}{
+				"simple": float64(0),
+			}
+			collectionArray, err := generator.DefaultsArrayToCollectionArray("foo", defaults, nil)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(collectionArray)).Should(Equal(1))
+			Expect(collectionArray[0]["simple"]).Should(Equal(generator.SimpleFloat(0.0)))
+		})
 	})
 
 	Context("DefaultsToArray", func() {

--- a/configtemplate/generator/value_types.go
+++ b/configtemplate/generator/value_types.go
@@ -42,6 +42,16 @@ func (s SimpleInteger) IsSelector() bool {
 	return false
 }
 
+type SimpleFloat float64
+
+func (s SimpleFloat) Parameters() []string {
+	return []string{fmt.Sprintf("%f", s)}
+}
+
+func (s SimpleFloat) IsSelector() bool {
+	return false
+}
+
 type SelectorValue struct {
 	Value string `yaml:"value"`
 }


### PR DESCRIPTION
Certain tiles (the Dell-provided ECS tile for example) have default values that are floats, which `config-template` is unable to parse because it does not take `float32` and `float64` into account. This adds that support by adding a `SimpleFloat` type and adding it to the collection property metadata generator.