### PR TITLE
feat: Update activate-certificate-authority to activate latest CA without passing CA GUID

### DIFF
--- a/commands/activate_certificate_authority.go
+++ b/commands/activate_certificate_authority.go
@@ -3,6 +3,9 @@ package commands
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
 
 import (
+	"fmt"
+	"time"
+
 	"github.com/pivotal-cf/om/api"
 )
 
@@ -10,13 +13,14 @@ type ActivateCertificateAuthority struct {
 	service activateCertificateAuthorityService
 	logger  logger
 	Options struct {
-		Id string `long:"id" required:"true" description:"certificate authority id"`
+		Id string `long:"id" required:"false" description:"certificate authority id"`
 	}
 }
 
 //counterfeiter:generate -o ./fakes/activate_certificate_authority_service.go --fake-name ActivateCertificateAuthorityService . activateCertificateAuthorityService
 type activateCertificateAuthorityService interface {
 	ActivateCertificateAuthority(api.ActivateCertificateAuthorityInput) error
+	ListCertificateAuthorities() (api.CertificateAuthoritiesOutput, error)
 }
 
 func NewActivateCertificateAuthority(service activateCertificateAuthorityService, logger logger) *ActivateCertificateAuthority {
@@ -24,8 +28,39 @@ func NewActivateCertificateAuthority(service activateCertificateAuthorityService
 }
 
 func (a ActivateCertificateAuthority) Execute(args []string) error {
+	guid := a.Options.Id
+	if a.Options.Id == "" {
+		caList, _ := a.service.ListCertificateAuthorities()
+		var activeCA api.CA
+		var inactiveCA api.CA
+
+		for _, ca := range caList.CAs {
+			if ca.Active {
+				activeCA = ca
+			} else {
+				inactiveCA = ca
+			}
+		}
+
+		if inactiveCA.GUID == "" {
+			return fmt.Errorf("no inactive certificate authorities to activate")
+		}
+
+		inactiveCreationTime, _ := time.Parse(time.RFC3339, inactiveCA.CreatedOn)
+		fmt.Printf("%+v\n", inactiveCreationTime)
+		activeCreationTime, _ := time.Parse(time.RFC3339, activeCA.CreatedOn)
+		fmt.Printf("%+v\n", activeCreationTime)
+
+		if activeCreationTime.After(inactiveCreationTime) {
+			a.logger.Printf("No newer certificate authority available to activate\n")
+			return nil
+		}
+
+		guid = inactiveCA.GUID
+	}
+
 	err := a.service.ActivateCertificateAuthority(api.ActivateCertificateAuthorityInput{
-		GUID: a.Options.Id,
+		GUID: guid,
 	})
 
 	if err != nil {

--- a/commands/activate_certificate_authority_test.go
+++ b/commands/activate_certificate_authority_test.go
@@ -41,6 +41,86 @@ var _ = Describe("ActivateCertificateAuthority", func() {
 			Expect(fmt.Sprintf(format, content...)).To(Equal("Certificate authority 'some-certificate-authority-id' activated\n"))
 		})
 
+		Context("with no guid specified", func() {
+			args := []string{}
+			Context("with an inactive CA newer than the active CA", func() {
+				BeforeEach(func() {
+					fakeService.ListCertificateAuthoritiesReturns(api.CertificateAuthoritiesOutput{CAs: []api.CA{
+						{
+							GUID:      "active-ca-guid",
+							Active:    true,
+							CreatedOn: "2015-06-16T05:17:43Z",
+						},
+						{
+							GUID:      "inactive-ca-guid",
+							Active:    false,
+							CreatedOn: "2025-06-16T05:17:44Z",
+						},
+					}}, nil)
+				})
+
+				It("activates the inactive CA", func() {
+					err := executeCommand(command, args)
+					Expect(err).ToNot(HaveOccurred())
+
+					Expect(fakeService.ListCertificateAuthoritiesCallCount()).To(Equal(1), "list certificates call count")
+					Expect(fakeService.ActivateCertificateAuthorityCallCount()).To(Equal(1), "activate certificate call count")
+					Expect(fakeService.ActivateCertificateAuthorityArgsForCall(0)).To(Equal(api.ActivateCertificateAuthorityInput{
+						GUID: "inactive-ca-guid",
+					}), "activate ca API args")
+				})
+			})
+
+			Context("with an inactive CA older than the active CA", func() {
+				BeforeEach(func() {
+					fakeService.ListCertificateAuthoritiesReturns(api.CertificateAuthoritiesOutput{CAs: []api.CA{
+						{
+							GUID:      "active-ca-guid",
+							Active:    true,
+							CreatedOn: "1995-06-16T05:17:43Z",
+						},
+						{
+							GUID:      "inactive-ca-guid",
+							Active:    false,
+							CreatedOn: "1895-06-16T05:17:44Z",
+						},
+					}}, nil)
+				})
+
+				It("makes no activate call", func() {
+					err := executeCommand(command, args)
+					Expect(err).ToNot(HaveOccurred())
+
+					Expect(fakeService.ListCertificateAuthoritiesCallCount()).To(Equal(1), "list certificates call count")
+					Expect(fakeService.ActivateCertificateAuthorityCallCount()).To(Equal(0), "activate certificate call count")
+
+					Expect(fakeLogger.PrintfCallCount()).To(Equal(1))
+					format, content := fakeLogger.PrintfArgsForCall(0)
+					Expect(fmt.Sprintf(format, content...)).To(Equal("No newer certificate authority available to activate\n"))
+				})
+			})
+
+			Context("with no inactive CA", func() {
+				BeforeEach(func() {
+					fakeService.ListCertificateAuthoritiesReturns(api.CertificateAuthoritiesOutput{CAs: []api.CA{
+						{
+							GUID:      "active-ca-guid",
+							Active:    true,
+							CreatedOn: "2023-01-31T12:00:00Z",
+						},
+					}}, nil)
+				})
+
+				It("returns an error", func() {
+					err := executeCommand(command, args)
+					Expect(err).To(MatchError("no inactive certificate authorities to activate"))
+
+					Expect(fakeService.ListCertificateAuthoritiesCallCount()).To(Equal(1), "list certificates call count")
+					Expect(fakeService.ActivateCertificateAuthorityCallCount()).To(Equal(0), "activate certificate call count")
+				})
+			})
+		})
+
 		When("the service fails to activate a certificate", func() {
 			It("returns an error", func() {
 				fakeService.ActivateCertificateAuthorityReturns(errors.New("failed to activate certificate"))

--- a/commands/activate_certificate_authority_test.go
+++ b/commands/activate_certificate_authority_test.go
@@ -213,12 +213,16 @@ var _ = Describe("ActivateCertificateAuthority", func() {
 					}}, nil)
 				})
 
-				It("returns an error", func() {
+				It("makes no activate call", func() {
 					err := executeCommand(command, args)
-					Expect(err).To(MatchError("no inactive certificate authorities to activate"))
+					Expect(err).ToNot(HaveOccurred())
 
 					Expect(fakeService.ListCertificateAuthoritiesCallCount()).To(Equal(1), "list certificates call count")
 					Expect(fakeService.ActivateCertificateAuthorityCallCount()).To(Equal(0), "activate certificate call count")
+
+					Expect(fakeLogger.PrintfCallCount()).To(Equal(1))
+					format, content := fakeLogger.PrintfArgsForCall(0)
+					Expect(fmt.Sprintf(format, content...)).To(Equal("No newer certificate authority available to activate\n"))
 				})
 			})
 		})

--- a/commands/fakes/activate_certificate_authority_service.go
+++ b/commands/fakes/activate_certificate_authority_service.go
@@ -19,6 +19,18 @@ type ActivateCertificateAuthorityService struct {
 	activateCertificateAuthorityReturnsOnCall map[int]struct {
 		result1 error
 	}
+	ListCertificateAuthoritiesStub        func() (api.CertificateAuthoritiesOutput, error)
+	listCertificateAuthoritiesMutex       sync.RWMutex
+	listCertificateAuthoritiesArgsForCall []struct {
+	}
+	listCertificateAuthoritiesReturns struct {
+		result1 api.CertificateAuthoritiesOutput
+		result2 error
+	}
+	listCertificateAuthoritiesReturnsOnCall map[int]struct {
+		result1 api.CertificateAuthoritiesOutput
+		result2 error
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
@@ -83,11 +95,68 @@ func (fake *ActivateCertificateAuthorityService) ActivateCertificateAuthorityRet
 	}{result1}
 }
 
+func (fake *ActivateCertificateAuthorityService) ListCertificateAuthorities() (api.CertificateAuthoritiesOutput, error) {
+	fake.listCertificateAuthoritiesMutex.Lock()
+	ret, specificReturn := fake.listCertificateAuthoritiesReturnsOnCall[len(fake.listCertificateAuthoritiesArgsForCall)]
+	fake.listCertificateAuthoritiesArgsForCall = append(fake.listCertificateAuthoritiesArgsForCall, struct {
+	}{})
+	fake.recordInvocation("ListCertificateAuthorities", []interface{}{})
+	fake.listCertificateAuthoritiesMutex.Unlock()
+	if fake.ListCertificateAuthoritiesStub != nil {
+		return fake.ListCertificateAuthoritiesStub()
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.listCertificateAuthoritiesReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *ActivateCertificateAuthorityService) ListCertificateAuthoritiesCallCount() int {
+	fake.listCertificateAuthoritiesMutex.RLock()
+	defer fake.listCertificateAuthoritiesMutex.RUnlock()
+	return len(fake.listCertificateAuthoritiesArgsForCall)
+}
+
+func (fake *ActivateCertificateAuthorityService) ListCertificateAuthoritiesCalls(stub func() (api.CertificateAuthoritiesOutput, error)) {
+	fake.listCertificateAuthoritiesMutex.Lock()
+	defer fake.listCertificateAuthoritiesMutex.Unlock()
+	fake.ListCertificateAuthoritiesStub = stub
+}
+
+func (fake *ActivateCertificateAuthorityService) ListCertificateAuthoritiesReturns(result1 api.CertificateAuthoritiesOutput, result2 error) {
+	fake.listCertificateAuthoritiesMutex.Lock()
+	defer fake.listCertificateAuthoritiesMutex.Unlock()
+	fake.ListCertificateAuthoritiesStub = nil
+	fake.listCertificateAuthoritiesReturns = struct {
+		result1 api.CertificateAuthoritiesOutput
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *ActivateCertificateAuthorityService) ListCertificateAuthoritiesReturnsOnCall(i int, result1 api.CertificateAuthoritiesOutput, result2 error) {
+	fake.listCertificateAuthoritiesMutex.Lock()
+	defer fake.listCertificateAuthoritiesMutex.Unlock()
+	fake.ListCertificateAuthoritiesStub = nil
+	if fake.listCertificateAuthoritiesReturnsOnCall == nil {
+		fake.listCertificateAuthoritiesReturnsOnCall = make(map[int]struct {
+			result1 api.CertificateAuthoritiesOutput
+			result2 error
+		})
+	}
+	fake.listCertificateAuthoritiesReturnsOnCall[i] = struct {
+		result1 api.CertificateAuthoritiesOutput
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *ActivateCertificateAuthorityService) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
 	fake.activateCertificateAuthorityMutex.RLock()
 	defer fake.activateCertificateAuthorityMutex.RUnlock()
+	fake.listCertificateAuthoritiesMutex.RLock()
+	defer fake.listCertificateAuthoritiesMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value


### PR DESCRIPTION
- Updated activate-certificate-authority command to remove id as a required flag
- Now activate-certificate-authority can query to get the latest Inactive CA guid and activate that