### PR TITLE
Prefer errors.New over fmt.Errorf

### DIFF
--- a/api/revert_staged_changes.go
+++ b/api/revert_staged_changes.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 )
@@ -21,7 +22,7 @@ func (a Api) RevertStagedChanges() (bool, error) {
 	}
 
 	if response.StatusCode == http.StatusNotFound {
-		return false, fmt.Errorf("The revert staged changes endpoint is not available in the version of Ops Manager.\nThis endpoint was not available until Ops Manager 2.5.21+, 2.6.13+, or 2.7.2+.")
+		return false, errors.New("The revert staged changes endpoint is not available in the version of Ops Manager.\nThis endpoint was not available until Ops Manager 2.5.21+, 2.6.13+, or 2.7.2+.")
 	}
 
 	if err := validateStatus(response, http.StatusNoContent); err != nil {

--- a/api/staged_products_service.go
+++ b/api/staged_products_service.go
@@ -3,6 +3,7 @@ package api
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -200,7 +201,7 @@ func (a Api) GetStagedProductSyslogConfiguration(product string) (map[string]int
 	return syslogConfig.SyslogConfiguration, nil
 }
 
-var errNotFound = fmt.Errorf("element not found")
+var errNotFound = errors.New("element not found")
 
 func getString(element interface{}, key string) (string, error) {
 	value, err := get(element, key)
@@ -365,7 +366,7 @@ func (a Api) UpdateSyslogConfiguration(input UpdateSyslogConfigurationInput) err
 	return nil
 }
 
-//TODO consider refactoring to use fetchProductResource
+// TODO consider refactoring to use fetchProductResource
 func (a Api) GetStagedProductManifest(guid string) (string, error) {
 	resp, err := a.sendAPIRequest("GET", fmt.Sprintf("/api/v0/staged/products/%s/manifest", guid), nil)
 	if err != nil {

--- a/api/stemcell_service.go
+++ b/api/stemcell_service.go
@@ -65,7 +65,7 @@ func (a Api) CheckStemcellAvailability(stemcellFilename string) (bool, error) {
 
 	info, err := a.Info()
 	if err != nil {
-		return false, fmt.Errorf("cannot retrieve version of Ops Manager")
+		return false, fmt.Errorf("cannot retrieve version of Ops Manager: %w", err)
 	}
 
 	validVersion, err := info.VersionAtLeast(2, 6)

--- a/api/vm_types_service.go
+++ b/api/vm_types_service.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 )
@@ -44,21 +45,21 @@ func (c *CreateVMType) UnmarshalJSON(b []byte) error {
 
 		case "ram":
 			if u, ok = value.(float64); !ok {
-				return fmt.Errorf("could not marshal ram into uint")
+				return errors.New("could not marshal ram into uint")
 			}
 
 			c.RAM = uint(u)
 
 		case "cpu":
 			if u, ok = value.(float64); !ok {
-				return fmt.Errorf("could not marshal cpu into uint")
+				return errors.New("could not marshal cpu into uint")
 			}
 
 			c.CPU = uint(u)
 
 		case "ephemeral_disk":
 			if u, ok = value.(float64); !ok {
-				return fmt.Errorf("could not marshal ephemeral_disk into uint")
+				return errors.New("could not marshal ephemeral_disk into uint")
 			}
 
 			c.EphemeralDisk = uint(u)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,7 +1,16 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"regexp"
+	"strings"
+	"time"
+
 	"github.com/jessevdk/go-flags"
 	"github.com/olekukonko/tablewriter"
 	"github.com/pivotal-cf/om/api"
@@ -13,13 +22,6 @@ import (
 	"github.com/pivotal-cf/om/presenters"
 	"github.com/pivotal-cf/om/renderers"
 	"gopkg.in/yaml.v2"
-	"io"
-	"log"
-	"net/http"
-	"os"
-	"regexp"
-	"strings"
-	"time"
 )
 
 type httpClient interface {
@@ -769,7 +771,7 @@ func checkForVars(opts *options) error {
 		errBuffer = append(errBuffer, "Or, to enable interpolation of env.yml with variables from env-vars,")
 		errBuffer = append(errBuffer, "set the OM_VARS_ENV env var and put export the needed vars.")
 
-		return fmt.Errorf(strings.Join(errBuffer, "\n"))
+		return errors.New(strings.Join(errBuffer, "\n"))
 	}
 
 	return nil

--- a/commands/apply_changes.go
+++ b/commands/apply_changes.go
@@ -4,10 +4,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"gopkg.in/yaml.v2"
 	"os"
 	"sort"
 	"time"
+
+	"gopkg.in/yaml.v2"
 
 	"github.com/pivotal-cf/om/api"
 )
@@ -56,7 +57,7 @@ func NewApplyChanges(service applyChangesService, pendingService pendingChangesS
 
 func (ac ApplyChanges) Execute(args []string) error {
 	if ac.Options.RecreateVMs && ac.Options.Reattach {
-		return fmt.Errorf("--recreate-vms cannot be used with --reattach because it requires the ability to update a director property")
+		return errors.New("--recreate-vms cannot be used with --reattach because it requires the ability to update a director property")
 	}
 
 	errands := api.ApplyErrandChanges{}
@@ -76,7 +77,7 @@ func (ac ApplyChanges) Execute(args []string) error {
 	var changedProducts []string
 	if len(ac.Options.ProductNames) > 0 {
 		if ac.Options.SkipDeployProducts {
-			return fmt.Errorf("product-name flag can not be passed with the skip-deploy-products flag")
+			return errors.New("product-name flag can not be passed with the skip-deploy-products flag")
 		}
 		info, err := ac.service.Info()
 		if err != nil {
@@ -104,7 +105,7 @@ func (ac ApplyChanges) Execute(args []string) error {
 			return err
 		} else {
 			ac.logger.Printf("found already running installation... not re-attaching (Installation ID: %d, Started: %s)", installation.ID, startedAtFormatted)
-			return fmt.Errorf("apply changes is already running, use \"--reattach\" to enable reattaching")
+			return errors.New("apply changes is already running, use \"--reattach\" to enable reattaching")
 		}
 	}
 

--- a/commands/assign_multi_stemcell.go
+++ b/commands/assign_multi_stemcell.go
@@ -1,9 +1,11 @@
 package commands
 
 import (
+	"errors"
 	"fmt"
-	"github.com/pivotal-cf/om/api"
 	"strings"
+
+	"github.com/pivotal-cf/om/api"
 )
 
 type AssignMultiStemcell struct {
@@ -141,13 +143,12 @@ Available Stemcells for "%s": %s`, version, os, as.Options.ProductName, listOfSt
 	}
 
 	return stemcellGroup, nil
-
 }
 
 func (as AssignMultiStemcell) validateOpsManVersion() error {
 	info, err := as.service.Info()
 	if err != nil {
-		return fmt.Errorf("cannot retrieve version of Ops Manager")
+		return errors.New("cannot retrieve version of Ops Manager")
 	}
 
 	validVersion, err := info.VersionAtLeast(2, 6)
@@ -159,7 +160,7 @@ func (as AssignMultiStemcell) validateOpsManVersion() error {
 		return nil
 	}
 
-	return fmt.Errorf("this command can only be used with OpsManager 2.6+")
+	return errors.New("this command can only be used with OpsManager 2.6+")
 }
 
 func (as AssignMultiStemcell) transformArgs(availableVersions []api.StemcellObject, index int, option string) ([]string, error) {

--- a/commands/bosh_diff_test.go
+++ b/commands/bosh_diff_test.go
@@ -1,7 +1,7 @@
 package commands_test
 
 import (
-	"fmt"
+	"errors"
 	"log"
 
 	"github.com/fatih/color"
@@ -126,8 +126,8 @@ var _ = Describe("BoshDiff", func() {
 			})
 
 			It("prints both", func() {
-				//disable color for just this test;
-				//we don't want to try to assemble this whole example with color
+				// disable color for just this test;
+				// we don't want to try to assemble this whole example with color
 				color.NoColor = true
 				defer func() { color.NoColor = false }()
 
@@ -245,7 +245,6 @@ var _ = Describe("BoshDiff", func() {
 				Expect(logBuffer).To(gbytes.Say("no changes"))
 				Expect(logBuffer).To(gbytes.Say("## Runtime Configs"))
 				Expect(logBuffer).To(gbytes.Say("timeout: 30"))
-
 			})
 		})
 
@@ -343,7 +342,7 @@ var _ = Describe("BoshDiff", func() {
 			It("returns that error", func() {
 				// setup
 				service.ProductDiffReturns(
-					api.ProductDiff{}, fmt.Errorf("too many cooks"))
+					api.ProductDiff{}, errors.New("too many cooks"))
 
 				// execute
 				diff := commands.NewBoshDiff(service, logger)
@@ -528,8 +527,8 @@ var _ = Describe("BoshDiff", func() {
 			})
 
 			It("--check prints runtime and manifest configs for the director and the product and exits with 1", func() {
-				//disable color for just this test;
-				//we don't want to try to assemble this whole example with color
+				// disable color for just this test;
+				// we don't want to try to assemble this whole example with color
 				color.NoColor = true
 				defer func() { color.NoColor = false }()
 
@@ -587,7 +586,7 @@ var _ = Describe("BoshDiff", func() {
 					GUID: "another-product-guid",
 					Type: "another-product",
 				}}}, nil)
-				service.DirectorDiffReturns(api.DirectorDiff{}, fmt.Errorf("insufficient cooks"))
+				service.DirectorDiffReturns(api.DirectorDiff{}, errors.New("insufficient cooks"))
 
 				diff := commands.NewBoshDiff(service, logger)
 				err = executeCommand(diff, []string{""})
@@ -599,7 +598,7 @@ var _ = Describe("BoshDiff", func() {
 		When("there is an error from the ListStagedProducts method", func() {
 			It("returns that error", func() {
 				service.ListStagedProductsReturns(
-					api.StagedProductsOutput{}, fmt.Errorf("insufficient cooks"))
+					api.StagedProductsOutput{}, errors.New("insufficient cooks"))
 
 				diff := commands.NewBoshDiff(service, logger)
 				err = executeCommand(diff, []string{""})

--- a/commands/certificate_authorities_test.go
+++ b/commands/certificate_authorities_test.go
@@ -1,7 +1,7 @@
 package commands_test
 
 import (
-	"fmt"
+	"errors"
 
 	"github.com/pivotal-cf/om/api"
 	"github.com/pivotal-cf/om/commands"
@@ -80,7 +80,7 @@ var _ = Describe("Certificate Authorities", func() {
 			It("returns an error", func() {
 				fakeCertificateAuthoritiesService.ListCertificateAuthoritiesReturns(
 					api.CertificateAuthoritiesOutput{},
-					fmt.Errorf("could not get certificate authorities"),
+					errors.New("could not get certificate authorities"),
 				)
 
 				err := executeCommand(command, []string{})

--- a/commands/config_template.go
+++ b/commands/config_template.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -46,8 +47,10 @@ var DefaultProvider = func() func(c *ConfigTemplate) MetadataProvider {
 	}
 }
 
-type buildProvider func(*ConfigTemplate) MetadataProvider
-type envProvider func() []string
+type (
+	buildProvider func(*ConfigTemplate) MetadataProvider
+	envProvider   func() []string
+)
 
 func NewConfigTemplate(bp buildProvider) *ConfigTemplate {
 	return NewConfigTemplateWithEnvironment(bp, os.Environ)
@@ -60,7 +63,7 @@ func NewConfigTemplateWithEnvironment(bp buildProvider, environFunc envProvider)
 	}
 }
 
-//Execute - generates config template and ops files
+// Execute - generates config template and ops files
 func (c *ConfigTemplate) Execute(args []string) error {
 	_, err := os.Stat(c.Options.OutputDirectory)
 	if os.IsNotExist(err) {
@@ -112,5 +115,5 @@ func (c *ConfigTemplate) Validate() error {
 		return nil
 	}
 
-	return fmt.Errorf("cannot load tile metadata: please provide either pivnet flags OR product-path")
+	return errors.New("cannot load tile metadata: please provide either pivnet flags OR product-path")
 }

--- a/commands/configure_director.go
+++ b/commands/configure_director.go
@@ -2,10 +2,12 @@ package commands
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
-	"github.com/pivotal-cf/om/interpolate"
 	"sort"
 	"strings"
+
+	"github.com/pivotal-cf/om/interpolate"
 
 	"github.com/pivotal-cf/om/api"
 	"gopkg.in/yaml.v2"
@@ -212,7 +214,7 @@ vmextensions-configuration: {}
 		for _, depKey := range deprecatedKeys {
 			for _, unrecKey := range unrecognizedKeys {
 				if depKey == unrecKey {
-					return fmt.Errorf(errorMessage)
+					return errors.New(errorMessage)
 				}
 			}
 		}
@@ -232,7 +234,7 @@ func (c ConfigureDirector) checkIAASConfigurationIsOnlySetOnce(config *directorC
 	iaasProperties := properties["iaas-configuration"]
 
 	if iaasConfigurations != nil && iaasProperties != nil {
-		return fmt.Errorf("iaas-configurations cannot be used with properties-configuration.iaas-configurations\n" +
+		return errors.New("iaas-configurations cannot be used with properties-configuration.iaas-configurations\n" +
 			"Please only use one implementation.")
 	}
 	return nil
@@ -448,7 +450,7 @@ func (c ConfigureDirector) configureVMExtensions(config *directorConfig) error {
 func (c ConfigureDirector) configureVMTypes(config *directorConfig) error {
 	if len(config.VMTypes.VMTypes) == 0 {
 		if config.VMTypes.CustomTypesOnly {
-			return fmt.Errorf("if custom_types = true, vm_types must not be empty")
+			return errors.New("if custom_types = true, vm_types must not be empty")
 		}
 
 		return nil
@@ -529,7 +531,7 @@ func checkRunningInstallation(listInstallations func() ([]api.InstallationsServi
 	}
 	if len(installations) > 0 {
 		if installations[0].Status == "running" {
-			return fmt.Errorf("OpsManager does not allow configuration or staging changes while apply changes are running to prevent data loss for configuration and/or staging changes")
+			return errors.New("OpsManager does not allow configuration or staging changes while apply changes are running to prevent data loss for configuration and/or staging changes")
 		}
 	}
 	return nil

--- a/commands/configure_product.go
+++ b/commands/configure_product.go
@@ -2,10 +2,12 @@ package commands
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
-	"github.com/pivotal-cf/om/interpolate"
 	"sort"
 	"strings"
+
+	"github.com/pivotal-cf/om/interpolate"
 
 	"github.com/pivotal-cf/om/api"
 	"github.com/pivotal-cf/om/config"
@@ -334,7 +336,7 @@ func (cp *ConfigureProduct) interpolateConfig(cfg configureProduct) (configurePr
 
 func (cp ConfigureProduct) validateConfig(cfg configureProduct) error {
 	if cfg.ProductName == "" {
-		return fmt.Errorf("could not parse configure-product config: \"product-name\" is required")
+		return errors.New("could not parse configure-product config: \"product-name\" is required")
 	}
 
 	if len(cfg.Field) > 0 {
@@ -386,7 +388,7 @@ func (cp ConfigureProduct) validateConfigComplete(productGUID string) error {
 		if changeList.GUID == productGUID {
 			completenessCheck := changeList.CompletenessChecks
 			if completenessCheck == nil {
-				return fmt.Errorf("configuration completeness could not be determined.\nThis feature is only supported for OpsMan 2.2+\nIf you're on older version of OpsMan add the line `validate-config-complete: false` to your config file.")
+				return errors.New("configuration completeness could not be determined.\nThis feature is only supported for OpsMan 2.2+\nIf you're on older version of OpsMan add the line `validate-config-complete: false` to your config file.")
 			}
 			if !completenessCheck.ConfigurationComplete {
 				return fmt.Errorf("configuration not complete.\nThe properties you provided have been set,\nbut some required properties or configuration details are still missing.\nVisit the Ops Manager for details: %s", cp.target)

--- a/commands/curl.go
+++ b/commands/curl.go
@@ -2,12 +2,11 @@ package commands
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"strings"
-
-	"encoding/json"
 
 	"github.com/pivotal-cf/om/api"
 )
@@ -91,7 +90,7 @@ func (c Curl) Execute(args []string) error {
 	c.stdout.Println(string(body))
 
 	if output.StatusCode >= 400 {
-		return fmt.Errorf("server responded with an error")
+		return fmt.Errorf("server responded with a %d error", output.StatusCode)
 	}
 
 	return nil

--- a/commands/curl_test.go
+++ b/commands/curl_test.go
@@ -130,7 +130,8 @@ var _ = Describe("Curl", func() {
 					"--request", "GET",
 					"--silent",
 				})
-				Expect(err).To(MatchError("server responded with an error"))
+
+				Expect(err).To(MatchError("server responded with a 404 error"))
 
 				format, content := stderr.PrintfArgsForCall(0)
 				Expect(fmt.Sprintf(format, content...)).To(Equal("Status: 404 Not Found"))
@@ -250,7 +251,7 @@ var _ = Describe("Curl", func() {
 					"--request", "POST",
 					"--data", `{"some-key": "some-value"}`,
 				})
-				Expect(err).To(MatchError("server responded with an error"))
+				Expect(err).To(MatchError("server responded with a 401 error"))
 			})
 		})
 	})

--- a/commands/download_product.go
+++ b/commands/download_product.go
@@ -242,26 +242,26 @@ func (c *DownloadProduct) validate() error {
 	c.handleAliases()
 
 	if c.Options.FileGlob == "" {
-		return fmt.Errorf("--file-glob is required")
+		return errors.New("--file-glob is required")
 	}
 
 	if c.Options.ProductVersionRegex != "" && c.Options.ProductVersion != "" {
-		return fmt.Errorf("cannot use both --product-version and --product-version-regex; please choose one or the other")
+		return errors.New("cannot use both --product-version and --product-version-regex; please choose one or the other")
 	}
 
 	if c.Options.ProductVersionRegex == "" && c.Options.ProductVersion == "" {
-		return fmt.Errorf("no version information provided; please provide either --product-version or --product-version-regex")
+		return errors.New("no version information provided; please provide either --product-version or --product-version-regex")
 	}
 
 	if c.Options.PivnetToken == "" && c.Options.Source == "pivnet" {
-		return fmt.Errorf(`could not execute "download-product": could not parse download-product flags: missing required flag "--pivnet-api-token"`)
+		return errors.New(`could not execute "download-product": could not parse download-product flags: missing required flag "--pivnet-api-token"`)
 	}
 
 	if c.Options.StemcellHeavy && c.Options.StemcellIaas == "" {
-		return fmt.Errorf("--stemcell-heavy requires --stemcell-iaas to be defined")
+		return errors.New("--stemcell-heavy requires --stemcell-iaas to be defined")
 	}
 	if c.Options.StemcellVersion != "" && c.Options.StemcellIaas == "" {
-		return fmt.Errorf("--stemcell-version requires --stemcell-iaas to be defined")
+		return errors.New("--stemcell-version requires --stemcell-iaas to be defined")
 	}
 
 	file, err := os.Open(c.Options.OutputDir)
@@ -504,7 +504,7 @@ func (c *DownloadProduct) downloadProductFile(slug, version, glob, prefixPath st
 			productFilePath)
 		c.stderr.Print(e)
 		_ = os.Remove(partialProductFilePath)
-		return productFilePath, fileArtifact, fmt.Errorf(e)
+		return productFilePath, fileArtifact, errors.New(e)
 	}
 
 	_ = os.Rename(partialProductFilePath, productFilePath)
@@ -519,8 +519,8 @@ func (c *DownloadProduct) cleanupCacheArtifacts(outputDir string, glob string, p
 			return err
 		}
 
-		var prefixedGlob = fmt.Sprintf("\\[%s,*\\]%s", slug, glob)
-		var globs = []string{glob, prefixedGlob}
+		prefixedGlob := fmt.Sprintf("\\[%s,*\\]%s", slug, glob)
+		globs := []string{glob, prefixedGlob}
 		for _, fileGlob := range globs {
 			c.stderr.Printf("Cleaning up cached artifacts in directory '%s' with the glob '%s'", outputDir, fileGlob)
 			for _, file := range outputDirContents {
@@ -632,5 +632,5 @@ func newDownloadClientFromSource(c DownloadProductOptions,
 		), nil
 	}
 
-	return nil, fmt.Errorf("could not find a plugin")
+	return nil, errors.New("could not find a plugin")
 }

--- a/commands/download_product_test.go
+++ b/commands/download_product_test.go
@@ -131,7 +131,6 @@ var _ = Describe("DownloadProduct", func() {
 
 			When("the releases contains non-semver-compatible version", func() {
 				BeforeEach(func() {
-
 					fakeProductDownloader.GetAllProductVersionsReturns(
 						[]string{"2.1.2", "2.0.x"},
 						nil,
@@ -804,7 +803,7 @@ var _ = Describe("DownloadProduct", func() {
 
 				When("the stemcell check service returns an error", func() {
 					BeforeEach(func() {
-						fakeDownloadProductService.CheckStemcellAvailabilityReturns(false, fmt.Errorf("some error"))
+						fakeDownloadProductService.CheckStemcellAvailabilityReturns(false, errors.New("some error"))
 					})
 
 					It("returns that error", func() {
@@ -835,7 +834,7 @@ var _ = Describe("DownloadProduct", func() {
 					BeforeEach(func() {
 						fa := &fakes.FileArtifacter{}
 						fa.NameReturns("/some-account/some-bucket/cf-2.1-build.11.pivotal")
-						fa.ProductMetadataReturns(nil, fmt.Errorf("some error"))
+						fa.ProductMetadataReturns(nil, errors.New("some error"))
 
 						fakeProductDownloader.GetLatestProductFileReturns(fa, nil)
 					})
@@ -933,7 +932,7 @@ var _ = Describe("DownloadProduct", func() {
 
 					When("the product check service returns an error", func() {
 						BeforeEach(func() {
-							fakeDownloadProductService.CheckProductAvailabilityReturns(false, fmt.Errorf("some error"))
+							fakeDownloadProductService.CheckProductAvailabilityReturns(false, errors.New("some error"))
 						})
 
 						It("returns that error", func() {
@@ -1277,7 +1276,7 @@ var _ = Describe("DownloadProduct", func() {
 
 	When("the release specified is not available", func() {
 		BeforeEach(func() {
-			fakeProductDownloader.GetLatestProductFileReturns(nil, fmt.Errorf("some-error"))
+			fakeProductDownloader.GetLatestProductFileReturns(nil, errors.New("some-error"))
 		})
 
 		It("returns an error", func() {

--- a/commands/expiring_certificates.go
+++ b/commands/expiring_certificates.go
@@ -3,11 +3,12 @@ package commands
 import (
 	"errors"
 	"fmt"
-	"github.com/fatih/color"
-	"github.com/pivotal-cf/om/api"
 	"regexp"
 	"strings"
 	"time"
+
+	"github.com/fatih/color"
+	"github.com/pivotal-cf/om/api"
 )
 
 //counterfeiter:generate -o ./fakes/expiring_certs_service.go --fake-name ExpiringCertsService . expiringCertsService
@@ -118,7 +119,7 @@ func (e ExpiringCerts) validateConfig() error {
 	}
 
 	if !matched {
-		return fmt.Errorf("only d,w,m, or y are supported. Default is \"3m\"")
+		return errors.New("only d,w,m, or y are supported. Default is \"3m\"")
 	}
 	return nil
 }

--- a/commands/import_installation.go
+++ b/commands/import_installation.go
@@ -2,11 +2,13 @@ package commands
 
 import (
 	"archive/zip"
+	"errors"
 	"fmt"
-	"github.com/pivotal-cf/om/api"
 	"os"
 	"strings"
 	"time"
+
+	"github.com/pivotal-cf/om/api"
 )
 
 const maxRetries = 3
@@ -118,7 +120,7 @@ func (ii ImportInstallation) ensureAvailability() error {
 
 func (ii *ImportInstallation) validate(args []string) error {
 	if ii.passphrase == "" {
-		return fmt.Errorf("the global decryption-passphrase argument is required for this command")
+		return errors.New("the global decryption-passphrase argument is required for this command")
 	}
 
 	if _, err := os.Stat(ii.Options.Installation); err != nil {

--- a/commands/import_installation_test.go
+++ b/commands/import_installation_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/pivotal-cf/om/api"
@@ -14,7 +15,6 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"os"
 )
 
 var _ = Describe("ImportInstallation", func() {
@@ -81,7 +81,8 @@ var _ = Describe("ImportInstallation", func() {
 
 		command := commands.NewImportInstallation(multipart, fakeService, "some-passphrase", logger)
 
-		err := executeCommand(command, []string{"--polling-interval", "0",
+		err := executeCommand(command, []string{
+			"--polling-interval", "0",
 			"--installation", installationFile,
 		})
 		Expect(err).ToNot(HaveOccurred())
@@ -124,7 +125,8 @@ var _ = Describe("ImportInstallation", func() {
 
 			command := commands.NewImportInstallation(multipart, fakeService, "some-passphrase", logger)
 
-			err := executeCommand(command, []string{"--polling-interval", "0",
+			err := executeCommand(command, []string{
+				"--polling-interval", "0",
 				"--installation", installationFile,
 			})
 			Expect(err).ToNot(HaveOccurred())
@@ -152,7 +154,7 @@ var _ = Describe("ImportInstallation", func() {
 		It("it retries on the specified polling interval to allow nginx time to boot up", func() {
 			fakeService.EnsureAvailabilityStub = func(api.EnsureAvailabilityInput) (api.EnsureAvailabilityOutput, error) {
 				if fakeService.EnsureAvailabilityCallCount() < 4 && fakeService.EnsureAvailabilityCallCount() > 2 {
-					return api.EnsureAvailabilityOutput{}, fmt.Errorf("connection refused")
+					return api.EnsureAvailabilityOutput{}, errors.New("connection refused")
 				}
 
 				eaOutputs := []api.EnsureAvailabilityOutput{
@@ -165,7 +167,8 @@ var _ = Describe("ImportInstallation", func() {
 				return eaOutputs[fakeService.EnsureAvailabilityCallCount()-1], nil
 			}
 
-			err := executeCommand(command, []string{"--polling-interval", "0",
+			err := executeCommand(command, []string{
+				"--polling-interval", "0",
 				"--installation", installationFile,
 			})
 			Expect(err).ToNot(HaveOccurred())
@@ -192,13 +195,14 @@ var _ = Describe("ImportInstallation", func() {
 		It("it only retries 3 times before giving up", func(done Done) {
 			fakeService.EnsureAvailabilityStub = func(api.EnsureAvailabilityInput) (api.EnsureAvailabilityOutput, error) {
 				if fakeService.EnsureAvailabilityCallCount() > 2 {
-					return api.EnsureAvailabilityOutput{}, fmt.Errorf("connection refused")
+					return api.EnsureAvailabilityOutput{}, errors.New("connection refused")
 				}
 
 				return api.EnsureAvailabilityOutput{Status: api.EnsureAvailabilityStatusUnstarted}, nil
 			}
 
-			err := executeCommand(command, []string{"--polling-interval", "0",
+			err := executeCommand(command, []string{
+				"--polling-interval", "0",
 				"--installation", installationFile,
 			})
 			Expect(err).To(MatchError(ContainSubstring("could not check Ops Manager Status:")))

--- a/commands/interpolate.go
+++ b/commands/interpolate.go
@@ -1,11 +1,13 @@
 package commands
 
 import (
+	"errors"
 	"fmt"
-	"github.com/pivotal-cf/om/interpolate"
 	"io/ioutil"
 	"log"
 	"os"
+
+	"github.com/pivotal-cf/om/interpolate"
 )
 
 type interpolateOptions struct {
@@ -76,7 +78,7 @@ func (c Interpolate) Execute(args []string) error {
 		c.Options.ConfigFile = tempFile.Name()
 
 	} else if len(c.Options.ConfigFile) == 0 || c.Options.ConfigFile == "-" {
-		return fmt.Errorf("no file or STDIN input provided. Please provide a valid --config file or use a pipe to get STDIN")
+		return errors.New("no file or STDIN input provided. Please provide a valid --config file or use a pipe to get STDIN")
 	}
 
 	expectAllKeys := true

--- a/commands/pre_deploy_check.go
+++ b/commands/pre_deploy_check.go
@@ -1,11 +1,13 @@
 package commands
 
 import (
+	"errors"
 	"fmt"
+	"strings"
+
 	"github.com/fatih/color"
 	"github.com/pivotal-cf/om/api"
 	"github.com/pivotal-cf/om/presenters"
-	"strings"
 )
 
 type PreDeployCheck struct {
@@ -79,7 +81,7 @@ func (pc PreDeployCheck) Execute(args []string) error {
 	if len(errorBuffer) > 0 {
 		pc.logger.Printf(strings.Join(errorBuffer, "\n") + "\n")
 
-		return fmt.Errorf("OpsManager is not fully configured")
+		return errors.New("OpsManager is not fully configured")
 	}
 
 	pc.logger.Println("\nThe director and products are configured correctly.")

--- a/commands/ssl_certificate_test.go
+++ b/commands/ssl_certificate_test.go
@@ -1,7 +1,7 @@
 package commands_test
 
 import (
-	"fmt"
+	"errors"
 
 	"github.com/pivotal-cf/om/api"
 	"github.com/pivotal-cf/om/commands"
@@ -65,7 +65,7 @@ var _ = Describe("SslCertificate", func() {
 			It("returns an error", func() {
 				fakeSSLCertificateService.GetSSLCertificateReturns(
 					api.SSLCertificateOutput{},
-					fmt.Errorf("could not get custom certificate"),
+					errors.New("could not get custom certificate"),
 				)
 
 				err := executeCommand(command, []string{})

--- a/configtemplate/generator/execute.go
+++ b/configtemplate/generator/execute.go
@@ -1,6 +1,7 @@
 package generator
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -36,7 +37,7 @@ func (e *Executor) Generate() error {
 	}
 	productVersion := metadata.ProductVersion()
 	if productVersion == "" {
-		return fmt.Errorf("version in metadata is blank")
+		return errors.New("version in metadata is blank")
 	}
 
 	productName := metadata.ProductName()

--- a/download_clients/determine_product_version.go
+++ b/download_clients/determine_product_version.go
@@ -1,12 +1,14 @@
 package download_clients
 
 import (
+	"errors"
 	"fmt"
-	"github.com/hashicorp/go-version"
 	"log"
 	"regexp"
 	"sort"
 	"strings"
+
+	"github.com/hashicorp/go-version"
 )
 
 //counterfeiter:generate -o ./fakes/product_versioner.go --fake-name ProductVersioner . productVersioner
@@ -69,7 +71,7 @@ func findLatestVersionFromRegex(productVersions []string, regex string, stderr *
 
 		v, err := version.NewVersion(productVersion)
 		if err != nil {
-			stderr.Printf(fmt.Sprintf("warning: could not parse semver version from: %s", productVersion))
+			stderr.Printf("warning: could not parse semver version from: %s", productVersion)
 			continue
 		}
 		versions = append(versions, v)
@@ -78,7 +80,7 @@ func findLatestVersionFromRegex(productVersions []string, regex string, stderr *
 	sort.Sort(versions)
 
 	if len(versions) == 0 {
-		return "", fmt.Errorf("no available version found")
+		return "", errors.New("no available version found")
 	}
 
 	return versions[len(versions)-1].Original(), nil

--- a/download_clients/determine_product_version_test.go
+++ b/download_clients/determine_product_version_test.go
@@ -1,13 +1,14 @@
 package download_clients_test
 
 import (
-	"fmt"
+	"errors"
+	"log"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
 	"github.com/pivotal-cf/om/download_clients"
 	"github.com/pivotal-cf/om/download_clients/fakes"
-	"log"
 )
 
 var _ = Describe("DetermineProductVersion", func() {
@@ -135,7 +136,7 @@ var _ = Describe("DetermineProductVersion", func() {
 		When("versions cannot be loaded", func() {
 			It("returns an error", func() {
 				versioner := &fakes.ProductVersioner{}
-				versioner.GetAllProductVersionsReturns(nil, fmt.Errorf("some error"))
+				versioner.GetAllProductVersionsReturns(nil, errors.New("some error"))
 
 				_, err := download_clients.DetermineProductVersion(
 					"product",

--- a/download_clients/s3_client.go
+++ b/download_clients/s3_client.go
@@ -1,12 +1,13 @@
 package download_clients
 
 import (
-	"fmt"
+	"errors"
+	"log"
+	"strconv"
+
 	"github.com/graymeta/stow"
 	"github.com/graymeta/stow/s3"
 	"gopkg.in/go-playground/validator.v9"
-	"log"
-	"strconv"
 )
 
 type S3Configuration struct {
@@ -59,7 +60,7 @@ func validateAccessKeyAuthType(config S3Configuration) error {
 	}
 
 	if config.AccessKeyID == "" || config.SecretAccessKey == "" {
-		return fmt.Errorf("the flags \"s3-access-key-id\" and \"s3-secret-access-key\" are required when the \"auth-type\" is \"accesskey\"")
+		return errors.New("the flags \"s3-access-key-id\" and \"s3-secret-access-key\" are required when the \"auth-type\" is \"accesskey\"")
 	}
 
 	return nil

--- a/extractor/metadata_extractor_test.go
+++ b/extractor/metadata_extractor_test.go
@@ -3,14 +3,16 @@ package extractor_test
 import (
 	"archive/zip"
 	"bytes"
+	"errors"
 	"fmt"
-	"github.com/onsi/gomega/ghttp"
-	"github.com/pivotal-cf/om/extractor/fakes"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"os"
 	"time"
+
+	"github.com/onsi/gomega/ghttp"
+	"github.com/pivotal-cf/om/extractor/fakes"
 
 	"github.com/pivotal-cf/om/extractor"
 
@@ -98,7 +100,7 @@ var _ = Describe("MetadataExtractor", func() {
 
 		It("allows a custom HTTP client", func() {
 			client := &fakes.HttpClient{}
-			client.DoReturns(nil, fmt.Errorf("some error"))
+			client.DoReturns(nil, errors.New("some error"))
 
 			metadataExtractor = extractor.NewMetadataExtractor(extractor.WithHTTPClient(client))
 			_, err := metadataExtractor.ExtractFromURL("https://example.com")

--- a/network/decrypt_client.go
+++ b/network/decrypt_client.go
@@ -65,7 +65,7 @@ func (c *DecryptClient) decrypt() error {
 		}
 
 		if e, ok := err.(net.Error); ok && e.Timeout() {
-			//jitter on the retry
+			// jitter on the retry
 			time.Sleep(time.Duration(rand.Intn(50)) * time.Millisecond)
 			continue
 		}
@@ -81,14 +81,14 @@ func (c *DecryptClient) decrypt() error {
 
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("could not unlock ops manager, check if the decryption passphrase is correct")
+		return errors.New("could not unlock ops manager, check if the decryption passphrase is correct")
 	}
 
 	return c.waitUntilAvailable()
 }
 
 func (c DecryptClient) waitUntilAvailable() error {
-	var trial = 1
+	trial := 1
 	for {
 		if trial == 2 {
 			_, _ = c.writer.Write([]byte("Waiting for Ops Manager's auth systems to start. This may take a few minutes...\n"))

--- a/network/http_client.go
+++ b/network/http_client.go
@@ -3,6 +3,7 @@ package network
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -53,7 +54,7 @@ func setCACert(caCert string, tlsConfig *tls.Config) error {
 		caCert = string(contents)
 	}
 	if ok := caCertPool.AppendCertsFromPEM([]byte(caCert)); !ok {
-		return fmt.Errorf("could not use ca cert")
+		return errors.New("could not use ca cert")
 	}
 
 	tlsConfig.RootCAs = caCertPool

--- a/network/unauthenticated_client.go
+++ b/network/unauthenticated_client.go
@@ -1,6 +1,7 @@
 package network
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -41,7 +42,7 @@ func (c UnauthenticatedClient) Do(request *http.Request) (*http.Response, error)
 	}
 
 	if targetURL.Host == "" {
-		return nil, fmt.Errorf("target flag is required. Run `om help` for more info.")
+		return nil, errors.New("target flag is required. Run `om help` for more info.")
 	}
 
 	request.URL.Scheme = targetURL.Scheme

--- a/vmlifecycle/configfetchers/gcp.go
+++ b/vmlifecycle/configfetchers/gcp.go
@@ -1,10 +1,12 @@
 package configfetchers
 
 import (
+	"errors"
 	"fmt"
+	"strings"
+
 	"github.com/pivotal-cf/om/vmlifecycle/vmmanagers"
 	"google.golang.org/api/compute/v1"
-	"strings"
 )
 
 type GCPConfigFetcher struct {
@@ -27,17 +29,16 @@ func (g *GCPConfigFetcher) FetchConfig() (*vmmanagers.OpsmanConfigFilePayload, e
 		g.credentials.GCP.Zone,
 		g.state.ID,
 	).Do()
-
 	if err != nil {
 		return nil, fmt.Errorf("could not fetch instance data: %s", err)
 	}
 
 	if len(instance.Disks) == 0 {
-		return nil, fmt.Errorf("expected a boot disk to be attached to the VM")
+		return nil, errors.New("expected a boot disk to be attached to the VM")
 	}
 
 	if len(instance.NetworkInterfaces) == 0 {
-		return nil, fmt.Errorf("expected a network interface to be attached to the VM")
+		return nil, errors.New("expected a network interface to be attached to the VM")
 	}
 
 	var scopes []string
@@ -56,7 +57,6 @@ func (g *GCPConfigFetcher) FetchConfig() (*vmmanagers.OpsmanConfigFilePayload, e
 		g.credentials.GCP.Zone,
 		splitMachineTypeURL[len(splitMachineTypeURL)-1],
 	).Do()
-
 	if err != nil {
 		return nil, fmt.Errorf("could not fetch machine type data: %s", err)
 	}
@@ -67,7 +67,6 @@ func (g *GCPConfigFetcher) FetchConfig() (*vmmanagers.OpsmanConfigFilePayload, e
 		g.credentials.GCP.Zone,
 		splitDiskURL[len(splitDiskURL)-1],
 	).Do()
-
 	if err != nil {
 		return nil, fmt.Errorf("could not fetch disk data: %s", err)
 	}

--- a/vmlifecycle/configfetchers/initialize.go
+++ b/vmlifecycle/configfetchers/initialize.go
@@ -4,14 +4,15 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-07-01/compute"
-	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-09-01/network"
-	"github.com/Azure/go-autorest/autorest/azure"
-	"github.com/Azure/go-autorest/autorest/azure/auth"
 	"io/ioutil"
 	"net/url"
 	"os"
 	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-07-01/compute"
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-09-01/network"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/Azure/go-autorest/autorest/azure/auth"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
@@ -238,7 +239,6 @@ func validateGCPCreds(creds *Credentials) (err error) {
 	if creds.GCP.ServiceAccount != "" {
 		if _, err := os.Stat(creds.GCP.ServiceAccount); os.IsNotExist(err) {
 			errs = append(errs, fmt.Sprintf("gcp-service-account-json file (%s) cannot be found", creds.GCP.ServiceAccount))
-
 		}
 
 		contents, err := ioutil.ReadFile(creds.GCP.ServiceAccount)
@@ -249,7 +249,7 @@ func validateGCPCreds(creds *Credentials) (err error) {
 	}
 
 	if len(errs) > 0 {
-		err = fmt.Errorf(strings.Join(errs, "\n"))
+		err = errors.New(strings.Join(errs, "\n"))
 	}
 
 	return err
@@ -270,7 +270,7 @@ func validateVCenterCreds(creds *Credentials) (err error) {
 	}
 
 	if len(errs) > 0 {
-		err = fmt.Errorf(strings.Join(errs, "\n"))
+		err = errors.New(strings.Join(errs, "\n"))
 	}
 
 	return err
@@ -295,7 +295,7 @@ func validateAzureCreds(creds *Credentials) (err error) {
 	}
 
 	if len(errs) > 0 {
-		err = fmt.Errorf(strings.Join(errs, "\n"))
+		err = errors.New(strings.Join(errs, "\n"))
 	}
 
 	return err

--- a/vmlifecycle/configfetchers/vsphere.go
+++ b/vmlifecycle/configfetchers/vsphere.go
@@ -4,6 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"path"
+	"strconv"
+	"strings"
+
 	"github.com/pivotal-cf/om/vmlifecycle/vmmanagers"
 	"github.com/vmware/govmomi"
 	"github.com/vmware/govmomi/object"
@@ -11,9 +15,6 @@ import (
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
-	"path"
-	"strconv"
-	"strings"
 )
 
 type VSphereConfigFetcher struct {
@@ -46,7 +47,7 @@ func (v *VSphereConfigFetcher) FetchConfig() (*vmmanagers.OpsmanConfigFilePayloa
 	}
 
 	if len(machine.Guest.Net) == 0 {
-		return nil, fmt.Errorf("expected the VM to be assigned to a network")
+		return nil, errors.New("expected the VM to be assigned to a network")
 	}
 
 	appConfigProperties, err := v.lookupAppConfigProperties(machine)

--- a/vmlifecycle/extractopsmansemver/do.go
+++ b/vmlifecycle/extractopsmansemver/do.go
@@ -1,15 +1,18 @@
 package extractopsmansemver
 
 import (
-	"fmt"
-	"github.com/blang/semver"
+	"errors"
 	"path/filepath"
 	"regexp"
 	"strings"
+
+	"github.com/blang/semver"
 )
 
-var extractSemverVersionRegex = regexp.MustCompile(`(\d+)\.(\d+)\.(\d+)(-build\.\d+)?`)
-var extractOldOpsmanVersionRegex = regexp.MustCompile(`(\d+)\.(\d+)-build\.(\d+)`)
+var (
+	extractSemverVersionRegex    = regexp.MustCompile(`(\d+)\.(\d+)\.(\d+)(-build\.\d+)?`)
+	extractOldOpsmanVersionRegex = regexp.MustCompile(`(\d+)\.(\d+)-build\.(\d+)`)
+)
 
 func Do(s string) (semver.Version, error) {
 	name := regexp.MustCompile(`^\[.*?]`).ReplaceAllString(filepath.Base(s), "")
@@ -26,7 +29,7 @@ func Do(s string) (semver.Version, error) {
 	}
 
 	if foundVersion == "" {
-		return semver.Version{}, fmt.Errorf("cannot find version from string")
+		return semver.Version{}, errors.New("cannot find version from string")
 	}
 
 	return semver.Make(foundVersion)

--- a/vmlifecycle/vmlifecyclecommands/create_vm.go
+++ b/vmlifecycle/vmlifecyclecommands/create_vm.go
@@ -1,13 +1,13 @@
 package vmlifecyclecommands
 
 import (
+	"errors"
+	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 
-	"fmt"
-
 	"github.com/pivotal-cf/om/vmlifecycle/vmmanagers"
-	"io/ioutil"
 )
 
 type initCreateFunc func(config *vmmanagers.OpsmanConfigFilePayload, image string, state vmmanagers.StateInfo, outWriter, errWriter io.Writer) (vmmanagers.CreateVMService, error)
@@ -56,7 +56,7 @@ func (c *CreateVM) Execute(args []string) error {
 		_, _ = c.stdout.Write([]byte("VM already exists, not attempting to create it\n"))
 		return writeStatefile(c.StateFile, newState)
 	case vmmanagers.StateMismatch:
-		return fmt.Errorf("VM specified in the statefile does not exist in your IAAS")
+		return errors.New("VM specified in the statefile does not exist in your IAAS")
 	case vmmanagers.Incomplete:
 		finalErr := fmt.Errorf("the VM was created, but subsequent configuration failed: %s", err)
 		writeErr := writeStatefile(c.StateFile, newState)

--- a/vmlifecycle/vmlifecyclecommands/create_vm_test.go
+++ b/vmlifecycle/vmlifecyclecommands/create_vm_test.go
@@ -1,7 +1,12 @@
 package vmlifecyclecommands_test
 
 import (
+	"errors"
 	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+
 	"github.com/jessevdk/go-flags"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
@@ -10,9 +15,6 @@ import (
 	"github.com/pivotal-cf/om/vmlifecycle/vmlifecyclecommands"
 	"github.com/pivotal-cf/om/vmlifecycle/vmmanagers"
 	"github.com/pivotal-cf/om/vmlifecycle/vmmanagers/fakes"
-	"io"
-	"io/ioutil"
-	"os"
 )
 
 var _ = Describe("Create VM", func() {
@@ -298,7 +300,6 @@ opsman-configuration:
 			err := command.Execute([]string{})
 			Expect(err.Error()).To(ContainSubstring(`unknown iaas: non-existent-iaas, please refer to documentation`))
 		})
-
 	})
 
 	When("more than one iaas matches", func() {
@@ -394,7 +395,7 @@ opsman-configuration:
 
 	When("the vm is not created and there is an error", func() {
 		It("does not write or change the state file", func() {
-			fakeService.CreateVMReturns(vmmanagers.Unknown, vmmanagers.StateInfo{}, fmt.Errorf("unknown error"))
+			fakeService.CreateVMReturns(vmmanagers.Unknown, vmmanagers.StateInfo{}, errors.New("unknown error"))
 			command = createCommand(outWriter, errWriter, fakeService, configStr, "", "", "iaas: gcp\nvm_id: 123")
 
 			err := command.Execute([]string{})
@@ -406,7 +407,7 @@ opsman-configuration:
 
 	When("the vm is created, but some some subsequent step fails", func() {
 		BeforeEach(func() {
-			fakeService.CreateVMReturns(vmmanagers.Incomplete, vmmanagers.StateInfo{IAAS: "gcp", ID: "vm-id"}, fmt.Errorf("unknown error"))
+			fakeService.CreateVMReturns(vmmanagers.Incomplete, vmmanagers.StateInfo{IAAS: "gcp", ID: "vm-id"}, errors.New("unknown error"))
 			command = createCommand(outWriter, errWriter, fakeService, configStr, "", "", "")
 		})
 		It("still writes the VM ID to the statefile", func() {

--- a/vmlifecycle/vmlifecyclecommands/delete_vm.go
+++ b/vmlifecycle/vmlifecyclecommands/delete_vm.go
@@ -1,15 +1,17 @@
 package vmlifecyclecommands
 
 import (
+	"errors"
 	"fmt"
-	"github.com/pivotal-cf/om/interpolate"
-	"github.com/pivotal-cf/om/vmlifecycle/vmmanagers"
-	"gopkg.in/yaml.v2"
 	"io"
 	"io/ioutil"
 	"os"
 	"reflect"
 	"sort"
+
+	"github.com/pivotal-cf/om/interpolate"
+	"github.com/pivotal-cf/om/vmlifecycle/vmmanagers"
+	"gopkg.in/yaml.v2"
 )
 
 type initDeleteFunc func(config *vmmanagers.OpsmanConfigFilePayload, image string, state vmmanagers.StateInfo, outWriter, errWriter io.Writer) (vmmanagers.DeleteVMService, error)
@@ -123,7 +125,7 @@ func GuardAgainstMissingOpsmanConfiguration(configContent []byte, configFilename
 		for _, key := range keys {
 			foundKeysMessage = foundKeysMessage + fmt.Sprintf("  '%s'\n", key)
 		}
-		return fmt.Errorf("top-level-key 'opsman-configuration' is a required key.\n" +
+		return errors.New("top-level-key 'opsman-configuration' is a required key.\n" +
 			"Ensure the correct file is passed, the 'opsman-configuration' key is present, " +
 			"and the key is spelled correctly with a dash(-).\n" +
 			foundKeysMessage)

--- a/vmlifecycle/vmlifecyclecommands/upgrade_opsman.go
+++ b/vmlifecycle/vmlifecyclecommands/upgrade_opsman.go
@@ -3,12 +3,8 @@ package vmlifecyclecommands
 import (
 	"archive/zip"
 	"bytes"
+	"errors"
 	"fmt"
-	"github.com/pivotal-cf/om/interpolate"
-	"github.com/pivotal-cf/om/vmlifecycle/extractopsmansemver"
-	"github.com/pivotal-cf/om/vmlifecycle/runner"
-	"github.com/pivotal-cf/om/vmlifecycle/vmmanagers"
-	"gopkg.in/yaml.v2"
 	"io"
 	"io/ioutil"
 	"log"
@@ -16,6 +12,12 @@ import (
 	"os/exec"
 	"strings"
 	"time"
+
+	"github.com/pivotal-cf/om/interpolate"
+	"github.com/pivotal-cf/om/vmlifecycle/extractopsmansemver"
+	"github.com/pivotal-cf/om/vmlifecycle/runner"
+	"github.com/pivotal-cf/om/vmlifecycle/vmmanagers"
+	"gopkg.in/yaml.v2"
 )
 
 type opsmanVersion struct {
@@ -93,7 +95,7 @@ func (n *UpgradeOpsman) Execute(args []string) error {
 		return n.upgradeOpsman()
 	}
 	if compare == DOWNGRADE {
-		return fmt.Errorf("downgrading is not supported by Ops Manager")
+		return errors.New("downgrading is not supported by Ops Manager")
 	}
 	if compare == EQUAL {
 		if !n.Recreate {
@@ -107,7 +109,7 @@ func (n *UpgradeOpsman) Execute(args []string) error {
 		return n.upgradeOpsman()
 	}
 
-	return fmt.Errorf("unexpected error in upgrading opsman")
+	return errors.New("unexpected error in upgrading opsman")
 }
 
 func (n *UpgradeOpsman) setup() {
@@ -145,7 +147,7 @@ func (n *UpgradeOpsman) compareOpsmanVersions(outBuf *bytes.Buffer) (processingE
 		return ERROR, fmt.Errorf("fatal error %s", err)
 	}
 	if version.Info.Version == "" {
-		return ERROR, fmt.Errorf("info struct could not be parsed")
+		return ERROR, errors.New("info struct could not be parsed")
 	}
 
 	versionToInstall, err := extractopsmansemver.Do(n.CreateVM.ImageFile) //[ops-manager,2.2.0]OpsManager2.2-build.296onGCP.yml
@@ -303,7 +305,7 @@ func (n *UpgradeOpsman) validateImportInstallationConfig() error {
 	}
 
 	if target.Target == "" {
-		return fmt.Errorf("target is a required field in the env configuration")
+		return errors.New("target is a required field in the env configuration")
 	}
 
 	if target.DecryptionPassphrase == "" {
@@ -311,7 +313,7 @@ func (n *UpgradeOpsman) validateImportInstallationConfig() error {
 	}
 
 	if target.DecryptionPassphrase == "" {
-		return fmt.Errorf("decryption-passphrase is a required field in the env configuration")
+		return errors.New("decryption-passphrase is a required field in the env configuration")
 	}
 
 	return nil

--- a/vmlifecycle/vmmanagers/gcp.go
+++ b/vmlifecycle/vmmanagers/gcp.go
@@ -2,6 +2,7 @@ package vmmanagers
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
@@ -110,15 +111,15 @@ func (g *GCPVMManager) CreateVM() (Status, StateInfo, error) {
 	}
 
 	if g.Config.OpsmanConfig.GCP.PublicIP == "" && g.Config.OpsmanConfig.GCP.PrivateIP == "" {
-		return Unknown, StateInfo{}, fmt.Errorf("PublicIP and/or PrivateIP must be set")
+		return Unknown, StateInfo{}, errors.New("PublicIP and/or PrivateIP must be set")
 	}
 
 	if g.Config.OpsmanConfig.GCP.ServiceAccount == "" && g.Config.OpsmanConfig.GCP.ServiceAccountName == "" {
-		return Unknown, StateInfo{}, fmt.Errorf("gcp_service_account or gcp_service_account_name must be set")
+		return Unknown, StateInfo{}, errors.New("gcp_service_account or gcp_service_account_name must be set")
 	}
 
 	if g.Config.OpsmanConfig.GCP.ServiceAccount != "" && g.Config.OpsmanConfig.GCP.ServiceAccountName != "" {
-		return Unknown, StateInfo{}, fmt.Errorf("both gcp_service_account and gcp_service_account_name cannot be set")
+		return Unknown, StateInfo{}, errors.New("both gcp_service_account and gcp_service_account_name cannot be set")
 	}
 
 	imageUriMap, err := loadImageYaml(g.ImageYaml)
@@ -169,7 +170,6 @@ func (g *GCPVMManager) authenticate() error {
 				"describe",
 				g.Config.OpsmanConfig.GCP.ServiceAccountName,
 			})
-
 			if err != nil {
 				return fmt.Errorf("service_account_name error. The service account may not exist or this SDK dose not have permission to access: %s", err)
 			}
@@ -204,7 +204,6 @@ func (g *GCPVMManager) setProject() error {
 		"project",
 		g.Config.OpsmanConfig.GCP.Project,
 	})
-
 	if err != nil {
 		return fmt.Errorf("gcloud error setting project: %s", err)
 	}
@@ -218,7 +217,6 @@ func (g *GCPVMManager) setComputeRegion() error {
 		"compute/region",
 		g.Config.OpsmanConfig.GCP.Region,
 	})
-
 	if err != nil {
 		return fmt.Errorf("gcloud error setting compute/region: %s", err)
 	}
@@ -321,7 +319,6 @@ func (g *GCPVMManager) createVM(publicIP string) (Status, StateInfo, error) {
 		return Exist, currentState, nil
 	}
 	return Unknown, StateInfo{}, fmt.Errorf("gcloud error creating VM: %s", err)
-
 }
 
 func (g *GCPVMManager) deleteVM(id string) error {
@@ -330,7 +327,6 @@ func (g *GCPVMManager) deleteVM(id string) error {
 		"--zone", g.Config.OpsmanConfig.GCP.Zone,
 		"--quiet",
 	})
-
 	if err != nil {
 		return fmt.Errorf("gcloud error deleting VM: %s", err)
 	}

--- a/vmlifecycle/vmmanagers/openstack.go
+++ b/vmlifecycle/vmmanagers/openstack.go
@@ -2,13 +2,15 @@ package vmmanagers
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
-	"github.com/pivotal-cf/om/vmlifecycle/runner"
 	"log"
 	"os"
 	"regexp"
 	"strconv"
 	"strings"
+
+	"github.com/pivotal-cf/om/vmlifecycle/runner"
 )
 
 type OpenstackCredential struct {
@@ -92,7 +94,7 @@ func (o *OpenstackVMManager) CreateVM() (Status, StateInfo, error) {
 	}
 
 	if o.Config.PublicIP == "" && o.Config.PrivateIP == "" {
-		return Unknown, StateInfo{}, fmt.Errorf("PublicIP and/or PrivateIP must be set")
+		return Unknown, StateInfo{}, errors.New("PublicIP and/or PrivateIP must be set")
 	}
 
 	o.addDefaultConfigFields()
@@ -176,7 +178,6 @@ func (o *OpenstackVMManager) createImage(imageName string) (imageURI string, err
 }
 
 func (o *OpenstackVMManager) createVM(imageID string) (serverID string, state StateInfo, err error) {
-
 	var nicStr string
 	if o.Config.PrivateIP != "" {
 		nicStr = fmt.Sprintf(`net-id=%s,v4-fixed-ip=%s`, o.Config.NetID, o.Config.PrivateIP)
@@ -261,7 +262,6 @@ func (o *OpenstackVMManager) getVMImage() (string, error) {
 		`--column`, `image`,
 		`--format`, `value`)
 	stdout, _, err := o.runner.Execute(args)
-
 	if err != nil {
 		return "", fmt.Errorf(
 			"%s\n       Could not find VM with ID %q.\n       To fix, ensure the VM ID in the statefile matches a VM that exists.\n       If the VM has already been deleted, delete the contents of the statefile.",


### PR DESCRIPTION
For simple errors with a static message, prefer `errors.New`, which doesn't need to parse a format string.