### PR TITLE
suppress deploy-in-parallel for products that don't support it

### DIFF
--- a/acceptance/staged_config_test.go
+++ b/acceptance/staged_config_test.go
@@ -1,3 +1,8 @@
+// @AI-Generated
+// Modified with AI assistance
+// Description:
+// 2026-06-05: Updated and added acceptance tests for SupportsParallelDeploys gating in staged-config - Cursor: Claude Sonnet 4.5
+
 package acceptance
 
 import (
@@ -131,10 +136,10 @@ syslog-properties:
 			server.AppendHandlers(
 				ghttp.CombineHandlers(
 					ghttp.VerifyRequest("GET", "/api/v0/staged/products"),
-					ghttp.RespondWith(http.StatusOK, `[
-						{"installation_name":"p-bosh","guid":"p-bosh-guid","type":"p-bosh","product_version":"1.10.0.0"},
-						{"installation_name":"some-product","guid":"some-product-guid","type":"some-product","product_version":"1.0.0","deploy_in_parallel":true}
-					]`),
+				ghttp.RespondWith(http.StatusOK, `[
+					{"installation_name":"p-bosh","guid":"p-bosh-guid","type":"p-bosh","product_version":"1.10.0.0"},
+					{"installation_name":"some-product","guid":"some-product-guid","type":"some-product","product_version":"1.0.0","supports_parallel_deploys":true,"deploy_in_parallel":true}
+				]`),
 				),
 				ghttp.CombineHandlers(
 					ghttp.VerifyRequest("GET", "/api/v0/staged/products/some-product-guid/properties", "redact=true"),
@@ -219,6 +224,66 @@ syslog-properties:
   permitted_peer: "*.example.com"
   ssl_ca_certificate: "-----BEGIN CERTIFICATE-----\r\nMIIBsjCCARug..."
 `))
+		})
+	})
+
+	When("the product does not support parallel deploys", func() {
+		BeforeEach(func() {
+			server.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("GET", "/api/v0/staged/products"),
+					ghttp.RespondWith(http.StatusOK, `[
+						{"installation_name":"p-bosh","guid":"p-bosh-guid","type":"p-bosh","product_version":"1.10.0.0"},
+						{"installation_name":"some-product","guid":"some-product-guid","type":"some-product","product_version":"1.0.0","supports_parallel_deploys":false,"deploy_in_parallel":false}
+					]`),
+				),
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("GET", "/api/v0/staged/products/some-product-guid/properties", "redact=true"),
+					ghttp.RespondWith(http.StatusOK, stagedPropertiesJSON),
+				),
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("GET", "/api/v0/staged/products/some-product-guid/networks_and_azs"),
+					ghttp.RespondWith(http.StatusOK, stagedNetworksAndAzsJSON),
+				),
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("GET", "/api/v0/staged/products/some-product-guid/jobs"),
+					ghttp.RespondWith(http.StatusOK, stagedJobsJSON),
+				),
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("GET", "/api/v0/staged/products/some-product-guid/max_in_flight"),
+					ghttp.RespondWith(http.StatusOK, `{"max_in_flight": {"some-guid": "20%"}}`),
+				),
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("GET", "/api/v0/staged/products/some-product-guid/syslog_configuration"),
+					ghttp.RespondWith(http.StatusOK, stagedSyslogConfigurationJSON),
+				),
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("GET", "/api/v0/staged/products/some-product-guid/jobs/some-guid/resource_config"),
+					ghttp.RespondWith(http.StatusOK, stagedResourceConfigJSON),
+				),
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("GET", "/api/v0/staged/products/some-product-guid/errands"),
+					ghttp.RespondWith(http.StatusOK, stagedErrandsJSON),
+				),
+			)
+		})
+
+		It("omits deploy-in-parallel from the configuration template", func() {
+			command := exec.Command(pathToMain,
+				"--target", server.URL(),
+				"--username", "some-username",
+				"--password", "some-password",
+				"--skip-ssl-validation",
+				"staged-config",
+				"--product-name", "some-product",
+			)
+
+			session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
+			Expect(err).ToNot(HaveOccurred())
+
+			Eventually(session, "10s").Should(gexec.Exit(0))
+
+			Expect(string(session.Out.Contents())).ToNot(ContainSubstring("deploy-in-parallel"))
 		})
 	})
 

--- a/api/staged_products_service.go
+++ b/api/staged_products_service.go
@@ -1,3 +1,8 @@
+// @AI-Generated
+// Modified with AI assistance
+// Description:
+// 2026-06-05: Added SupportsParallelDeploys field to StagedProduct struct - Cursor: Claude Sonnet 4.5
+
 package api
 
 import (
@@ -25,12 +30,13 @@ type StagedProductsOutput struct {
 }
 
 type StagedProduct struct {
-	GUID                string
-	Type                string
-	ProductTemplateName string            `json:"product_template_name"`
-	LicenseMetadata     []LicenseMetadata `json:"license_metadata"`
-	ProductVersion      string            `json:"product_version"`
-	DeployInParallel    *bool             `json:"deploy_in_parallel,omitempty"`
+	GUID                    string
+	Type                    string
+	ProductTemplateName     string            `json:"product_template_name"`
+	LicenseMetadata         []LicenseMetadata `json:"license_metadata"`
+	ProductVersion          string            `json:"product_version"`
+	DeployInParallel        *bool             `json:"deploy_in_parallel,omitempty"`
+	SupportsParallelDeploys bool              `json:"supports_parallel_deploys"`
 }
 
 type UnstageProductInput struct {

--- a/commands/staged_config.go
+++ b/commands/staged_config.go
@@ -1,3 +1,8 @@
+// @AI-Generated
+// Modified with AI assistance
+// Description:
+// 2026-06-05: Suppress deploy-in-parallel in staged-config output for products that don't support parallel deploys - Cursor: Claude Sonnet 4.5
+
 package commands
 
 import (
@@ -174,9 +179,14 @@ func (ec StagedConfig) Execute(args []string) error {
 		errandConfigs[errand.Name] = errandConfig
 	}
 
+	var deployInParallel *bool
+	if findOutput.Product.SupportsParallelDeploys {
+		deployInParallel = findOutput.Product.DeployInParallel
+	}
+
 	config := config.ProductConfiguration{
 		ProductName:              ec.Options.Product,
-		DeployInParallel:         findOutput.Product.DeployInParallel,
+		DeployInParallel:         deployInParallel,
 		ProductProperties:        configurableProperties,
 		NetworkProperties:        networks,
 		ResourceConfigProperties: resourceConfig,

--- a/commands/staged_config_test.go
+++ b/commands/staged_config_test.go
@@ -1,3 +1,8 @@
+// @AI-Generated
+// Modified with AI assistance
+// Description:
+// 2026-06-05: Updated and added tests for SupportsParallelDeploys gating in staged-config - Cursor: Claude Sonnet 4.5
+
 package commands_test
 
 import (
@@ -430,8 +435,9 @@ syslog-properties:
 			deployTrue := true
 			fakeService.GetStagedProductByNameReturns(api.StagedProductsFindOutput{
 				Product: api.StagedProduct{
-					GUID:             "some-product-guid",
-					DeployInParallel: &deployTrue,
+					GUID:                    "some-product-guid",
+					DeployInParallel:        &deployTrue,
+					SupportsParallelDeploys: true,
 				},
 			}, nil)
 		})
@@ -490,8 +496,9 @@ syslog-properties:
 			deployFalse := false
 			fakeService.GetStagedProductByNameReturns(api.StagedProductsFindOutput{
 				Product: api.StagedProduct{
-					GUID:             "some-product-guid",
-					DeployInParallel: &deployFalse,
+					GUID:                    "some-product-guid",
+					DeployInParallel:        &deployFalse,
+					SupportsParallelDeploys: true,
 				},
 			}, nil)
 		})
@@ -536,6 +543,37 @@ syslog-properties:
   enabled: true
   host: tcp://1.1.1.1
 `)))
+		})
+	})
+
+	When("the product does not support parallel deploys", func() {
+		BeforeEach(func() {
+			internalSelector = api.ResponseProperty{
+				Value:        "internal",
+				Type:         "selector",
+				Configurable: true,
+			}
+			fakeService = setFakeService(internalSelector, true)
+			deployFalse := false
+			fakeService.GetStagedProductByNameReturns(api.StagedProductsFindOutput{
+				Product: api.StagedProduct{
+					GUID:                    "some-product-guid",
+					DeployInParallel:        &deployFalse,
+					SupportsParallelDeploys: false,
+				},
+			}, nil)
+		})
+
+		It("omits deploy-in-parallel from the output", func() {
+			command := commands.NewStagedConfig(fakeService, logger)
+			err := executeCommand(command, []string{
+				"--product-name", "some-product",
+			})
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(logger.PrintlnCallCount()).To(Equal(1))
+			output := logger.PrintlnArgsForCall(0)
+			Expect(output).ToNot(ContainElement(ContainSubstring("deploy-in-parallel")))
 		})
 	})
 


### PR DESCRIPTION
I thought it might be confusing for this field to show up in the output of something like the TAS tile, that doesn't and won't support parallel deploys

ai-assisted=yes
[TNZ-107986] om staged-config: suppress deploy-in-parallel for tiles that don't support parallel deploys