### PR TITLE
Allow to specify separate UAA Host for local dev

### DIFF
--- a/network/oauth_client.go
+++ b/network/oauth_client.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 	"time"
 
@@ -104,9 +105,19 @@ func (oc *OAuthClient) Do(request *http.Request) (*http.Response, error) {
 			uaa.JSONWebToken,
 		)
 	}
+	var targetString string
+	if len(os.Getenv("OM_UAA_HOST")) != 0 {
+		uaaTargetURL, err := url.Parse(os.Getenv("OM_UAA_HOST"))
+		if err != nil {
+			return nil, fmt.Errorf("could not reset UAA Host: %w", err)
+		}
+		targetString = uaaTargetURL.String()
+	} else {
+		targetString = targetURL.String()
+	}
 
 	api, err := uaa.New(
-		targetURL.String(),
+		targetString,
 		authOption,
 		options...,
 	)


### PR DESCRIPTION
Hey I'm from the BOSH/OpsMan Team

We'd like to allow to reset uaa host to a value from an env var. 

In local dev envs we do not always have nginx or another lb to do 
path based routing and therefore possibly run UAA on a different port.

Currently this blocks os from using om to setup local OpsMan configs for testing (e.g. we add stuff)

I opted to not expose that as a flag to avoid customer iritation about the possibility of resetting
the UAA Host since that should not really be necessary for other purposes than engineering.

If you need me to add tests for this let me know.

