### PR TITLE
fix(ci): update MinIO client command syntax

### DIFF
--- a/acceptance/init_test.go
+++ b/acceptance/init_test.go
@@ -44,7 +44,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 		Expect(err).ToNot(HaveOccurred())
 
 		Eventually(minio.Err, "10s").Should(gbytes.Say("API:"))
-		runCommand("mc", "--debug", "config", "host", "add", "testing", "http://127.0.0.1:9001", "minio", "password")
+		runCommand("mc", "--debug", "alias", "set", "testing", "http://127.0.0.1:9001", "minio", "password")
 	}
 	return []byte(omPath)
 }, func(data []byte) {


### PR DESCRIPTION
- Replace deprecated 'mc config host add' with 'mc alias set'
- Fixes CI pipeline failure caused by upstream MinIO client breaking change

The 'mc config' command was removed in minio/mc#5201, requiring migration to 'mc alias set' syntax for newer MinIO client versions.

Resolves: CI pipeline failure in test case