### PR TITLE
Update s3-disable-ssl description

### DIFF
--- a/commands/download_product.go
+++ b/commands/download_product.go
@@ -42,7 +42,7 @@ type S3Options struct {
 	S3SecretAccessKey string `long:"s3-secret-access-key"             description:"secret key for the s3 compatible blobstore"`
 	S3RegionName      string `long:"s3-region-name"                   description:"bucket region in the s3 compatible blobstore. If not using AWS, this value is 'region'"`
 	S3Endpoint        string `long:"s3-endpoint"                      description:"the endpoint to access the s3 compatible blobstore. If not using AWS, this is required"`
-	S3DisableSSL      bool   `long:"s3-disable-ssl"                   description:"whether to disable ssl validation when contacting the s3 compatible blobstore"`
+	S3DisableSSL      bool   `long:"s3-disable-ssl"                   description:"whether to disable ssl (https or http) when contacting the s3 compatible blobstore"`
 	S3EnableV2Signing bool   `long:"s3-enable-v2-signing"             description:"whether to use v2 signing with your s3 compatible blobstore. (if you don't know what this is, leave blank, or set to 'false')"`
 }
 


### PR DESCRIPTION
The description for disable-ssl is currently incorrect. It states that ssl validation is disabled, which is false. Currently stow does not have anyway to disable ssl validation. This option actually disables the use of ssl completely to make an http call.