### PR TITLE
add stemcell-slug option to download-product command

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
           CGO_ENABLED: 1
 
       - name: Archive Unit Test Code Coverage Output
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Unit Test Code Coverage Output
           path: coverage/*.out

--- a/commands/download_product.go
+++ b/commands/download_product.go
@@ -54,6 +54,7 @@ type StemcellOptions struct {
 	StemcellIaas    string `long:"stemcell-iaas"     description:"download the latest available stemcell for the product for the specified iaas. for example 'vsphere' or 'vcloud' or 'openstack' or 'google' or 'azure' or 'aws'. Can contain globbing patterns to match specific files in a stemcell release on Pivnet"`
 	StemcellVersion string `long:"stemcell-version" description:"the version number of the stemcell to download (ie 458.61)"`
 	StemcellHeavy   bool   `long:"stemcell-heavy" description:"force the downloading of a heavy stemcell, will fail if non exists"`
+	StemcellSlug    string `long:"stemcell-slug" description:"download the stemcell for the product that matches with the specified stemcell slug"`
 }
 
 type DownloadProductOptions struct {
@@ -147,7 +148,7 @@ func (c *DownloadProduct) Execute(args []string) error {
 		return c.writeDownloadProductOutput(productFileName, productVersion, "", "")
 	}
 
-	stemcellVersion, stemcellFileName, err := c.downloadStemcell(productFileName, productVersion, productFileArtifact)
+	stemcellVersion, stemcellFileName, err := c.downloadStemcell(productFileName, productVersion, productFileArtifact, c.Options.StemcellSlug)
 	if err != nil {
 		return err
 	}
@@ -160,10 +161,10 @@ func (c *DownloadProduct) Execute(args []string) error {
 	return c.writeAssignStemcellInput(productFileName, productFileArtifact, stemcellVersion)
 }
 
-func (c *DownloadProduct) downloadStemcell(productFileName string, productVersion string, productFileArtifact download_clients.FileArtifacter) (string, string, error) {
+func (c *DownloadProduct) downloadStemcell(productFileName string, productVersion string, productFileArtifact download_clients.FileArtifacter, stemCellSlug string) (string, string, error) {
 	c.stderr.Printf("Downloading stemcell")
 
-	stemcell, err := c.downloadClient.GetLatestStemcellForProduct(productFileArtifact, productFileName)
+	stemcell, err := c.downloadClient.GetLatestStemcellForProduct(productFileArtifact, productFileName, stemCellSlug)
 	if err != nil {
 		return "", "", fmt.Errorf("could not get information about stemcell: %s", err)
 	}

--- a/commands/download_product.go
+++ b/commands/download_product.go
@@ -54,7 +54,7 @@ type StemcellOptions struct {
 	StemcellIaas    string `long:"stemcell-iaas"     description:"download the latest available stemcell for the product for the specified iaas. for example 'vsphere' or 'vcloud' or 'openstack' or 'google' or 'azure' or 'aws'. Can contain globbing patterns to match specific files in a stemcell release on Pivnet"`
 	StemcellVersion string `long:"stemcell-version" description:"the version number of the stemcell to download (ie 458.61)"`
 	StemcellHeavy   bool   `long:"stemcell-heavy" description:"force the downloading of a heavy stemcell, will fail if non exists"`
-	StemcellSlug    string `long:"stemcell-slug" description:"download the stemcell for the product that matches with the specified stemcell slug"`
+	StemcellSlug    string `long:"stemcell-slug" description:"download the stemcell for the product that matches with the specified stemcell slug on Pivnet"`
 }
 
 type DownloadProductOptions struct {

--- a/download_clients/fakes/product_downloader_service.go
+++ b/download_clients/fakes/product_downloader_service.go
@@ -49,11 +49,12 @@ type ProductDownloader struct {
 		result1 download_clients.FileArtifacter
 		result2 error
 	}
-	GetLatestStemcellForProductStub        func(download_clients.FileArtifacter, string) (download_clients.StemcellArtifacter, error)
+	GetLatestStemcellForProductStub        func(download_clients.FileArtifacter, string, string) (download_clients.StemcellArtifacter, error)
 	getLatestStemcellForProductMutex       sync.RWMutex
 	getLatestStemcellForProductArgsForCall []struct {
 		arg1 download_clients.FileArtifacter
 		arg2 string
+		arg3 string
 	}
 	getLatestStemcellForProductReturns struct {
 		result1 download_clients.StemcellArtifacter
@@ -266,17 +267,18 @@ func (fake *ProductDownloader) GetLatestProductFileReturnsOnCall(i int, result1 
 	}{result1, result2}
 }
 
-func (fake *ProductDownloader) GetLatestStemcellForProduct(arg1 download_clients.FileArtifacter, arg2 string) (download_clients.StemcellArtifacter, error) {
+func (fake *ProductDownloader) GetLatestStemcellForProduct(arg1 download_clients.FileArtifacter, arg2 string, arg3 string) (download_clients.StemcellArtifacter, error) {
 	fake.getLatestStemcellForProductMutex.Lock()
 	ret, specificReturn := fake.getLatestStemcellForProductReturnsOnCall[len(fake.getLatestStemcellForProductArgsForCall)]
 	fake.getLatestStemcellForProductArgsForCall = append(fake.getLatestStemcellForProductArgsForCall, struct {
 		arg1 download_clients.FileArtifacter
 		arg2 string
-	}{arg1, arg2})
+		arg3 string
+	}{arg1, arg2, arg3})
 	fake.recordInvocation("GetLatestStemcellForProduct", []interface{}{arg1, arg2})
 	fake.getLatestStemcellForProductMutex.Unlock()
 	if fake.GetLatestStemcellForProductStub != nil {
-		return fake.GetLatestStemcellForProductStub(arg1, arg2)
+		return fake.GetLatestStemcellForProductStub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -291,17 +293,17 @@ func (fake *ProductDownloader) GetLatestStemcellForProductCallCount() int {
 	return len(fake.getLatestStemcellForProductArgsForCall)
 }
 
-func (fake *ProductDownloader) GetLatestStemcellForProductCalls(stub func(download_clients.FileArtifacter, string) (download_clients.StemcellArtifacter, error)) {
+func (fake *ProductDownloader) GetLatestStemcellForProductCalls(stub func(download_clients.FileArtifacter, string, string) (download_clients.StemcellArtifacter, error)) {
 	fake.getLatestStemcellForProductMutex.Lock()
 	defer fake.getLatestStemcellForProductMutex.Unlock()
 	fake.GetLatestStemcellForProductStub = stub
 }
 
-func (fake *ProductDownloader) GetLatestStemcellForProductArgsForCall(i int) (download_clients.FileArtifacter, string) {
+func (fake *ProductDownloader) GetLatestStemcellForProductArgsForCall(i int) (download_clients.FileArtifacter, string, string) {
 	fake.getLatestStemcellForProductMutex.RLock()
 	defer fake.getLatestStemcellForProductMutex.RUnlock()
 	argsForCall := fake.getLatestStemcellForProductArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
 func (fake *ProductDownloader) GetLatestStemcellForProductReturns(result1 download_clients.StemcellArtifacter, result2 error) {

--- a/download_clients/interfaces.go
+++ b/download_clients/interfaces.go
@@ -1,8 +1,9 @@
 package download_clients
 
 import (
-	"github.com/pivotal-cf/om/extractor"
 	"os"
+
+	"github.com/pivotal-cf/om/extractor"
 )
 
 //counterfeiter:generate -o ./fakes/file_artifacter.go --fake-name FileArtifacter . FileArtifacter
@@ -24,5 +25,5 @@ type ProductDownloader interface {
 	GetAllProductVersions(slug string) ([]string, error)
 	GetLatestProductFile(slug, version, glob string) (FileArtifacter, error)
 	DownloadProductToFile(fa FileArtifacter, file *os.File) error
-	GetLatestStemcellForProduct(fa FileArtifacter, downloadedProductFileName string) (StemcellArtifacter, error)
+	GetLatestStemcellForProduct(fa FileArtifacter, downloadedProductFileName string, stemcellSlug string) (StemcellArtifacter, error)
 }

--- a/download_clients/pivnet_client.go
+++ b/download_clients/pivnet_client.go
@@ -172,38 +172,38 @@ func (p *pivnetClient) checkForSingleProductFile(glob string, productFiles []piv
 
 func (p *pivnetClient) getLatestStemcell(dependencies []pivnet.ReleaseDependency, stemcellSlug string) (string, string, error) {
 	var (
-		versions              []string
-		matched_stemcell_slug string
+		versions            []string
+		matchedStemcellSlug string
 	)
-	stemCellMap := make(map[string][]string)
+	stemCellSlugVersions := make(map[string][]string)
 
 	for _, dependency := range dependencies {
 		if strings.Contains(dependency.Release.Product.Slug, "stemcells") {
-			if _, exists := stemCellMap[dependency.Release.Product.Slug]; exists {
-				stemCellMap[dependency.Release.Product.Slug] = append(stemCellMap[dependency.Release.Product.Slug], dependency.Release.Version)
-			} else {
-				stemCellMap[dependency.Release.Product.Slug] = []string{dependency.Release.Version}
-			}
+			stemCellSlugVersions[dependency.Release.Product.Slug] = append(stemCellSlugVersions[dependency.Release.Product.Slug], dependency.Release.Version)
 			if strings.Contains(dependency.Release.Product.Slug, stemcellSlug) {
-				matched_stemcell_slug = dependency.Release.Product.Slug
+				matchedStemcellSlug = dependency.Release.Product.Slug
 			}
 		}
 	}
 
-	if len(stemCellMap) >= 2 && stemcellSlug == "" {
+	if len(stemCellSlugVersions) >= 2 && stemcellSlug == "" {
 		var stemcells []string
-		for k := range stemCellMap {
+		for k := range stemCellSlugVersions {
 			stemcells = append(stemcells, k)
 		}
 		return "", "", fmt.Errorf("multiple stemcell types found: %q."+
 			" Provide %q option to specify the stemcell slug of stemcell that needs to be downloaded",
 			strings.Join(stemcells, ","), "stemcell-slug")
-	} else if matched_stemcell_slug == "" {
+	}
+
+	if matchedStemcellSlug == "" {
 		return "", "", fmt.Errorf("provided %q stemcell slug is invalid, please provide the correct one", stemcellSlug)
-	} else if stemcellSlug != "" {
-		versions = stemCellMap[matched_stemcell_slug]
+	}
+
+	if stemcellSlug != "" {
+		versions = stemCellSlugVersions[matchedStemcellSlug]
 	} else {
-		for _, stemcellVersions := range stemCellMap {
+		for _, stemcellVersions := range stemCellSlugVersions {
 			versions = stemcellVersions
 		}
 	}
@@ -212,7 +212,7 @@ func (p *pivnetClient) getLatestStemcell(dependencies []pivnet.ReleaseDependency
 	if err != nil {
 		return "", "", err
 	}
-	return matched_stemcell_slug, stemcellVersion, nil
+	return matchedStemcellSlug, stemcellVersion, nil
 }
 
 const (

--- a/download_clients/pivnet_client_test.go
+++ b/download_clients/pivnet_client_test.go
@@ -446,7 +446,7 @@ var _ = Describe("PivnetClient", func() {
 
 			client := download_clients.NewPivnetClient(stdout, stderr, fakePivnetFactory, "", true, "")
 			_, err := client.GetLatestStemcellForProduct(createPivnetFileArtifact(), "", "")
-			Expect(err).To(MatchError(ContainSubstring("could not sort stemcell dependency: multiple stemcell types found: \"stemcells-ubuntu-jammy,stemcells-windows-server\". Provide \"stemcell-slug\" option to specify the stemcell slug of stemcell that needs to be downloaded")))
+			Expect(err).To(MatchError(ContainSubstring("could not sort stemcell dependency: multiple stemcell types found:")))
 		})
 	})
 

--- a/download_clients/pivnet_client_test.go
+++ b/download_clients/pivnet_client_test.go
@@ -303,7 +303,7 @@ var _ = Describe("PivnetClient", func() {
 			}, nil)
 
 			client := download_clients.NewPivnetClient(stdout, stderr, fakePivnetFactory, "", true, "")
-			stemcell, err := client.GetLatestStemcellForProduct(createPivnetFileArtifact(), "")
+			stemcell, err := client.GetLatestStemcellForProduct(createPivnetFileArtifact(), "", "")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(stemcell).ToNot(BeNil())
 			Expect(stemcell.Version()).To(Equal("1.0"))
@@ -315,7 +315,7 @@ var _ = Describe("PivnetClient", func() {
 			}, nil)
 
 			client := download_clients.NewPivnetClient(stdout, stderr, fakePivnetFactory, "", true, "")
-			stemcell, err := client.GetLatestStemcellForProduct(createPivnetFileArtifact(), "")
+			stemcell, err := client.GetLatestStemcellForProduct(createPivnetFileArtifact(), "", "")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(stemcell).ToNot(BeNil())
 			Expect(stemcell.Version()).To(Equal("1"))
@@ -329,7 +329,7 @@ var _ = Describe("PivnetClient", func() {
 			}, nil)
 
 			client := download_clients.NewPivnetClient(stdout, stderr, fakePivnetFactory, "", true, "")
-			stemcell, err := client.GetLatestStemcellForProduct(createPivnetFileArtifact(), "")
+			stemcell, err := client.GetLatestStemcellForProduct(createPivnetFileArtifact(), "", "")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(stemcell).ToNot(BeNil())
 			Expect(stemcell.Version()).To(Equal("5.10"))
@@ -343,7 +343,7 @@ var _ = Describe("PivnetClient", func() {
 			}, nil)
 
 			client := download_clients.NewPivnetClient(stdout, stderr, fakePivnetFactory, "", true, "")
-			stemcell, err := client.GetLatestStemcellForProduct(createPivnetFileArtifact(), "")
+			stemcell, err := client.GetLatestStemcellForProduct(createPivnetFileArtifact(), "", "")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(stemcell).ToNot(BeNil())
 			Expect(stemcell.Version()).To(Equal("1.3"))
@@ -357,7 +357,7 @@ var _ = Describe("PivnetClient", func() {
 			}, nil)
 
 			client := download_clients.NewPivnetClient(stdout, stderr, fakePivnetFactory, "", true, "")
-			stemcell, err := client.GetLatestStemcellForProduct(createPivnetFileArtifact(), "")
+			stemcell, err := client.GetLatestStemcellForProduct(createPivnetFileArtifact(), "", "")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(stemcell).ToNot(BeNil())
 			Expect(stemcell.Version()).To(Equal("97.190"))
@@ -367,7 +367,7 @@ var _ = Describe("PivnetClient", func() {
 			fakePivnetDownloader.ReleaseDependenciesReturns([]pivnet.ReleaseDependency{}, errors.New("stemcell not found"))
 
 			client := download_clients.NewPivnetClient(stdout, stderr, fakePivnetFactory, "", true, "")
-			_, err := client.GetLatestStemcellForProduct(createPivnetFileArtifact(), "")
+			_, err := client.GetLatestStemcellForProduct(createPivnetFileArtifact(), "", "")
 			Expect(err).To(MatchError(ContainSubstring("could not fetch stemcell dependency for")))
 		})
 
@@ -377,7 +377,7 @@ var _ = Describe("PivnetClient", func() {
 			}, nil)
 
 			client := download_clients.NewPivnetClient(stdout, stderr, fakePivnetFactory, "", true, "")
-			_, err := client.GetLatestStemcellForProduct(createPivnetFileArtifact(), "")
+			_, err := client.GetLatestStemcellForProduct(createPivnetFileArtifact(), "", "")
 			Expect(err).To(MatchError(ContainSubstring("could not sort stemcell dependency")))
 			Expect(err).To(MatchError(ContainSubstring(fmt.Sprintf(errorTemplateForStemcell, "1.0.0"))))
 		})
@@ -388,7 +388,7 @@ var _ = Describe("PivnetClient", func() {
 			}, nil)
 
 			client := download_clients.NewPivnetClient(stdout, stderr, fakePivnetFactory, "", true, "")
-			_, err := client.GetLatestStemcellForProduct(createPivnetFileArtifact(), "")
+			_, err := client.GetLatestStemcellForProduct(createPivnetFileArtifact(), "", "")
 			Expect(err).To(MatchError(ContainSubstring(fmt.Sprintf(errorTemplateForStemcell, "abc1.0"))))
 		})
 
@@ -398,19 +398,8 @@ var _ = Describe("PivnetClient", func() {
 			}, nil)
 
 			client := download_clients.NewPivnetClient(stdout, stderr, fakePivnetFactory, "", true, "")
-			_, err := client.GetLatestStemcellForProduct(createPivnetFileArtifact(), "")
+			_, err := client.GetLatestStemcellForProduct(createPivnetFileArtifact(), "", "")
 			Expect(err).To(MatchError(ContainSubstring(fmt.Sprintf(errorTemplateForStemcell, "1.0def"))))
-		})
-
-		It("returns an error when multiple stemcell types are found", func() {
-			fakePivnetDownloader.ReleaseDependenciesReturns([]pivnet.ReleaseDependency{
-				createReleaseDependency(789, "1.0", "stemcells-ubuntu-jammy"),
-				createReleaseDependency(789, "1.0", "stemcells-windows-server"),
-			}, nil)
-		
-			client := download_clients.NewPivnetClient(stdout, stderr, fakePivnetFactory, "", true, "")
-			_, err := client.GetLatestStemcellForProduct(createPivnetFileArtifact(), "")
-			Expect(err).To(MatchError(ContainSubstring("could not determine stemcell: multiple stemcell types found: stemcells-ubuntu-jammy, stemcells-windows-server")))
 		})
 	})
 

--- a/download_clients/stow_client.go
+++ b/download_clients/stow_client.go
@@ -2,15 +2,17 @@ package download_clients
 
 import (
 	"fmt"
-	"github.com/cheggaaa/pb/v3"
-	"github.com/graymeta/stow"
-	"github.com/pivotal-cf/om/extractor"
 	"io"
 	"log"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
+
+	"github.com/cheggaaa/pb/v3"
+	"github.com/graymeta/stow"
+
+	"github.com/pivotal-cf/om/extractor"
 )
 
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
@@ -252,7 +254,7 @@ func (s stowClient) streamBufferToFile(destinationFile *os.File, wrappedBlobRead
 	return err
 }
 
-func (s stowClient) GetLatestStemcellForProduct(_ FileArtifacter, downloadedProductFileName string) (StemcellArtifacter, error) {
+func (s stowClient) GetLatestStemcellForProduct(_ FileArtifacter, downloadedProductFileName string, stemcellSlug string) (StemcellArtifacter, error) {
 	definedStemcell, err := stemcellFromProduct(downloadedProductFileName)
 	if err != nil {
 		return nil, err

--- a/download_clients/stow_client_test.go
+++ b/download_clients/stow_client_test.go
@@ -304,7 +304,7 @@ var _ = Describe("stowClient", func() {
 
 				client := download_clients.NewStowClient(stower, nil, stow.ConfigMap{"endpoint": "endpoint"}, "", stemcellPath, "", "bucket")
 
-				stemcell, err := client.GetLatestStemcellForProduct(nil, exampleTileFileName)
+				stemcell, err := client.GetLatestStemcellForProduct(nil, exampleTileFileName, "")
 				Expect(err).ToNot(HaveOccurred())
 
 				Expect(stemcell.Version()).To(Equal("97.101"))
@@ -334,14 +334,14 @@ var _ = Describe("stowClient", func() {
 
 				client := download_clients.NewStowClient(stower, nil, stow.ConfigMap{"endpoint": "endpoint"}, "", "", "", "bucket")
 
-				_, err := client.GetLatestStemcellForProduct(nil, exampleTileFileName)
+				_, err := client.GetLatestStemcellForProduct(nil, exampleTileFileName, "")
 				Expect(err).To(MatchError("versioning of stemcell dependency in unexpected format: \"major.minor\" or \"major\". the following version could not be parsed: bad-version"))
 			})
 
 			It("errors when the product file does not have stemcell information", func() {
 				client := download_clients.NewStowClient(nil, nil, stow.ConfigMap{"endpoint": "endpoint"}, "", "", "", "bucket")
 
-				_, err := client.GetLatestStemcellForProduct(nil, "./fixtures/example-product.yml")
+				_, err := client.GetLatestStemcellForProduct(nil, "./fixtures/example-product.yml", "")
 				Expect(err).To(HaveOccurred())
 			})
 
@@ -358,7 +358,7 @@ var _ = Describe("stowClient", func() {
 
 				client := download_clients.NewStowClient(stower, nil, stow.ConfigMap{"endpoint": "endpoint"}, "", "", "blobstore", "bucket")
 
-				_, err := client.GetLatestStemcellForProduct(nil, exampleTileFileName)
+				_, err := client.GetLatestStemcellForProduct(nil, exampleTileFileName, "")
 				Expect(err).To(MatchError("could not find stemcells on blobstore: bucket 'bucket' contains no files"))
 			})
 
@@ -379,7 +379,7 @@ var _ = Describe("stowClient", func() {
 
 				client := download_clients.NewStowClient(stower, nil, stow.ConfigMap{"endpoint": "endpoint"}, "", "", "blobstore", "bucket")
 
-				_, err := client.GetLatestStemcellForProduct(nil, exampleTileFileName)
+				_, err := client.GetLatestStemcellForProduct(nil, exampleTileFileName, "")
 				Expect(err).To(MatchError("no versions could be found equal to or greater than 97.28"))
 			})
 		})


### PR DESCRIPTION
This PR adds a `stemcell-slug` optinal option to `download-product` command to specify the stemcell slug in case of multiple stemcells