### PR TITLE
Fix patch update grouping by ignoring conflicting preset groups

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
     "extends": [
       "config:recommended"
     ],
+    "ignorePresets": ["group:monorepos", "group:recommended"],
     "schedule": ["on tuesday and thursday"],
     "postUpdateOptions": [
       "gomodTidy",


### PR DESCRIPTION
Add ignorePresets to drop group:monorepos and group:recommended which were overriding the custom patch groupName due to preset rules running after user packageRules in Renovate's evaluation order.