### PR TITLE
fix: prevent duplicate stemcell uploads

### DIFF
--- a/api/diagnostic_service.go
+++ b/api/diagnostic_service.go
@@ -24,9 +24,9 @@ type DiagnosticReport struct {
 }
 
 type Stemcell struct {
-	Filename string
-	OS       string
-	Version  string
+	Filename string `json:"filename"`
+	OS       string `json:"os"`
+	Version  string `json:"version"`
 }
 
 type DiagnosticReportUnavailable struct{}


### PR DESCRIPTION
Previously, om would re-upload a stemcell even if it was already present in Ops Manager, due to mismatches in filename conventions & incomplete checks. This caused unnecessary uploads & pipeline delays.

This PR addresses the issue by -
- Extracting the OS, version, & infrastructure (IAAS) directly from the stemcell manifest (stemcell.MF) instead of relying on the filename.
- Matching these fields against the diagnostic report's available stemcells & infrastructure_type, ensuring a stemcell is only uploaded if it is truly absent for the given OS, version, & IAAS.

**Alternatives considered:**
- Parsing IAAS from the stemcell filename in the diagnostic report (error-prone & brittle).

**Final solution:**
- Use the manifest's `operating_system`, `version`, & `cloud_properties.infrastructure` fields.
- Compare these to the diagnostic report's `os`, `version`, and `infrastructure_type` fields for robust, intent-driven matching.

Also includes new & updated tests to verify the improved logic and prevent regressions.