### PR TITLE
bump go to 1.19 in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,86 +1,133 @@
 module github.com/pivotal-cf/om
 
-go 1.16
+go 1.19
 
 require (
-	cloud.google.com/go v0.74.0 // indirect
 	cloud.google.com/go/storage v1.10.0
-	code.cloudfoundry.org/archiver v0.0.0-20200131002800-4ca7245c29b1 // indirect
-	code.cloudfoundry.org/clock v1.0.0 // indirect
 	code.cloudfoundry.org/credhub-cli v0.0.0-20201102140135-1a6b82ad1f99
-	code.cloudfoundry.org/hydrator v0.0.0-20191120195058-919ca7133daa // indirect
-	code.cloudfoundry.org/tlsconfig v0.0.0-20200131000646-bbe0f8da39b3 // indirect
-	code.cloudfoundry.org/workpool v0.0.0-20200131000409-2ac56b354115 // indirect
 	github.com/Azure/azure-sdk-for-go v49.2.0+incompatible
 	github.com/Azure/go-autorest/autorest v0.11.15
-	github.com/Azure/go-autorest/autorest/adal v0.9.10 // indirect
 	github.com/Azure/go-autorest/autorest/azure/auth v0.5.5
-	github.com/Azure/go-autorest/autorest/to v0.4.0 // indirect
-	github.com/Azure/go-autorest/autorest/validation v0.3.1 // indirect
 	github.com/aws/aws-sdk-go v1.36.19
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/bmatcuk/doublestar v1.3.4
-	github.com/cheggaaa/pb v1.0.28 // indirect
 	github.com/cheggaaa/pb/v3 v3.0.5
 	github.com/cloudfoundry-community/go-uaa v0.3.1
-	github.com/cloudfoundry/bosh-agent v2.340.0+incompatible // indirect
 	github.com/cloudfoundry/bosh-cli v6.4.1+incompatible
+	github.com/cppforlife/go-patch v0.2.0
+	github.com/fatih/color v1.10.0
+	github.com/ghodss/yaml v1.0.0
+	github.com/graymeta/stow v0.2.6
+	github.com/hashicorp/go-version v1.2.1
+	github.com/jessevdk/go-flags v1.4.0
+	github.com/maxbrunsfeld/counterfeiter/v6 v6.2.2
+	github.com/olekukonko/tablewriter v0.0.4
+	github.com/onsi/ginkgo v1.14.2
+	github.com/onsi/gomega v1.10.4
+	github.com/pivotal-cf/go-pivnet v1.0.3
+	github.com/pivotal-cf/go-pivnet/v6 v6.0.2
+	github.com/pivotal-cf/pivnet-cli/v2 v2.0.2
+	github.com/pivotal-cf/replicator v0.0.0-20181127185712-7c58987ce14b
+	github.com/pivotal-cf/winfs-injector v0.0.0-20200827170301-91411420d92f
+	github.com/vmware/govmomi v0.24.0
+	golang.org/x/oauth2 v0.0.0-20201208152858-08078c50e5b5
+	google.golang.org/api v0.36.0
+	gopkg.in/go-playground/validator.v9 v9.31.0
+	gopkg.in/yaml.v2 v2.4.0
+	howett.net/ranger v0.0.0-20171016084633-e2e137620847
+)
+
+require (
+	cloud.google.com/go v0.74.0 // indirect
+	code.cloudfoundry.org/archiver v0.0.0-20200131002800-4ca7245c29b1 // indirect
+	code.cloudfoundry.org/clock v1.0.0 // indirect
+	code.cloudfoundry.org/hydrator v0.0.0-20191120195058-919ca7133daa // indirect
+	code.cloudfoundry.org/tlsconfig v0.0.0-20200131000646-bbe0f8da39b3 // indirect
+	code.cloudfoundry.org/workpool v0.0.0-20200131000409-2ac56b354115 // indirect
+	github.com/Azure/go-autorest v14.2.0+incompatible // indirect
+	github.com/Azure/go-autorest/autorest/adal v0.9.10 // indirect
+	github.com/Azure/go-autorest/autorest/azure/cli v0.4.2 // indirect
+	github.com/Azure/go-autorest/autorest/date v0.3.0 // indirect
+	github.com/Azure/go-autorest/autorest/to v0.4.0 // indirect
+	github.com/Azure/go-autorest/autorest/validation v0.3.1 // indirect
+	github.com/Azure/go-autorest/logger v0.2.0 // indirect
+	github.com/Azure/go-autorest/tracing v0.6.0 // indirect
+	github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d // indirect
+	github.com/VividCortex/ewma v1.1.1 // indirect
+	github.com/charlievieth/fs v0.0.1 // indirect
+	github.com/cheggaaa/pb v1.0.28 // indirect
+	github.com/cloudfoundry/bosh-agent v2.340.0+incompatible // indirect
 	github.com/cloudfoundry/bosh-davcli v0.0.44 // indirect
 	github.com/cloudfoundry/bosh-gcscli v0.0.6 // indirect
 	github.com/cloudfoundry/bosh-s3cli v0.0.95 // indirect
 	github.com/cloudfoundry/bosh-utils v0.0.0-20210102100234-ed8dcddc80c2 // indirect
 	github.com/cloudfoundry/config-server v0.1.21 // indirect
-	github.com/cppforlife/go-patch v0.2.0
+	github.com/cloudfoundry/go-socks5 v0.0.0-20180221174514-54f73bdb8a8e // indirect
+	github.com/cloudfoundry/socks5-proxy v0.2.0 // indirect
 	github.com/cppforlife/go-semi-semantic v0.0.0-20160921010311-576b6af77ae4 // indirect
 	github.com/cyphar/filepath-securejoin v0.2.2 // indirect
 	github.com/dimchansky/utfbom v1.1.1 // indirect
 	github.com/dnaeon/go-vcr v1.0.1 // indirect
 	github.com/dsnet/compress v0.0.1 // indirect
 	github.com/dustin/go-humanize v1.0.0 // indirect
-	github.com/fatih/color v1.10.0
+	github.com/form3tech-oss/jwt-go v3.2.2+incompatible // indirect
 	github.com/frankban/quicktest v1.11.2 // indirect
-	github.com/ghodss/yaml v1.0.0
+	github.com/fsnotify/fsnotify v1.4.9 // indirect
+	github.com/go-ole/go-ole v1.2.4 // indirect
+	github.com/go-playground/locales v0.13.0 // indirect
 	github.com/go-playground/universal-translator v0.17.0 // indirect
+	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
+	github.com/golang/protobuf v1.4.3 // indirect
 	github.com/golang/snappy v0.0.2 // indirect
-	github.com/graymeta/stow v0.2.6
-	github.com/hashicorp/go-version v1.2.1
-	github.com/jessevdk/go-flags v1.4.0
+	github.com/google/uuid v1.1.2 // indirect
+	github.com/googleapis/gax-go/v2 v2.0.5 // indirect
+	github.com/hashicorp/errwrap v1.0.0 // indirect
+	github.com/hashicorp/go-multierror v1.0.0 // indirect
+	github.com/howeyc/gopass v0.0.0-20190910152052-7cb4b85ec19c // indirect
 	github.com/jhoonb/archivex v0.0.0-20201016144719-6a343cdae81d // indirect
+	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/jpillora/backoff v1.0.0 // indirect
+	github.com/jstemmer/go-junit-report v0.9.1 // indirect
+	github.com/kr/pretty v0.2.1 // indirect
+	github.com/kr/text v0.2.0 // indirect
 	github.com/leodido/go-urn v1.2.1 // indirect
+	github.com/mattn/go-colorable v0.1.8 // indirect
+	github.com/mattn/go-isatty v0.0.12 // indirect
 	github.com/mattn/go-runewidth v0.0.9 // indirect
-	github.com/maxbrunsfeld/counterfeiter/v6 v6.2.2
 	github.com/mholt/archiver v3.1.1+incompatible // indirect
+	github.com/mitchellh/go-homedir v1.1.0 // indirect
+	github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d // indirect
 	github.com/nwaples/rardecode v1.1.0 // indirect
-	github.com/olekukonko/tablewriter v0.0.4
-	github.com/onsi/ginkgo v1.14.2
-	github.com/onsi/gomega v1.10.4
+	github.com/nxadm/tail v1.4.5 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.0.2 // indirect
 	github.com/pierrec/lz4 v2.6.0+incompatible // indirect
 	github.com/pivotal-cf-experimental/gomegamatchers v0.0.0-20180326192815-e36bfcc98c3a // indirect
-	github.com/pivotal-cf/go-pivnet v1.0.3
-	github.com/pivotal-cf/go-pivnet/v6 v6.0.2
 	github.com/pivotal-cf/jhanda v0.0.0-20200619200912-8de8eb943a43 // indirect
 	github.com/pivotal-cf/paraphernalia v0.0.0-20180203224945-a64ae2051c20 // indirect
-	github.com/pivotal-cf/pivnet-cli/v2 v2.0.2
-	github.com/pivotal-cf/replicator v0.0.0-20181127185712-7c58987ce14b
-	github.com/pivotal-cf/winfs-injector v0.0.0-20200827170301-91411420d92f
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/satori/go.uuid v1.2.0 // indirect
 	github.com/sclevine/spec v1.4.0 // indirect
 	github.com/shirou/gopsutil v3.20.12+incompatible // indirect
 	github.com/ulikunitz/xz v0.5.8 // indirect
 	github.com/vito/go-interact v1.0.0 // indirect
-	github.com/vmware/govmomi v0.24.0
 	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect
+	go.opencensus.io v0.22.5 // indirect
 	golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad // indirect
+	golang.org/x/lint v0.0.0-20201208152925-83fdc39ff7b5 // indirect
+	golang.org/x/mod v0.4.0 // indirect
 	golang.org/x/net v0.0.0-20201224014010-6772e930b67b // indirect
-	golang.org/x/oauth2 v0.0.0-20201208152858-08078c50e5b5
 	golang.org/x/sync v0.0.0-20201207232520-09787c993a3a // indirect
 	golang.org/x/sys v0.0.0-20201231184435-2d18734c6014 // indirect
-	google.golang.org/api v0.36.0
+	golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 // indirect
+	golang.org/x/text v0.3.4 // indirect
+	golang.org/x/tools v0.0.0-20201208233053-a543418bbed2 // indirect
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
+	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20201214200347-8c77b98c765d // indirect
+	google.golang.org/grpc v1.34.0 // indirect
+	google.golang.org/protobuf v1.25.0 // indirect
+	gopkg.in/cheggaaa/pb.v1 v1.0.28 // indirect
 	gopkg.in/go-playground/assert.v1 v1.2.1 // indirect
-	gopkg.in/go-playground/validator.v9 v9.31.0
-	gopkg.in/yaml.v2 v2.4.0
-	howett.net/ranger v0.0.0-20171016084633-e2e137620847
+	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 )


### PR DESCRIPTION
bump go version in go.mod to 1.19


Co-authored-by: Jhonathan Aristizabal <jhonathana@vmware.com>
