### PR TITLE
Add optional --ldap-max-search-depth to fix issue #601

### DIFF
--- a/api/setup_service.go
+++ b/api/setup_service.go
@@ -17,6 +17,7 @@ type LDAPSettings struct {
 	LDAPRBACAdminGroup string `json:"ldap_rbac_admin_group_name,omitempty"`
 	LDAPReferral       string `json:"ldap_referrals,omitempty"`
 	LDAPUsername       string `json:"ldap_username,omitempty"`
+	LDAPMaxSearchDepth uint   `json:"ldap_max_search_depth,omitempty"`
 	ServerSSLCert      string `json:"server_ssl_cert,omitempty"`
 	ServerURL          string `json:"server_url,omitempty"`
 	UserSearchBase     string `json:"user_search_base,omitempty"`

--- a/docs/configure-ldap-authentication/README.md
+++ b/docs/configure-ldap-authentication/README.md
@@ -80,6 +80,10 @@ Help Options:
                                            behavior
           --ldap-username=                 DN for the LDAP credentials used to
                                            search the directory
+          --ldap-max-search-depth=         The LDAP group search depth. Allowed
+                                           values are between 1 and 10. The
+                                           default value is 1, which will turn
+                                           off the nested group search.
           --server-ssl-cert=               the server certificate when using
                                            ldaps://
           --server-url=                    URL to the ldap server, must start


### PR DESCRIPTION
Added an optional `--ldap-max-search-depth` flag to use with Operations Manager 3.0+. The new flag can be used like so:

```
om configure-ldap-authentication \
  --decryption-passphrase='supersecret' \
  --email-attribute='email' \
  --group-search-base='ou=Groups,dc=vmware,dc=com' \
  --group-search-filter='Corp' \
  --ldap-password='supersecret' \
  --ldap-rbac-admin-group-name='Admins' \
  --ldap-referrals=follow \
  --ldap-username=ldapadmin \
  --ldap-max-search-depth=5 \
  --server-ssl-cert="$(cat ~/ldap.crt)" \
  --server-url='ldaps://ad.vmware.com' \
  --user-search-base='Users' \
  --user-search-filter='devs' \
  --skip-create-bosh-admin-client \
  --precreated-client-secret='supersecret'
  ```