### PR TITLE
Update docs to contain new changes to commands

### DIFF
--- a/docs/assign-multi-stemcell/README.md
+++ b/docs/assign-multi-stemcell/README.md
@@ -51,6 +51,12 @@ Help Options:
   -h, --help                   Show this help message
 
 [assign-multi-stemcell command options]
+      -p, --product=           name of Ops Manager tile to associate a stemcell
+                               to
+      -s, --stemcell=          associate a particular stemcell version to a
+                               tile (ie 'ubuntu-trusty:123.4')
+
+    config file interpolation:
       -c, --config=            path to yml file for configuration (keys must
                                match the following command line flags)
           --vars-env=          load variables from environment variables
@@ -59,9 +65,5 @@ Help Options:
       -l, --vars-file=         load variables from a YAML file
       -v, --var=               load variable from the command line. Format:
                                VAR=VAL
-      -p, --product=           name of Ops Manager tile to associate a stemcell
-                               to
-      -s, --stemcell=          associate a particular stemcell version to a
-                               tile (ie 'ubuntu-trusty:123.4')
 ```
 

--- a/docs/assign-stemcell/README.md
+++ b/docs/assign-stemcell/README.md
@@ -54,6 +54,12 @@ Help Options:
   -h, --help                   Show this help message
 
 [assign-stemcell command options]
+      -p, --product=           name of Ops Manager tile to associate a stemcell
+                               to
+      -s, --stemcell=          associate a particular stemcell version to a
+                               tile. (default: latest)
+
+    config file interpolation:
       -c, --config=            path to yml file for configuration (keys must
                                match the following command line flags)
           --vars-env=          load variables from environment variables
@@ -62,9 +68,5 @@ Help Options:
       -l, --vars-file=         load variables from a YAML file
       -v, --var=               load variable from the command line. Format:
                                VAR=VAL
-      -p, --product=           name of Ops Manager tile to associate a stemcell
-                               to
-      -s, --stemcell=          associate a particular stemcell version to a
-                               tile. (default: latest)
 ```
 

--- a/docs/config-template/README.md
+++ b/docs/config-template/README.md
@@ -50,14 +50,6 @@ Help Options:
   -h, --help                     Show this help message
 
 [config-template command options]
-      -c, --config=              path to yml file for configuration (keys must
-                                 match the following command line flags)
-          --vars-env=            load variables from environment variables
-                                 matching the provided prefix (e.g.: 'MY' to
-                                 load MY_var=value) [$OM_VARS_ENV]
-      -l, --vars-file=           load variables from a YAML file
-      -v, --var=                 load variable from the command line. Format:
-                                 VAR=VAL
           --pivnet-api-token=
           --pivnet-product-slug= the product name in pivnet
           --product-version=     the version of the product from which to
@@ -74,5 +66,15 @@ Help Options:
           --exclude-version      if set, will not output a version-specific
                                  directory
           --size-of-collections=
+
+    config file interpolation:
+      -c, --config=              path to yml file for configuration (keys must
+                                 match the following command line flags)
+          --vars-env=            load variables from environment variables
+                                 matching the provided prefix (e.g.: 'MY' to
+                                 load MY_var=value) [$OM_VARS_ENV]
+      -l, --vars-file=           load variables from a YAML file
+      -v, --var=                 load variable from the command line. Format:
+                                 VAR=VAL
 ```
 

--- a/docs/configure-authentication/README.md
+++ b/docs/configure-authentication/README.md
@@ -56,15 +56,6 @@ Help Options:
   -h, --help                          Show this help message
 
 [configure-authentication command options]
-      -c, --config=                   path to yml file for configuration (keys
-                                      must match the following command line
-                                      flags)
-          --vars-env=                 load variables from environment variables
-                                      matching the provided prefix (e.g.: 'MY'
-                                      to load MY_var=value) [$OM_VARS_ENV]
-      -l, --vars-file=                load variables from a YAML file
-      -v, --var=                      load variable from the command line.
-                                      Format: VAR=VAL
       -u, --username=                 admin username [$OM_USERNAME]
       -p, --password=                 admin password [$OM_PASSWORD]
       -d, --decryption-passphrase=    passphrase used to encrypt the
@@ -76,5 +67,16 @@ Help Options:
           --precreated-client-secret= create a UAA client on the Ops Manager
                                       vm. The client_secret will be the value
                                       provided to this option
+
+    config file interpolation:
+      -c, --config=                   path to yml file for configuration (keys
+                                      must match the following command line
+                                      flags)
+          --vars-env=                 load variables from environment variables
+                                      matching the provided prefix (e.g.: 'MY'
+                                      to load MY_var=value) [$OM_VARS_ENV]
+      -l, --vars-file=                load variables from a YAML file
+      -v, --var=                      load variable from the command line.
+                                      Format: VAR=VAL
 ```
 

--- a/docs/configure-ldap-authentication/README.md
+++ b/docs/configure-ldap-authentication/README.md
@@ -56,16 +56,6 @@ Help Options:
   -h, --help                               Show this help message
 
 [configure-ldap-authentication command options]
-      -c, --config=                        path to yml file for configuration
-                                           (keys must match the following
-                                           command line flags)
-          --vars-env=                      load variables from environment
-                                           variables matching the provided
-                                           prefix (e.g.: 'MY' to load
-                                           MY_var=value) [$OM_VARS_ENV]
-      -l, --vars-file=                     load variables from a YAML file
-      -v, --var=                           load variable from the command line.
-                                           Format: VAR=VAL
       -d, --decryption-passphrase=         passphrase used to encrypt the
                                            installation
           --http-proxy-url=                proxy for outbound HTTP network
@@ -107,5 +97,17 @@ Help Options:
           --precreated-client-secret=      create a UAA client on the Ops
                                            Manager vm. The client_secret will
                                            be the value provided to this option
+
+    config file interpolation:
+      -c, --config=                        path to yml file for configuration
+                                           (keys must match the following
+                                           command line flags)
+          --vars-env=                      load variables from environment
+                                           variables matching the provided
+                                           prefix (e.g.: 'MY' to load
+                                           MY_var=value) [$OM_VARS_ENV]
+      -l, --vars-file=                     load variables from a YAML file
+      -v, --var=                           load variable from the command line.
+                                           Format: VAR=VAL
 ```
 

--- a/docs/configure-opsman/README.md
+++ b/docs/configure-opsman/README.md
@@ -81,11 +81,11 @@ on the Ops Manager Settings page (will update as more functionality is added):
 ssl-certificate:
   certificate: |
     -----BEGIN CERTIFICATE-----
-    [ CERTIFICATE BODY REDACTED ]
+    certificate
     -----END CERTIFICATE-----
   private_key:
     ----BEGIN RSA PRIVATE KEY-----
-    [ PRIVATE KEY REDACTED ]
+    private-key
     -----END RSA PRIVATE KEY-----
 pivotal-network-settings:
   api_token: your-pivnet-token
@@ -101,7 +101,7 @@ syslog-settings:
   permitted_peer: "*.example.com"
   ssl_ca_certificate: |
     -----BEGIN CERTIFICATE-----
-    [ CERTIFICATE BODY REDACTED ]
+    certificate
     -----END CERTIFICATE-----
   queue_size: 100000
   forward_debug_logs: false

--- a/docs/configure-saml-authentication/README.md
+++ b/docs/configure-saml-authentication/README.md
@@ -57,16 +57,6 @@ Help Options:
   -h, --help                               Show this help message
 
 [configure-saml-authentication command options]
-      -c, --config=                        path to yml file for configuration
-                                           (keys must match the following
-                                           command line flags)
-          --vars-env=                      load variables from environment
-                                           variables matching the provided
-                                           prefix (e.g.: 'MY' to load
-                                           MY_var=value) [$OM_VARS_ENV]
-      -l, --vars-file=                     load variables from a YAML file
-      -v, --var=                           load variable from the command line.
-                                           Format: VAR=VAL
       -d, --decryption-passphrase=         passphrase used to encrypt the
                                            installation
           --http-proxy-url=                proxy for outbound HTTP network
@@ -90,6 +80,18 @@ Help Options:
           --precreated-client-secret=      create a UAA client on the Ops
                                            Manager vm, whose secret will be the
                                            value provided to this option
+
+    config file interpolation:
+      -c, --config=                        path to yml file for configuration
+                                           (keys must match the following
+                                           command line flags)
+          --vars-env=                      load variables from environment
+                                           variables matching the provided
+                                           prefix (e.g.: 'MY' to load
+                                           MY_var=value) [$OM_VARS_ENV]
+      -l, --vars-file=                     load variables from a YAML file
+      -v, --var=                           load variable from the command line.
+                                           Format: VAR=VAL
 ```
 
 The `--saml-idp-metadata` and `--saml-bosh-idp-metadata` can be the same.

--- a/docs/curl/README.md
+++ b/docs/curl/README.md
@@ -49,7 +49,8 @@ Help Options:
 
 [curl command options]
       -p, --path=              path to api endpoint
-      -x, --request=           http verb (default: GET)
+      -x, --request=           http verb (defaults to GET, POST when 'data'
+                               specified
       -d, --data=              api request payload
       -s, --silent             only write response headers to stderr if
                                response status is 4XX or 5XX

--- a/docs/disable-director-verifiers/README.md
+++ b/docs/disable-director-verifiers/README.md
@@ -48,6 +48,9 @@ Help Options:
   -h, --help                   Show this help message
 
 [disable-director-verifiers command options]
+      -t, --type=              verifier types to disable
+
+    config file interpolation:
       -c, --config=            path to yml file for configuration (keys must
                                match the following command line flags)
           --vars-env=          load variables from environment variables
@@ -56,6 +59,5 @@ Help Options:
       -l, --vars-file=         load variables from a YAML file
       -v, --var=               load variable from the command line. Format:
                                VAR=VAL
-      -t, --type=              verifier types to disable
 ```
 

--- a/docs/disable-product-verifiers/README.md
+++ b/docs/disable-product-verifiers/README.md
@@ -48,7 +48,7 @@ Help Options:
   -h, --help                   Show this help message
 
 [disable-product-verifiers command options]
-      -c, --product-name=      the name of the product
+      -n, --product-name=      the name of the product
       -t, --type=              verifier types to disable
 ```
 

--- a/docs/download-product/README.md
+++ b/docs/download-product/README.md
@@ -88,16 +88,6 @@ Help Options:
           --gcs-service-account-json=  the service account key JSON
           --gcs-project-id=            the project id for the bucket's gcp
                                        account
-      -c, --config=                    path to yml file for configuration (keys
-                                       must match the following command line
-                                       flags)
-          --vars-env=                  load variables from environment
-                                       variables matching the provided prefix
-                                       (e.g.: 'MY' to load MY_var=value)
-                                       [$OM_VARS_ENV]
-      -l, --vars-file=                 load variables from a YAML file
-      -v, --var=                       load variable from the command line.
-                                       Format: VAR=VAL
       -p, --pivnet-product-slug=       path to product
           --pivnet-disable-ssl         whether to disable ssl validation when
                                        contacting the Pivotal Network
@@ -145,5 +135,17 @@ Help Options:
                                        download (ie 458.61)
           --stemcell-heavy             force the downloading of a heavy
                                        stemcell, will fail if non exists
+
+    config file interpolation:
+      -c, --config=                    path to yml file for configuration (keys
+                                       must match the following command line
+                                       flags)
+          --vars-env=                  load variables from environment
+                                       variables matching the provided prefix
+                                       (e.g.: 'MY' to load MY_var=value)
+                                       [$OM_VARS_ENV]
+      -l, --vars-file=                 load variables from a YAML file
+      -v, --var=                       load variable from the command line.
+                                       Format: VAR=VAL
 ```
 

--- a/docs/import-installation/README.md
+++ b/docs/import-installation/README.md
@@ -51,6 +51,11 @@ Help Options:
   -h, --help                   Show this help message
 
 [import-installation command options]
+      -i, --installation=      path to installation.
+      -p, --polling-interval=  interval (in seconds) to check OpsManager
+                               availability (default: 10)
+
+    config file interpolation:
       -c, --config=            path to yml file for configuration (keys must
                                match the following command line flags)
           --vars-env=          load variables from environment variables
@@ -59,8 +64,5 @@ Help Options:
       -l, --vars-file=         load variables from a YAML file
       -v, --var=               load variable from the command line. Format:
                                VAR=VAL
-      -i, --installation=      path to installation.
-      -p, --polling-interval=  interval (in seconds) to check OpsManager
-                               availability (default: 10)
 ```
 

--- a/docs/upload-product/README.md
+++ b/docs/upload-product/README.md
@@ -49,6 +49,15 @@ Help Options:
   -h, --help                   Show this help message
 
 [upload-product command options]
+      -p, --product=           path to product
+      -i, --polling-interval=  interval (in seconds) at which to print status
+                               (default: 1)
+          --shasum=            shasum of the provided product file to be used
+                               for validation
+          --product-version=   version of the provided product file to be used
+                               for validation
+
+    config file interpolation:
       -c, --config=            path to yml file for configuration (keys must
                                match the following command line flags)
           --vars-env=          load variables from environment variables
@@ -57,12 +66,5 @@ Help Options:
       -l, --vars-file=         load variables from a YAML file
       -v, --var=               load variable from the command line. Format:
                                VAR=VAL
-      -p, --product=           path to product
-      -i, --polling-interval=  interval (in seconds) at which to print status
-                               (default: 1)
-          --shasum=            shasum of the provided product file to be used
-                               for validation
-          --product-version=   version of the provided product file to be used
-                               for validation
 ```
 

--- a/docs/upload-stemcell/README.md
+++ b/docs/upload-stemcell/README.md
@@ -50,6 +50,15 @@ Help Options:
   -h, --help                   Show this help message
 
 [upload-stemcell command options]
+      -s, --stemcell=          path to stemcell
+      -f, --force              upload stemcell even if it already exists on the
+                               target Ops Manager
+          --floating=          assigns the stemcell to all compatible products
+                               (default: true)
+          --shasum=            shasum of the provided product file to be used
+                               for validation
+
+    config file interpolation:
       -c, --config=            path to yml file for configuration (keys must
                                match the following command line flags)
           --vars-env=          load variables from environment variables
@@ -58,12 +67,5 @@ Help Options:
       -l, --vars-file=         load variables from a YAML file
       -v, --var=               load variable from the command line. Format:
                                VAR=VAL
-      -s, --stemcell=          path to stemcell
-      -f, --force              upload stemcell even if it already exists on the
-                               target Ops Manager
-          --floating=          assigns the stemcell to all compatible products
-                               (default: true)
-          --shasum=            shasum of the provided product file to be used
-                               for validation
 ```
 


### PR DESCRIPTION
There are multiple commands which have command help output that is different than what is in the `docs` folder. I ran `go run docsgenerator/update-docs.go` and this PR contains the updated documentation.