### PR TITLE
Add rotation procedure to `expiring-certificates`

### DIFF
--- a/api/expiring_certificates_service.go
+++ b/api/expiring_certificates_service.go
@@ -13,15 +13,17 @@ type ExpiringCertificatesResponse struct {
 }
 
 type ExpiringCertificate struct {
-	Issuer            string    `json:"issuer"`
-	ValidFrom         time.Time `json:"valid_from"`
-	ValidUntil        time.Time `json:"valid_until"`
-	Configurable      bool      `json:"configurable"`
-	PropertyReference string    `json:"property_reference"`
-	PropertyType      string    `json:"property_type"`
-	ProductGUID       string    `json:"product_guid"`
-	Location          string    `json:"location"`
-	VariablePath      string    `json:"variable_path"`
+	Issuer                string    `json:"issuer"`
+	ValidFrom             time.Time `json:"valid_from"`
+	ValidUntil            time.Time `json:"valid_until"`
+	Configurable          bool      `json:"configurable"`
+	PropertyReference     string    `json:"property_reference"`
+	PropertyType          string    `json:"property_type"`
+	ProductGUID           string    `json:"product_guid"`
+	Location              string    `json:"location"`
+	VariablePath          string    `json:"variable_path"`
+	RotationProcedureName string    `json:"rotation_procedure_name"`
+	RotationProcedureUrl  string    `json:"rotation_procedure_url"`
 }
 
 func (a Api) ListExpiringCertificates(expiresWithin string) ([]ExpiringCertificate, error) {

--- a/commands/expiring_certificates_test.go
+++ b/commands/expiring_certificates_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/pivotal-cf/om/api"
@@ -55,106 +56,248 @@ var _ = Describe("ExpiringCertificates", func() {
 	})
 
 	When("there are expiring certs", func() {
-		It("prints a clear message of the cert expiring or expired", func() {
-			omTime := "2999-01-01T01:01:01Z"
-			opsManagerUntilTime, err := time.Parse(time.RFC3339, omTime)
-			Expect(err).ToNot(HaveOccurred())
-			credhubTime := "2999-12-12T12:12:12Z"
-			credhubUntilTime, err := time.Parse(time.RFC3339, credhubTime)
-			Expect(err).ToNot(HaveOccurred())
-			credhubTimeAlreadyExpired := "2015-12-12T12:12:12Z"
-			credhubUntilTimeAlreadyExpired, err := time.Parse(time.RFC3339, credhubTimeAlreadyExpired)
-			Expect(err).ToNot(HaveOccurred())
+		When("the rotation procedure is missing from API response", func() {
+			It("prints a clear message of the cert expiring or expired", func() {
+				omTime := "2999-01-01T01:01:01Z"
+				opsManagerUntilTime, err := time.Parse(time.RFC3339, omTime)
+				Expect(err).ToNot(HaveOccurred())
+				credhubTime := "2999-12-12T12:12:12Z"
+				credhubUntilTime, err := time.Parse(time.RFC3339, credhubTime)
+				Expect(err).ToNot(HaveOccurred())
+				credhubTimeAlreadyExpired := "2015-12-12T12:12:12Z"
+				credhubUntilTimeAlreadyExpired, err := time.Parse(time.RFC3339, credhubTimeAlreadyExpired)
+				Expect(err).ToNot(HaveOccurred())
 
-			service.ListExpiringCertificatesStub = func(duration string) ([]api.ExpiringCertificate, error) {
-				return []api.ExpiringCertificate{
-					{
-						Issuer:            "",
-						ValidFrom:         time.Time{},
-						ValidUntil:        opsManagerUntilTime,
-						Configurable:      false,
-						PropertyReference: "property-reference-1",
-						PropertyType:      "",
-						ProductGUID:       "product-guid-1",
-						Location:          "ops_manager",
-						VariablePath:      "",
-					},
-					{
-						Issuer:            "",
-						ValidFrom:         time.Time{},
-						ValidUntil:        opsManagerUntilTime,
-						Configurable:      false,
-						PropertyReference: "property-reference-2",
-						PropertyType:      "",
-						ProductGUID:       "product-guid-1",
-						Location:          "ops_manager",
-						VariablePath:      "",
-					},
-					{
-						Issuer:            "",
-						ValidFrom:         time.Time{},
-						ValidUntil:        opsManagerUntilTime,
-						Configurable:      false,
-						PropertyReference: "property-reference-3",
-						PropertyType:      "",
-						ProductGUID:       "product-guid-2",
-						Location:          "ops_manager",
-						VariablePath:      "",
-					},
-					{
-						Issuer:            "",
-						ValidFrom:         time.Time{},
-						ValidUntil:        opsManagerUntilTime,
-						Configurable:      false,
-						PropertyReference: "property-reference-4",
-						PropertyType:      "",
-						ProductGUID:       "product-guid-4",
-						Location:          "other_location",
-						VariablePath:      "",
-					},
-					{
-						Issuer:            "",
-						ValidFrom:         time.Time{},
-						ValidUntil:        credhubUntilTimeAlreadyExpired,
-						Configurable:      false,
-						PropertyReference: "",
-						PropertyType:      "",
-						ProductGUID:       "",
-						Location:          "credhub_location",
-						VariablePath:      "/opsmgr/bosh_dns/other_ca",
-					},
-					{
-						Issuer:            "",
-						ValidFrom:         time.Time{},
-						ValidUntil:        credhubUntilTime,
-						Configurable:      false,
-						PropertyReference: "",
-						PropertyType:      "",
-						ProductGUID:       "",
-						Location:          "credhub_location",
-						VariablePath:      "/opsmgr/bosh_dns/tls_ca",
-					},
-				}, nil
-			}
-			command := commands.NewExpiringCertificates(service, logger)
-			err = executeCommand(command, []string{})
-			Expect(err).To(HaveOccurred())
+				service.ListExpiringCertificatesStub = func(duration string) ([]api.ExpiringCertificate, error) {
+					return []api.ExpiringCertificate{
+						{
+							Issuer:            "",
+							ValidFrom:         time.Time{},
+							ValidUntil:        opsManagerUntilTime,
+							Configurable:      false,
+							PropertyReference: "property-reference-1",
+							PropertyType:      "",
+							ProductGUID:       "product-guid-1",
+							Location:          "ops_manager",
+							VariablePath:      "",
+						},
+						{
+							Issuer:            "",
+							ValidFrom:         time.Time{},
+							ValidUntil:        opsManagerUntilTime,
+							Configurable:      false,
+							PropertyReference: "property-reference-2",
+							PropertyType:      "",
+							ProductGUID:       "product-guid-1",
+							Location:          "ops_manager",
+							VariablePath:      "",
+						},
+						{
+							Issuer:            "",
+							ValidFrom:         time.Time{},
+							ValidUntil:        opsManagerUntilTime,
+							Configurable:      false,
+							PropertyReference: "property-reference-3",
+							PropertyType:      "",
+							ProductGUID:       "product-guid-2",
+							Location:          "ops_manager",
+							VariablePath:      "",
+						},
+						{
+							Issuer:            "",
+							ValidFrom:         time.Time{},
+							ValidUntil:        opsManagerUntilTime,
+							Configurable:      false,
+							PropertyReference: "property-reference-4",
+							PropertyType:      "",
+							ProductGUID:       "product-guid-4",
+							Location:          "other_location",
+							VariablePath:      "",
+						},
+						{
+							Issuer:            "",
+							ValidFrom:         time.Time{},
+							ValidUntil:        credhubUntilTimeAlreadyExpired,
+							Configurable:      false,
+							PropertyReference: "",
+							PropertyType:      "",
+							ProductGUID:       "",
+							Location:          "credhub_location",
+							VariablePath:      "/opsmgr/bosh_dns/other_ca",
+						},
+						{
+							Issuer:            "",
+							ValidFrom:         time.Time{},
+							ValidUntil:        credhubUntilTime,
+							Configurable:      false,
+							PropertyReference: "",
+							PropertyType:      "",
+							ProductGUID:       "",
+							Location:          "credhub_location",
+							VariablePath:      "/opsmgr/bosh_dns/tls_ca",
+						},
+					}, nil
+				}
+				command := commands.NewExpiringCertificates(service, logger)
+				err = executeCommand(command, []string{})
+				Expect(err).To(HaveOccurred())
 
-			contentsStr := string(stdout.Contents())
-			Expect(contentsStr).To(ContainSubstring("Getting expiring certificates..."))
-			Expect(contentsStr).To(ContainSubstring("[X] Credhub Location"))
-			Expect(contentsStr).To(ContainSubstring(fmt.Sprintf("    /opsmgr/bosh_dns/other_ca: expired on %s", credhubUntilTimeAlreadyExpired.Format(time.RFC822))))
-			Expect(contentsStr).To(ContainSubstring(fmt.Sprintf("    /opsmgr/bosh_dns/tls_ca: expiring on %s", credhubUntilTime.Format(time.RFC822))))
-			Expect(contentsStr).To(ContainSubstring("[X] Ops Manager"))
-			Expect(contentsStr).To(ContainSubstring("    product-guid-1:"))
-			Expect(contentsStr).To(ContainSubstring(fmt.Sprintf("        property-reference-1: expiring on %s", opsManagerUntilTime.Format(time.RFC822))))
-			Expect(contentsStr).To(ContainSubstring(fmt.Sprintf("        property-reference-2: expiring on %s", opsManagerUntilTime.Format(time.RFC822))))
-			Expect(contentsStr).To(ContainSubstring("    product-guid-2:"))
-			Expect(contentsStr).To(ContainSubstring(fmt.Sprintf("        property-reference-3: expiring on %s", opsManagerUntilTime.Format(time.RFC822))))
-			Expect(contentsStr).To(ContainSubstring("[X] Other Location"))
-			Expect(contentsStr).To(ContainSubstring("    product-guid-4:"))
-			Expect(contentsStr).To(ContainSubstring(fmt.Sprintf("        property-reference-4: expiring on %s", opsManagerUntilTime.Format(time.RFC822))))
-			Expect(contentsStr).To(ContainSubstring(""))
+				contentsStr := string(stdout.Contents())
+				Expect(contentsStr).To(ContainSubstring("Getting expiring certificates..."))
+				Expect(contentsStr).To(ContainSubstring("[X] Credhub Location"))
+				Expect(contentsStr).To(ContainSubstring(fmt.Sprintf("    /opsmgr/bosh_dns/other_ca: expired on %s", credhubUntilTimeAlreadyExpired.Format(time.RFC822))))
+				Expect(contentsStr).To(ContainSubstring(fmt.Sprintf("    /opsmgr/bosh_dns/tls_ca: expiring on %s", credhubUntilTime.Format(time.RFC822))))
+				Expect(contentsStr).To(ContainSubstring("[X] Ops Manager"))
+				Expect(contentsStr).To(ContainSubstring("    product-guid-1:"))
+				Expect(contentsStr).To(ContainSubstring(fmt.Sprintf("        property-reference-1: expiring on %s", opsManagerUntilTime.Format(time.RFC822))))
+				Expect(contentsStr).To(ContainSubstring(fmt.Sprintf("        property-reference-2: expiring on %s", opsManagerUntilTime.Format(time.RFC822))))
+				Expect(contentsStr).To(ContainSubstring("    product-guid-2:"))
+				Expect(contentsStr).To(ContainSubstring(fmt.Sprintf("        property-reference-3: expiring on %s", opsManagerUntilTime.Format(time.RFC822))))
+				Expect(contentsStr).To(ContainSubstring("[X] Other Location"))
+				Expect(contentsStr).To(ContainSubstring("    product-guid-4:"))
+				Expect(contentsStr).To(ContainSubstring(fmt.Sprintf("        property-reference-4: expiring on %s", opsManagerUntilTime.Format(time.RFC822))))
+				Expect(contentsStr).To(ContainSubstring(""))
+			})
+		})
+
+		When("the rotation procedure is present in the API response", func() {
+			It("prints a clear message of the cert expiring or expired", func() {
+				omTime := "2999-01-01T01:01:01Z"
+				opsManagerUntilTime, err := time.Parse(time.RFC3339, omTime)
+				Expect(err).ToNot(HaveOccurred())
+				credhubTime := "2999-12-12T12:12:12Z"
+				credhubUntilTime, err := time.Parse(time.RFC3339, credhubTime)
+				Expect(err).ToNot(HaveOccurred())
+				credhubTimeAlreadyExpired := "2015-12-12T12:12:12Z"
+				credhubUntilTimeAlreadyExpired, err := time.Parse(time.RFC3339, credhubTimeAlreadyExpired)
+				Expect(err).ToNot(HaveOccurred())
+
+				service.ListExpiringCertificatesStub = func(duration string) ([]api.ExpiringCertificate, error) {
+					return []api.ExpiringCertificate{
+						{
+							Issuer:                "",
+							ValidFrom:             time.Time{},
+							ValidUntil:            opsManagerUntilTime,
+							Configurable:          false,
+							PropertyReference:     "property-reference-1",
+							PropertyType:          "",
+							ProductGUID:           "product-guid-1",
+							Location:              "ops_manager",
+							VariablePath:          "",
+							RotationProcedureName: "Standard Procedure",
+							RotationProcedureUrl:  "https://procedure/standard/url",
+						},
+						{
+							Issuer:                "",
+							ValidFrom:             time.Time{},
+							ValidUntil:            opsManagerUntilTime,
+							Configurable:          false,
+							PropertyReference:     "property-reference-2",
+							PropertyType:          "",
+							ProductGUID:           "product-guid-1",
+							Location:              "ops_manager",
+							VariablePath:          "",
+							RotationProcedureName: "Standard Procedure",
+							RotationProcedureUrl:  "https://procedure/standard/url",
+						},
+						{
+							Issuer:                "",
+							ValidFrom:             time.Time{},
+							ValidUntil:            opsManagerUntilTime,
+							Configurable:          false,
+							PropertyReference:     "property-reference-3",
+							PropertyType:          "",
+							ProductGUID:           "product-guid-2",
+							Location:              "ops_manager",
+							VariablePath:          "",
+							RotationProcedureName: "Standard Procedure",
+							RotationProcedureUrl:  "https://procedure/standard/url",
+						},
+						{
+							Issuer:                "",
+							ValidFrom:             time.Time{},
+							ValidUntil:            opsManagerUntilTime,
+							Configurable:          false,
+							PropertyReference:     "property-reference-4",
+							PropertyType:          "",
+							ProductGUID:           "product-guid-4",
+							Location:              "other_location",
+							VariablePath:          "",
+							RotationProcedureName: "Standard Procedure",
+							RotationProcedureUrl:  "https://procedure/standard/url",
+						},
+						{
+							Issuer:                "",
+							ValidFrom:             time.Time{},
+							ValidUntil:            credhubUntilTime,
+							Configurable:          false,
+							PropertyReference:     "",
+							PropertyType:          "",
+							ProductGUID:           "product-guid-1",
+							Location:              "credhub_location",
+							VariablePath:          "/opsmgr/bosh_dns/tls_ca",
+							RotationProcedureName: "Other Procedure",
+							RotationProcedureUrl:  "https://procedure/other/url",
+						},
+						{
+							Issuer:                "",
+							ValidFrom:             time.Time{},
+							ValidUntil:            credhubUntilTimeAlreadyExpired,
+							Configurable:          false,
+							PropertyReference:     "",
+							PropertyType:          "",
+							ProductGUID:           "",
+							Location:              "credhub_location",
+							VariablePath:          "/opsmgr/bosh_dns/other_ca",
+							RotationProcedureName: "CA Procedure",
+							RotationProcedureUrl:  "https://procedure/ca/url",
+						},
+						{
+							Issuer:                "",
+							ValidFrom:             time.Time{},
+							ValidUntil:            credhubUntilTimeAlreadyExpired,
+							Configurable:          false,
+							PropertyReference:     "",
+							PropertyType:          "",
+							ProductGUID:           "product-guid-3",
+							Location:              "credhub_location",
+							VariablePath:          "/telemetry_ca",
+							RotationProcedureName: "Procedure for Telemetry CA",
+							RotationProcedureUrl:  "https://procedure/telemetry/url",
+						},
+					}, nil
+				}
+				command := commands.NewExpiringCertificates(service, logger)
+				err = executeCommand(command, []string{})
+				Expect(err).To(HaveOccurred())
+
+				contentsStr := string(stdout.Contents())
+				Expect(contentsStr).To(ContainSubstring("Getting expiring certificates..."))
+				Expect(contentsStr).To(ContainSubstring("One or more certificates will expire in "))
+				Expect(contentsStr).To(ContainSubstring("CA Procedure (https://procedure/ca/url)"))
+				Expect(contentsStr).To(ContainSubstring(fmt.Sprintf("    /opsmgr/bosh_dns/other_ca: expired on %s", credhubUntilTimeAlreadyExpired.Format(time.RFC822))))
+				Expect(contentsStr).To(ContainSubstring("Procedure for Telemetry CA (https://procedure/telemetry/url)"))
+				Expect(contentsStr).To(ContainSubstring(fmt.Sprintf("    /telemetry_ca: expired on %s", credhubUntilTimeAlreadyExpired.Format(time.RFC822))))
+				Expect(contentsStr).To(ContainSubstring("Standard Procedure (https://procedure/standard/url)"))
+				Expect(contentsStr).To(ContainSubstring("    product-guid-1:"))
+				Expect(contentsStr).To(ContainSubstring(fmt.Sprintf("        property-reference-1: expiring on %s", opsManagerUntilTime.Format(time.RFC822))))
+				Expect(contentsStr).To(ContainSubstring(fmt.Sprintf("        property-reference-2: expiring on %s", opsManagerUntilTime.Format(time.RFC822))))
+				Expect(contentsStr).To(ContainSubstring("    product-guid-2:"))
+				Expect(contentsStr).To(ContainSubstring(fmt.Sprintf("        property-reference-3: expiring on %s", opsManagerUntilTime.Format(time.RFC822))))
+				Expect(contentsStr).To(ContainSubstring("    product-guid-4:"))
+				Expect(contentsStr).To(ContainSubstring(fmt.Sprintf("        property-reference-4: expiring on %s", opsManagerUntilTime.Format(time.RFC822))))
+				Expect(contentsStr).To(ContainSubstring("Other Procedure (https://procedure/other/url)"))
+				Expect(contentsStr).To(ContainSubstring("    credhub:"))
+				Expect(contentsStr).To(ContainSubstring(fmt.Sprintf("    /opsmgr/bosh_dns/tls_ca: expiring on %s", credhubUntilTime.Format(time.RFC822))))
+				Expect(contentsStr).To(ContainSubstring(""))
+
+				// Ensure that CA procedures appear before the leaf procedures
+				caProcedureIndex := strings.Index(contentsStr, "CA Procedure")
+				telemetryProcedureIndex := strings.Index(contentsStr, "Procedure for Telemetry CA")
+				standardProcedureIndex := strings.Index(contentsStr, "Standard Procedure")
+				Expect(caProcedureIndex).To(BeNumerically("<", standardProcedureIndex))
+				Expect(telemetryProcedureIndex).To(BeNumerically("<", standardProcedureIndex))
+			})
 		})
 
 		It("sets ExpiresWithin to 3m as default", func() {


### PR DESCRIPTION
An upcoming version of Ops Manager 2.10 will start including two new
fields with the `/api/v0/deployed/certificates` endpoint;
rotation_procedure_name and rotation_procedure_url. These fields will be
on every certificate returned, and represent the rotation procedure used
to rotate that particular certificate.

The text output for the `om expiring-certificates` command has been
reworked when this data is available to group certificates by procedure
because in most cases, following a single procedure will rotate all
certificates for that procedure at once; that is, instead of running
that procedure once for each certificate separately.

The new output looks similar to the following:
```
Getting expiring certificates...
Found expiring certificates in the foundation:

One or more certificates will expire in 89 days. Please refer to the certificate rotation procedures below. To optimize deployment time, please rotate expiring CA certificates prior to any leaf certificates.

Services TLS CA Procedure (https://docs.pivotal.io/ops-manager/2-10/security/pcf-infrastructure/advanced-certificate-rotation.html#services-rotation)
    credhub:
        /services/tls_ca: expiring on 28 Feb 23 13:57 UTC

Identity Provider SAML Procedure (https://docs.pivotal.io/ops-manager/2-10/security/pcf-infrastructure/rotate-saml-ca.html)
    cf-625e965c186c7b029061:
        .uaa.service_provider_key_credentials: expiring on 29 May 22 12:57 UTC

Standard CA Procedure (https://docs.pivotal.io/ops-manager/2-10/security/pcf-infrastructure/rotate-cas-and-leaf-certs.html)
    ops_manager:
        .properties.nats_client_ca.c8b520555b0bc0a9f9f7: expiring on 27 Feb 26 13:57 UTC
        .properties.root_ca.c8b520555b0bc0a9f9f7: expiring on 28 Feb 23 13:57 UTC
    cf-625e965c186c7b029061:
        /opsmgr/bosh_dns/tls_ca: expiring on 27 Feb 26 14:40 UTC
        /p-bosh/cf-625e965c186c7b029061/diego-instance-identity-intermediate-ca-2-7: expiring on 28 Feb 24 14:40 UTC
        /cf/diego-instance-identity-root-ca-2-6: expiring on 27 Feb 25 14:40 UTC

Standard Configurable Leaf Procedure (https://docs.pivotal.io/ops-manager/2-10/security/pcf-infrastructure/rotate-configurable-certs.html)
    cf-625e965c186c7b029061:
        .properties.networking_poe_ssl_certs[0].certificate: expiring on 29 May 22 12:57 UTC

Standard Non-Configurable Leaf Procedure (https://docs.pivotal.io/ops-manager/2-10/security/pcf-infrastructure/rotate-non-configurable-certs.html)
    p-bosh-38683bbbab412b152fad:
        .properties.director_ssl: expiring on 28 Feb 24 14:06 UTC
        .properties.uaa_ssl: expiring on 28 Feb 24 14:06 UTC
        ...
    cf-625e965c186c7b029061:
        .properties.auctioneer_client_cert: expiring on 28 Feb 24 14:06 UTC
        .properties.auctioneer_server_cert: expiring on 28 Feb 24 14:06 UTC
        ...

2022/02/28 14:47:46 found expiring certificates in the foundation
```

If the new API fields are blank, then it is assumed that `om` is
targeted at an older version of Ops Manager and the previous output
format is used instead.

[#181158588] Update om CLI to output rotation procedures

Signed-off-by: Brian Upton <bupton@vmware.com>
Signed-off-by: Camila Londoño <londonoc@vmware.com>
Signed-off-by: Long Nguyen <nguyenlo@vmware.com>