### PR TITLE
Added error when publicIP addr not found on azure

### DIFF
--- a/vmlifecycle/vmmanagers/azure.go
+++ b/vmlifecycle/vmmanagers/azure.go
@@ -427,6 +427,10 @@ func (a *AzureVMManager) getPublicIP() (publicIP string, err error) {
 			"--query", fmt.Sprintf("[?ipAddress == '%s'].name | [0]", a.Config.OpsmanConfig.Azure.PublicIP),
 		})
 
+	if out.String() == "" {
+		return "", fmt.Errorf("could not find resource assignment for public ip address %s", a.Config.OpsmanConfig.Azure.PublicIP)
+	}
+
 	return cleanupString(out.String()), checkFormatedError("azure error: %s", err)
 }
 

--- a/vmlifecycle/vmmanagers/azure_test.go
+++ b/vmlifecycle/vmmanagers/azure_test.go
@@ -709,6 +709,18 @@ opsman-configuration:
 						Expect(err.Error()).To(ContainSubstring("open does-not-exist.yml"))
 					})
 				})
+
+				When("Provided publicIP address does not exists", func() {
+					It("returns an error specifying the wrong IP address", func() {
+						setupCommand(configStrTemplate)
+						runner.ExecuteWithEnvVarsReturnsOnCall(7, bytes.NewBufferString(""), nil, nil)
+						command.Config.OpsmanConfig.Azure.PublicIP = "1.2.3.4"
+						command.Config.OpsmanConfig.Azure.PrivateIP = "10.0.0.3"
+						_, _, err := command.CreateVM()
+						Expect(err).To(HaveOccurred())
+						Expect(err.Error()).To(ContainSubstring("could not find resource assignment for public ip address " + command.Config.OpsmanConfig.Azure.PublicIP))
+					})
+				})
 			})
 		})
 


### PR DESCRIPTION
- Added a validation to the `vm-lifecycle create-vm` command to throw an
  error if a public IP address has been configured as part of the
  configuration and the resource cannot be found. Applies to Azure
  Cloud only.

Authored-by: Jhonathan Aristizabal <jhonathana@vmware.com>