### PR TITLE
fix acceptance failure - getent not found

### DIFF
--- a/acceptance/init_test.go
+++ b/acceptance/init_test.go
@@ -34,6 +34,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 		Expect(err).ToNot(HaveOccurred())
 		command := exec.Command("minio", "server", "--config-dir", dataDir, "--address", ":9001", dataDir)
 		command.Env = []string{
+			fmt.Sprintf("HOME=%s", os.Getenv("HOME")),
 			"MINIO_ACCESS_KEY=minio",
 			"MINIO_SECRET_KEY=password",
 			"MINIO_BROWSER=off",


### PR DESCRIPTION
based on fix from: https://github.com/minio/minio/issues/12641

might fix:
```
[1626954229] acceptance - 187/187 specs minio: <ERROR> Unable to get
mcConfigDir. exec: "getent": executable file not found in $PATH.

------------------------------
Failure [21.642 seconds]
[BeforeSuite] BeforeSuite
/tmp/build/a94a8fe5/om/acceptance/init_test.go:26

  No future change is possible.  Bailing out early after 1.178s.
  Got stuck at:

  Waiting for:
      Endpoint:
```