### PR TITLE
🐞 Fix: deploying opsman to vSphere 15% boot fail

### DIFF
--- a/vmlifecycle/runner/runner.go
+++ b/vmlifecycle/runner/runner.go
@@ -2,6 +2,7 @@ package runner
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"github.com/fatih/color"
 	"github.com/onsi/gomega/gexec"
@@ -35,6 +36,10 @@ func (r *Runner) Execute(args []interface{}) (*bytes.Buffer, *bytes.Buffer, erro
 }
 
 func (r *Runner) ExecuteWithEnvVars(env []string, args []interface{}) (*bytes.Buffer, *bytes.Buffer, error) {
+	return r.ExecuteWithEnvVarsCtx(context.Background(), env, args)
+}
+
+func (r *Runner) ExecuteWithEnvVarsCtx(ctx context.Context, env []string, args []interface{}) (*bytes.Buffer, *bytes.Buffer, error) {
 	var outBufWriter bytes.Buffer
 	var errBufWriter bytes.Buffer
 
@@ -53,7 +58,7 @@ func (r *Runner) ExecuteWithEnvVars(env []string, args []interface{}) (*bytes.Bu
 		}
 	}
 
-	command := exec.Command(r.command, stringArgs...)
+	command := exec.CommandContext(ctx, r.command, stringArgs...)
 	if len(env) > 0 {
 		command.Env = append(os.Environ(), env...)
 	}

--- a/vmlifecycle/vmmanagers/fakes/govcRunner.go
+++ b/vmlifecycle/vmmanagers/fakes/govcRunner.go
@@ -3,6 +3,7 @@ package fakes
 
 import (
 	"bytes"
+	"context"
 	"sync"
 )
 
@@ -19,6 +20,23 @@ type GovcRunner struct {
 		result3 error
 	}
 	executeWithEnvVarsReturnsOnCall map[int]struct {
+		result1 *bytes.Buffer
+		result2 *bytes.Buffer
+		result3 error
+	}
+	ExecuteWithEnvVarsCtxStub        func(context.Context, []string, []interface{}) (*bytes.Buffer, *bytes.Buffer, error)
+	executeWithEnvVarsCtxMutex       sync.RWMutex
+	executeWithEnvVarsCtxArgsForCall []struct {
+		arg1 context.Context
+		arg2 []string
+		arg3 []interface{}
+	}
+	executeWithEnvVarsCtxReturns struct {
+		result1 *bytes.Buffer
+		result2 *bytes.Buffer
+		result3 error
+	}
+	executeWithEnvVarsCtxReturnsOnCall map[int]struct {
 		result1 *bytes.Buffer
 		result2 *bytes.Buffer
 		result3 error
@@ -104,11 +122,91 @@ func (fake *GovcRunner) ExecuteWithEnvVarsReturnsOnCall(i int, result1 *bytes.Bu
 	}{result1, result2, result3}
 }
 
+func (fake *GovcRunner) ExecuteWithEnvVarsCtx(arg1 context.Context, arg2 []string, arg3 []interface{}) (*bytes.Buffer, *bytes.Buffer, error) {
+	var arg2Copy []string
+	if arg2 != nil {
+		arg2Copy = make([]string, len(arg2))
+		copy(arg2Copy, arg2)
+	}
+	var arg3Copy []interface{}
+	if arg3 != nil {
+		arg3Copy = make([]interface{}, len(arg3))
+		copy(arg3Copy, arg3)
+	}
+	fake.executeWithEnvVarsCtxMutex.Lock()
+	ret, specificReturn := fake.executeWithEnvVarsCtxReturnsOnCall[len(fake.executeWithEnvVarsCtxArgsForCall)]
+	fake.executeWithEnvVarsCtxArgsForCall = append(fake.executeWithEnvVarsCtxArgsForCall, struct {
+		arg1 context.Context
+		arg2 []string
+		arg3 []interface{}
+	}{arg1, arg2Copy, arg3Copy})
+	fake.recordInvocation("ExecuteWithEnvVarsCtx", []interface{}{arg1, arg2Copy, arg3Copy})
+	fake.executeWithEnvVarsCtxMutex.Unlock()
+	if fake.ExecuteWithEnvVarsCtxStub != nil {
+		return fake.ExecuteWithEnvVarsCtxStub(arg1, arg2, arg3)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2, ret.result3
+	}
+	fakeReturns := fake.executeWithEnvVarsCtxReturns
+	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
+}
+
+func (fake *GovcRunner) ExecuteWithEnvVarsCtxCallCount() int {
+	fake.executeWithEnvVarsCtxMutex.RLock()
+	defer fake.executeWithEnvVarsCtxMutex.RUnlock()
+	return len(fake.executeWithEnvVarsCtxArgsForCall)
+}
+
+func (fake *GovcRunner) ExecuteWithEnvVarsCtxCalls(stub func(context.Context, []string, []interface{}) (*bytes.Buffer, *bytes.Buffer, error)) {
+	fake.executeWithEnvVarsCtxMutex.Lock()
+	defer fake.executeWithEnvVarsCtxMutex.Unlock()
+	fake.ExecuteWithEnvVarsCtxStub = stub
+}
+
+func (fake *GovcRunner) ExecuteWithEnvVarsCtxArgsForCall(i int) (context.Context, []string, []interface{}) {
+	fake.executeWithEnvVarsCtxMutex.RLock()
+	defer fake.executeWithEnvVarsCtxMutex.RUnlock()
+	argsForCall := fake.executeWithEnvVarsCtxArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *GovcRunner) ExecuteWithEnvVarsCtxReturns(result1 *bytes.Buffer, result2 *bytes.Buffer, result3 error) {
+	fake.executeWithEnvVarsCtxMutex.Lock()
+	defer fake.executeWithEnvVarsCtxMutex.Unlock()
+	fake.ExecuteWithEnvVarsCtxStub = nil
+	fake.executeWithEnvVarsCtxReturns = struct {
+		result1 *bytes.Buffer
+		result2 *bytes.Buffer
+		result3 error
+	}{result1, result2, result3}
+}
+
+func (fake *GovcRunner) ExecuteWithEnvVarsCtxReturnsOnCall(i int, result1 *bytes.Buffer, result2 *bytes.Buffer, result3 error) {
+	fake.executeWithEnvVarsCtxMutex.Lock()
+	defer fake.executeWithEnvVarsCtxMutex.Unlock()
+	fake.ExecuteWithEnvVarsCtxStub = nil
+	if fake.executeWithEnvVarsCtxReturnsOnCall == nil {
+		fake.executeWithEnvVarsCtxReturnsOnCall = make(map[int]struct {
+			result1 *bytes.Buffer
+			result2 *bytes.Buffer
+			result3 error
+		})
+	}
+	fake.executeWithEnvVarsCtxReturnsOnCall[i] = struct {
+		result1 *bytes.Buffer
+		result2 *bytes.Buffer
+		result3 error
+	}{result1, result2, result3}
+}
+
 func (fake *GovcRunner) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
 	fake.executeWithEnvVarsMutex.RLock()
 	defer fake.executeWithEnvVarsMutex.RUnlock()
+	fake.executeWithEnvVarsCtxMutex.RLock()
+	defer fake.executeWithEnvVarsCtxMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/vmlifecycle/vmmanagers/vsphere_test.go
+++ b/vmlifecycle/vmmanagers/vsphere_test.go
@@ -1,11 +1,10 @@
 package vmmanagers_test
 
 import (
+	"archive/tar"
 	"fmt"
 	"io/ioutil"
 	"os"
-
-	"archive/tar"
 
 	"bytes"
 	"errors"
@@ -111,6 +110,14 @@ opsman-configuration:
 						"-on=true",
 						"-vm.ipath=/datacenter/vm/folder/vm_name",
 					))
+
+					_, _, args = runner.ExecuteWithEnvVarsCtxArgsForCall(0)
+					Expect(args).To(matchers.OrderedConsistOf(
+						"vm.info",
+						"-vm.ipath=/datacenter/vm/folder/vm_name",
+						"-waitip",
+					))
+					Expect(runner.ExecuteWithEnvVarsCtxCallCount()).To(Equal(1))
 				})
 
 				When("setting custom cpu and memory", func() {


### PR DESCRIPTION
When deploying opsman to vSphere, it fails to boot 15% of the time. It happens very early in the boot process, apparently even before loading the kernel. When viewing the opsman's VM's console, the symptom is a flashing cursor in the upper left hand side of the screen.

This commit fixes that failure by waiting 80 seconds for the opsman VM to report its IP address to vCenter, and if it hasn't reported its IP address by then, it sends a hardware reset to the VM. An opsman VM typically reports its IP address to vCenter 43 seconds after being powered-on.

We verified this fix by successfully deploying & booting opsman 146 times in a row.

More about the boot failure:

- The boot failure only occurs the very first time an opsman is booted; subsequent boots will always succeed. We tested 100 shutdown/boots to confirm.
- The failure was seen both on vSphere 7 and vSphere 8.
- Sending a reset or a ctl-alt-del to the machine within the first few seconds of being powered-on reduced but did not eliminate the failure.

This fix should have negligible impact on the length of time to deploy opsman.

Typical output when resetting a failed initial boot:

```
Executing: "govc vm.info -vm.ipath=/dc/vm/pcf_vms/om.tas.nono.io -waitip"
This could take a few moments...
VM hasn't acquired IP, is probably stuck, resetting VM to free it

Executing: "govc vm.power -vm.ipath=/dc/vm/pcf_vms/om.tas.nono.io -reset"
This could take a few moments...
govc[stdout]: Reset VirtualMachine:vm-42616... OK
```

The added tests are admittedly lackluster, but I couldn't find a way to implement them without making `vsphere.go` overly-complicated.