### PR TITLE
Fix: Pass azure vm tags as separate arguments.

### DIFF
--- a/vmlifecycle/vmmanagers/azure.go
+++ b/vmlifecycle/vmmanagers/azure.go
@@ -506,7 +506,10 @@ func (a *AzureVMManager) createVM(imageUrl string, imageID string, publicIP stri
 	}
 
 	if azure.Tags != "" {
-		args = append(args, "--tags", azure.Tags)
+		args = append(args, "--tags")
+		for _, t := range strings.Split(azure.Tags, " ") {
+			args = append(args, t)
+		}
 	}
 
 	_, _, err = a.runner.ExecuteWithEnvVars(a.addEnvVars(), args)

--- a/vmlifecycle/vmmanagers/azure_test.go
+++ b/vmlifecycle/vmmanagers/azure_test.go
@@ -211,7 +211,7 @@ opsman-configuration:
 						"--private-ip-address", "10.0.0.3",
 						"--storage-sku", "Standard_LRS",
 						"--image", "/some/resource/id/image",
-						"--tags", "Project=ECommerce CostCenter=00123 Team=Web",
+						"--tags", "Project=ECommerce", "CostCenter=00123", "Team=Web",
 					},
 					{
 						"storage", "blob", "delete-batch",


### PR DESCRIPTION
- The `az` CLI expects each key pair to be it's own argument (a bit odd behavior for CLI parsing, but taking space-separated options for a flag is a bit odd in the first place).
- Without this change, `vm-lifecycle` will not correctly add multiple tags against Operations Manager VMs deployed to Azure (e.g., a value of "foo=bar baz=quux", intended to add tags `foo="bar"` and `baz="quux"` will instead add a single tag of `foo="bar baz=quux"`)