### PR TITLE
Add darwin_arm64 builds to goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,6 +12,7 @@ builds:
   - CGO_ENABLED=0
   targets:
   - darwin_amd64
+  - darwin_arm64
   - linux_amd64
   - linux_arm64
   - windows_amd64

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,21 +10,20 @@ release:
 builds:
 - env:
   - CGO_ENABLED=0
-  goos:
-  - darwin
-  - linux
-  - windows
-  goarch:
-  - amd64
+  targets:
+  - darwin_amd64
+  - linux_amd64
+  - linux_arm64
+  - windows_amd64
   ldflags:
   - -s -w -X "main.version={{.Version}}"
 archives:
 - id: github
   format: binary
-  name_template: "om-{{ .Os }}-{{ .Version }}"
+  name_template: "om-{{ .Os }}-{{ .Arch }}-{{ .Version }}"
 - id: homebrew
   format: "tar.gz"
-  name_template: "om-{{ .Os }}-{{ .Version }}"
+  name_template: "om-{{ .Os }}-{{ .Arch }}-{{ .Version }}"
   format_overrides:
   - goos: windows
     format: zip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,16 @@ can be found in [Pivotal Documentation](https://docs.pivotal.io/platform-automat
   This ensures that commands are not kept in `bash` history.
   The environment variable `OM_PASSWORD` will overwrite the password value in `env.yml`.
 
+## 7.7.0
+
+Features
+
+- [#582](https://github.com/pivotal-cf/om/pull/582): Include builds for M1 architecture in Mac and Linux builds. This may require changes to CI that pulls artifacts from GitHub releases.
+
+Bug fixes
+
+- [#586](https://github.com/pivotal-cf/om/pull/586): Fixes `om nom` panic when OpsMan instance does not have a public IP address.
+
 ## 7.6.0
 
 ### What's Changed


### PR DESCRIPTION
This will add automatic builds for Apple computers with M1 architecture to published releases.

It changes the names of build artifacts to include architecture, as well.