### PR TITLE
fix: typo in error message

### DIFF
--- a/vmlifecycle/vmmanagers/azure.go
+++ b/vmlifecycle/vmmanagers/azure.go
@@ -645,7 +645,7 @@ func (a *AzureVMManager) validateDeprecatedVars() error {
 	}
 
 	if a.Config.OpsmanConfig.Azure.VPCSubnetDEPRECATED != "" {
-		log.Println("\"vpc_subnet\" is DEPRECATED. Please use \"subnet-id\"")
+		log.Println("\"vpc_subnet\" is DEPRECATED. Please use \"subnet_id\"")
 		a.Config.OpsmanConfig.Azure.SubnetID = a.Config.OpsmanConfig.Azure.VPCSubnetDEPRECATED
 	}
 


### PR DESCRIPTION
Property name is consistently "subnet_id", so the error message should say that.

For example:
- https://github.com/pivotal-cf/om/blob/f36c44a37f5397f6c83b36ae6d46e88aa7ca80c0/vmlifecycle/vmmanagers/azure.go#L38
- https://github.com/pivotal-cf/om/blob/f36c44a37f5397f6c83b36ae6d46e88aa7ca80c0/vmlifecycle/vmmanagers/azure.go#L644

I did not run any tests as I could not get "go test" to succeed locally and I did not find any instructions.