### PR TITLE
Ensure existing clusters within availability zones match correctly

### DIFF
--- a/api/director_service.go
+++ b/api/director_service.go
@@ -481,10 +481,12 @@ func (a Api) addGUIDToExistingAZs(azs AvailabilityZones) (AvailabilityZones, err
 				az.GUID = existingAZ.GUID
 
 				for _, cluster := range az.Clusters {
-					for _, existingCluster := range existingAZ.Clusters {
-						if cluster.Name == existingCluster.Name {
-							cluster.GUID = existingCluster.GUID
-							break
+					if cluster.GUID == "" {
+						for _, existingCluster := range existingAZ.Clusters {
+							if cluster.Name == existingCluster.Name {
+								cluster.GUID = existingCluster.GUID
+								break
+							}
 						}
 					}
 				}


### PR DESCRIPTION
The previous implementation expected cluster names to be unique. Unfortunately, this is not true across infras so we instead assume the configuration is complete for a given cluster if the guid is already set.