### PR TITLE
Add --all-inactive option to delete CAs

### DIFF
--- a/commands/delete_certificate_authority.go
+++ b/commands/delete_certificate_authority.go
@@ -1,6 +1,8 @@
 package commands
 
 import (
+	"errors"
+
 	"github.com/pivotal-cf/om/api"
 )
 
@@ -8,13 +10,15 @@ type DeleteCertificateAuthority struct {
 	service deleteCertificateAuthorityService
 	logger  logger
 	Options struct {
-		Id string `long:"id" required:"true" description:"certificate authority id"`
+		Id          string `long:"id" required:"false" description:"certificate authority id"`
+		AllInactive bool   `long:"all-inactive" required:"false" description:"delete all inactive certificate authorities"`
 	}
 }
 
 //counterfeiter:generate -o ./fakes/delete_certificate_authority_service.go --fake-name DeleteCertificateAuthorityService . deleteCertificateAuthorityService
 type deleteCertificateAuthorityService interface {
 	DeleteCertificateAuthority(api.DeleteCertificateAuthorityInput) error
+	ListCertificateAuthorities() (api.CertificateAuthoritiesOutput, error)
 }
 
 func NewDeleteCertificateAuthority(service deleteCertificateAuthorityService, logger logger) *DeleteCertificateAuthority {
@@ -22,15 +26,44 @@ func NewDeleteCertificateAuthority(service deleteCertificateAuthorityService, lo
 }
 
 func (a DeleteCertificateAuthority) Execute(args []string) error {
-	err := a.service.DeleteCertificateAuthority(api.DeleteCertificateAuthorityInput{
-		GUID: a.Options.Id,
+	var caGuid string
+	var err error
+
+	switch {
+	case a.Options.AllInactive:
+		if caGuid, err = a.getInactiveCA(); err != nil {
+			return err
+		}
+	case a.Options.Id != "":
+		caGuid = a.Options.Id
+	default:
+		return errors.New("--id or --all-inactive must be provided")
+	}
+
+	err = a.service.DeleteCertificateAuthority(api.DeleteCertificateAuthorityInput{
+		GUID: caGuid,
 	})
 
 	if err != nil {
 		return err
 	}
 
-	a.logger.Printf("Certificate authority '%s' deleted\n", a.Options.Id)
+	a.logger.Printf("Certificate authority '%s' deleted\n", caGuid)
 
 	return nil
+}
+
+func (a DeleteCertificateAuthority) getInactiveCA() (string, error) {
+	caList, err := a.service.ListCertificateAuthorities()
+	if err != nil {
+		return "", err
+	}
+
+	for _, ca := range caList.CAs {
+		if !ca.Active {
+			return ca.GUID, nil
+		}
+	}
+
+	return "", errors.New("no inactive CAs found")
 }

--- a/commands/fakes/delete_certificate_authority_service.go
+++ b/commands/fakes/delete_certificate_authority_service.go
@@ -19,6 +19,18 @@ type DeleteCertificateAuthorityService struct {
 	deleteCertificateAuthorityReturnsOnCall map[int]struct {
 		result1 error
 	}
+	ListCertificateAuthoritiesStub        func() (api.CertificateAuthoritiesOutput, error)
+	listCertificateAuthoritiesMutex       sync.RWMutex
+	listCertificateAuthoritiesArgsForCall []struct {
+	}
+	listCertificateAuthoritiesReturns struct {
+		result1 api.CertificateAuthoritiesOutput
+		result2 error
+	}
+	listCertificateAuthoritiesReturnsOnCall map[int]struct {
+		result1 api.CertificateAuthoritiesOutput
+		result2 error
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
@@ -83,11 +95,68 @@ func (fake *DeleteCertificateAuthorityService) DeleteCertificateAuthorityReturns
 	}{result1}
 }
 
+func (fake *DeleteCertificateAuthorityService) ListCertificateAuthorities() (api.CertificateAuthoritiesOutput, error) {
+	fake.listCertificateAuthoritiesMutex.Lock()
+	ret, specificReturn := fake.listCertificateAuthoritiesReturnsOnCall[len(fake.listCertificateAuthoritiesArgsForCall)]
+	fake.listCertificateAuthoritiesArgsForCall = append(fake.listCertificateAuthoritiesArgsForCall, struct {
+	}{})
+	fake.recordInvocation("ListCertificateAuthorities", []interface{}{})
+	fake.listCertificateAuthoritiesMutex.Unlock()
+	if fake.ListCertificateAuthoritiesStub != nil {
+		return fake.ListCertificateAuthoritiesStub()
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.listCertificateAuthoritiesReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *DeleteCertificateAuthorityService) ListCertificateAuthoritiesCallCount() int {
+	fake.listCertificateAuthoritiesMutex.RLock()
+	defer fake.listCertificateAuthoritiesMutex.RUnlock()
+	return len(fake.listCertificateAuthoritiesArgsForCall)
+}
+
+func (fake *DeleteCertificateAuthorityService) ListCertificateAuthoritiesCalls(stub func() (api.CertificateAuthoritiesOutput, error)) {
+	fake.listCertificateAuthoritiesMutex.Lock()
+	defer fake.listCertificateAuthoritiesMutex.Unlock()
+	fake.ListCertificateAuthoritiesStub = stub
+}
+
+func (fake *DeleteCertificateAuthorityService) ListCertificateAuthoritiesReturns(result1 api.CertificateAuthoritiesOutput, result2 error) {
+	fake.listCertificateAuthoritiesMutex.Lock()
+	defer fake.listCertificateAuthoritiesMutex.Unlock()
+	fake.ListCertificateAuthoritiesStub = nil
+	fake.listCertificateAuthoritiesReturns = struct {
+		result1 api.CertificateAuthoritiesOutput
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *DeleteCertificateAuthorityService) ListCertificateAuthoritiesReturnsOnCall(i int, result1 api.CertificateAuthoritiesOutput, result2 error) {
+	fake.listCertificateAuthoritiesMutex.Lock()
+	defer fake.listCertificateAuthoritiesMutex.Unlock()
+	fake.ListCertificateAuthoritiesStub = nil
+	if fake.listCertificateAuthoritiesReturnsOnCall == nil {
+		fake.listCertificateAuthoritiesReturnsOnCall = make(map[int]struct {
+			result1 api.CertificateAuthoritiesOutput
+			result2 error
+		})
+	}
+	fake.listCertificateAuthoritiesReturnsOnCall[i] = struct {
+		result1 api.CertificateAuthoritiesOutput
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *DeleteCertificateAuthorityService) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
 	fake.deleteCertificateAuthorityMutex.RLock()
 	defer fake.deleteCertificateAuthorityMutex.RUnlock()
+	fake.listCertificateAuthoritiesMutex.RLock()
+	defer fake.listCertificateAuthoritiesMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value


### PR DESCRIPTION
This adds an optional flag to `om delete-certificate-authority` that finds the inactive certificate authority and deletes it rather than requiring that the operator specify the guid.