### PR TITLE
vmlifecycle - aws - add support for setting volume type

### DIFF
--- a/vmlifecycle/configfetchers/aws.go
+++ b/vmlifecycle/configfetchers/aws.go
@@ -93,6 +93,7 @@ func (a *AWSConfigFetcher) createConfig(output *ec2.DescribeInstancesOutput, vol
 				PrivateIP:              *instance.PrivateIpAddress,
 				InstanceType:           *instance.InstanceType,
 				BootDiskSize:           strconv.Itoa(int(*volumesOutput.Volumes[0].Size)),
+				BootDiskType:           *volumesOutput.Volumes[0].VolumeType,
 			},
 		},
 	}

--- a/vmlifecycle/configfetchers/aws_test.go
+++ b/vmlifecycle/configfetchers/aws_test.go
@@ -42,6 +42,7 @@ var _ = Describe("aws", func() {
 						PrivateIP:              "5.6.7.8",
 						VMName:                 "opsman-vm",
 						BootDiskSize:           "160",
+						BootDiskType:           "gp3",
 						InstanceType:           "some-instance-type",
 					},
 				},
@@ -94,7 +95,8 @@ var _ = Describe("aws", func() {
 
 				return &ec2.DescribeVolumesOutput{
 					Volumes: []*ec2.Volume{{
-						Size: aws.Int64(160),
+						Size:       aws.Int64(160),
+						VolumeType: aws.String("gp3"),
 					}},
 				}, nil
 			}


### PR DESCRIPTION
default to gp2 (current behavior). allows user to define boot_disk_type in their aws config to instruct the type of volume to use when modifying the volume after vm creation

refactoring aws lifecycle create to no longer perform a modify volume after initial creation. pass those disk options to initial creation to allow users to modify the volume if necessary after initial create without a penalty. aws imposes a 6 hour cool down between changes and this allows a user to modify vs the create causing a 6 hour cooldown before the next change is allowed