### PR TITLE
fix empty array being encoded as null in json in expiring-licenses command

### DIFF
--- a/presenters/json_presenter.go
+++ b/presenters/json_presenter.go
@@ -2,9 +2,10 @@ package presenters
 
 import (
 	"encoding/json"
+	"io"
+
 	"github.com/pivotal-cf/om/api"
 	"github.com/pivotal-cf/om/models"
-	"io"
 )
 
 type JSONPresenter struct {
@@ -116,10 +117,9 @@ func (j JSONPresenter) PresentLicensedProducts(products []api.ExpiringLicenseOut
 		ProductVersion string   `json:"product_version"`
 		LicenseVersion string   `json:"licensed_version"`
 	}
-	var output []licenseOutput
+	output := []licenseOutput{}
 	var expiresAt string
 	for _, product := range products {
-
 		if product.ExpiresAt.IsZero() {
 			expiresAt = ""
 		} else {


### PR DESCRIPTION
This PR fixes the json encoding issue where an empty array is being encoded as nil in Json.