### PR TITLE
Removed double quotes escaping

### DIFF
--- a/cmd/loadConfigFile.go
+++ b/cmd/loadConfigFile.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/jessevdk/go-flags"
 	"github.com/pivotal-cf/om/interpolate"
@@ -99,8 +98,7 @@ func parseOptions(opts map[string]interface{}) ([]string, error) {
 				fileArgs = append(fileArgs, fmt.Sprintf("--%s", key))
 			}
 		default:
-			nval := strings.Replace(convertedValue.(string), "\"", "\\\"", -1)
-			fileArgs = append(fileArgs, fmt.Sprintf("--%s=%s", key, nval))
+			fileArgs = append(fileArgs, fmt.Sprintf("--%s=%s", key, convertedValue))
 		}
 
 	}

--- a/cmd/loadConfigFile_test.go
+++ b/cmd/loadConfigFile_test.go
@@ -11,11 +11,11 @@ var fakeOptions map[string]interface{}
 
 var _ = Describe("parseOptions", func() {
 	BeforeEach(func() {
-		fakeOptions = map[string]interface{}{"test-name": "\"pas"}
+		fakeOptions = map[string]interface{}{"test-name": `"pas`}
 	})
 
-	It("Should parse values with double quotes", func() {
-		expected := []string{"--test-name=\\\"pas"}
+	It("Should parse values with double quotes not escaping it", func() {
+		expected := []string{`--test-name="pas`}
 		val, err := parseOptions(fakeOptions)
 		Expect(err).To(BeNil())
 		Expect(val).To(Equal(expected))


### PR DESCRIPTION
Removed escaping of double-quotes on parameter values which caused
problems when parsing correctly formed parameters.

Authored-by: Jhonathan Aristizabal <jhonathana@vmware.com>