### PR TITLE
Fix stemcell availability check to fallback to filename matching

### DIFF
--- a/api/stemcell_service.go
+++ b/api/stemcell_service.go
@@ -8,6 +8,8 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"regexp"
+	"strings"
 
 	"gopkg.in/yaml.v2"
 )
@@ -111,16 +113,57 @@ func extractStemcellManifest(tgzPath string) (stemcellManifest, error) {
 	return stemcellManifest{}, fmt.Errorf("stemcell.MF not found in %s", tgzPath)
 }
 
+// parseStemcellFilename attempts to extract OS, version, and infrastructure from a stemcell filename.
+// Handles both common formats:
+// - bosh-stemcell-1.1250-vsphere-esxi-ubuntu-jammy-go_agent.tgz
+// - light-bosh-stemcell-2022.4-google-kvm-windows2022-go_agent.tgz
+// - bosh-vsphere-esxi-ubuntu-jammy-go_agent-1.1250.tgz
+func parseStemcellFilename(filename string) (os string, version string, infrastructure string) {
+	// Extract just the filename if a path is provided
+	filename = filepath.Base(filename)
+	filename = strings.TrimSuffix(filename, ".tgz")
+
+	// Try pattern 1: [light-]bosh-stemcell-VERSION-INFRASTRUCTURE-OS-go_agent
+	// The light- prefix is optional (used for some stemcells like Windows)
+	re1 := regexp.MustCompile(`^(?:light-)?bosh-stemcell-(\d+\.\d+(?:\.\d+)?)-(.+?)-((?:ubuntu|centos|rhel|windows|alpine|debian).+?)-go_agent$`)
+	if matches := re1.FindStringSubmatch(filename); matches != nil {
+		version = matches[1]
+		infrastructure = matches[2]
+		os = matches[3]
+		return
+	}
+
+	// Try pattern 2: bosh-INFRASTRUCTURE-OS-go_agent-VERSION
+	re2 := regexp.MustCompile(`^bosh-(.+?)-((?:ubuntu|centos|rhel|windows|alpine|debian).+?)-go_agent-(\d+\.\d+(?:\.\d+)?)$`)
+	if matches := re2.FindStringSubmatch(filename); matches != nil {
+		infrastructure = matches[1]
+		os = matches[2]
+		version = matches[3]
+		return
+	}
+
+	return "", "", ""
+}
+
 // infrastructureMatches reports whether the stemcell's infrastructure matches the
-// report's infrastructure type. Treats "warden" and "docker" as equivalent so that
-// duplicate detection works with Docker Ops Manager, where stemcells are built for
-// warden but the diagnostic report may report infrastructure_type as "docker".
+// report's infrastructure type. Treats equivalent infrastructure types as matches:
+// - "warden" and "docker" are equivalent (for Docker Ops Manager)
+// - "vsphere" variants (vsphere, vsphere-esxi) are equivalent
 func infrastructureMatches(manifestInfrastructure, reportInfrastructureType string) bool {
 	if manifestInfrastructure == reportInfrastructureType {
 		return true
 	}
-	return (manifestInfrastructure == "warden" && reportInfrastructureType == "docker") ||
-		(manifestInfrastructure == "docker" && reportInfrastructureType == "warden")
+	// Docker equivalence
+	if (manifestInfrastructure == "warden" && reportInfrastructureType == "docker") ||
+		(manifestInfrastructure == "docker" && reportInfrastructureType == "warden") {
+		return true
+	}
+	// vSphere variants are equivalent (vsphere, vsphere-esxi)
+	manifestIsVsphere := manifestInfrastructure == "vsphere" ||
+		manifestInfrastructure == "vsphere-esxi"
+	reportIsVsphere := reportInfrastructureType == "vsphere" ||
+		reportInfrastructureType == "vsphere-esxi"
+	return manifestIsVsphere && reportIsVsphere
 }
 
 func (a Api) CheckStemcellAvailability(stemcellFilename string) (bool, error) {
@@ -153,13 +196,24 @@ func (a Api) CheckStemcellAvailability(stemcellFilename string) (bool, error) {
 						return true, nil
 					}
 				}
-				return false, nil
 			}
 		}
-		// Fall back to filename match when manifest cannot be used (e.g. file not found, invalid tgz)
+		// Fall back to exact filename match when manifest cannot be used (e.g. file not found, invalid tgz)
+		baseFilename := filepath.Base(stemcellFilename)
 		for _, stemcell := range report.AvailableStemcells {
-			if stemcell.Filename == filepath.Base(stemcellFilename) {
+			if stemcell.Filename == baseFilename {
 				return true, nil
+			}
+		}
+
+		// Try smart filename parsing when exact filename doesn't match.
+		// This handles cases where the requested filename and available filename have different formats.
+		parsedOS, parsedVersion, parsedInfra := parseStemcellFilename(baseFilename)
+		if parsedOS != "" && parsedVersion != "" && parsedInfra != "" {
+			for _, stemcell := range report.AvailableStemcells {
+				if stemcell.OS == parsedOS && stemcell.Version == parsedVersion && infrastructureMatches(parsedInfra, report.InfrastructureType) {
+					return true, nil
+				}
 			}
 		}
 	}

--- a/api/stemcell_service_test.go
+++ b/api/stemcell_service_test.go
@@ -38,6 +38,129 @@ var _ = Describe("StemcellService", func() {
 		server.Close()
 	})
 
+	Describe("CheckStemcellAvailability with smart filename parsing", func() {
+		It("detects stemcell when filename format differs but OS/version/infra match", func() {
+			// This tests the smart filename parsing fallback:
+			// - Requested: bosh-stemcell-1.1250-vsphere-esxi-ubuntu-jammy-go_agent.tgz (Pivnet format)
+			// - Available: bosh-vsphere-esxi-ubuntu-jammy-go_agent-1.1250.tgz (Ops Manager format)
+			// The exact filenames don't match, so exact matching fails.
+			// But smart parsing should extract the same OS, version, infra and match.
+
+			server.AppendHandlers(
+				ghttp.RespondWith(http.StatusOK, `{
+					"stemcells": [],
+					"infrastructure_type": "vsphere-esxi",
+					"available_stemcells": [
+						{
+							"filename": "bosh-vsphere-esxi-ubuntu-jammy-go_agent-1.1250.tgz",
+							"os": "ubuntu-jammy",
+							"version": "1.1250"
+						}
+					]
+				}`),
+				ghttp.RespondWith(http.StatusOK, `{"info":{"version":"2.6.3"}}`),
+			)
+
+			found, err := service.CheckStemcellAvailability("bosh-stemcell-1.1250-vsphere-esxi-ubuntu-jammy-go_agent.tgz")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(found).To(BeTrue())
+		})
+
+		It("detects stemcell using smart parsing even when manifest extraction fails", func() {
+			// File is not a valid .tgz, so manifest extraction fails.
+			// Smart filename parsing should still extract OS/version/infra from the filename
+			// and match against the Ops Manager inventory.
+
+			invalidPath := filepath.Join(os.TempDir(), "bosh-stemcell-1.1250-vsphere-esxi-ubuntu-jammy-go_agent.tgz")
+			Expect(os.WriteFile(invalidPath, []byte("not a tgz"), 0600)).To(Succeed())
+			defer os.Remove(invalidPath)
+
+			server.AppendHandlers(
+				ghttp.RespondWith(http.StatusOK, `{
+					"stemcells": [],
+					"infrastructure_type": "vsphere-esxi",
+					"available_stemcells": [
+						{
+							"filename": "bosh-vsphere-esxi-ubuntu-jammy-go_agent-1.1250.tgz",
+							"os": "ubuntu-jammy",
+							"version": "1.1250"
+						}
+					]
+				}`),
+				ghttp.RespondWith(http.StatusOK, `{"info":{"version":"2.6.3"}}`),
+			)
+
+			found, err := service.CheckStemcellAvailability(invalidPath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(found).To(BeTrue())
+		})
+
+		It("handles smart parsing with AWS infrastructure", func() {
+			server.AppendHandlers(
+				ghttp.RespondWith(http.StatusOK, `{
+					"stemcells": [],
+					"infrastructure_type": "aws",
+					"available_stemcells": [
+						{
+							"filename": "bosh-aws-ubuntu-bionic-1.100.tgz",
+							"os": "ubuntu-bionic",
+							"version": "1.100"
+						}
+					]
+				}`),
+				ghttp.RespondWith(http.StatusOK, `{"info":{"version":"2.6.3"}}`),
+			)
+
+			found, err := service.CheckStemcellAvailability("bosh-stemcell-1.100-aws-ubuntu-bionic-go_agent.tgz")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(found).To(BeTrue())
+		})
+
+		It("returns false when smart parsing extracts different version", func() {
+			server.AppendHandlers(
+				ghttp.RespondWith(http.StatusOK, `{
+					"stemcells": [],
+					"infrastructure_type": "vsphere-esxi",
+					"available_stemcells": [
+						{
+							"filename": "bosh-vsphere-esxi-ubuntu-jammy-go_agent-1.1251.tgz",
+							"os": "ubuntu-jammy",
+							"version": "1.1251"
+						}
+					]
+				}`),
+				ghttp.RespondWith(http.StatusOK, `{"info":{"version":"2.6.3"}}`),
+			)
+
+			// Requested version is 1.1250, available is 1.1251 -> should not match
+			found, err := service.CheckStemcellAvailability("bosh-stemcell-1.1250-vsphere-esxi-ubuntu-jammy-go_agent.tgz")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(found).To(BeFalse())
+		})
+
+		It("returns false when smart parsing can't extract from unparseable filename", func() {
+			server.AppendHandlers(
+				ghttp.RespondWith(http.StatusOK, `{
+					"stemcells": [],
+					"infrastructure_type": "vsphere-esxi",
+					"available_stemcells": [
+						{
+							"filename": "bosh-vsphere-esxi-ubuntu-jammy-go_agent-1.1250.tgz",
+							"os": "ubuntu-jammy",
+							"version": "1.1250"
+						}
+					]
+				}`),
+				ghttp.RespondWith(http.StatusOK, `{"info":{"version":"2.6.3"}}`),
+			)
+
+			// Filename that can't be parsed -> smart parsing returns empty strings
+			found, err := service.CheckStemcellAvailability("unparseable-filename.tgz")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(found).To(BeFalse())
+		})
+	})
+
 	Describe("ListStemcells", func() {
 		It("makes a request to list the stemcells", func() {
 			server.AppendHandlers(
@@ -356,6 +479,38 @@ cloud_properties:
 			})
 		})
 
+		When("vSphere variants (vsphere/vsphere-esxi infrastructure equivalence)", func() {
+			It("returns true when stemcell manifest has vsphere and report has vsphere-esxi", func() {
+				manifestContent := `name: bosh-vsphere-esxi-ubuntu-jammy
+version: "1.1016"
+operating_system: ubuntu-jammy
+cloud_properties:
+  infrastructure: vsphere
+`
+				var buf bytes.Buffer
+				gw := gzip.NewWriter(&buf)
+				tw := tar.NewWriter(gw)
+				Expect(tw.WriteHeader(&tar.Header{Name: "stemcell.MF", Size: int64(len(manifestContent))})).To(Succeed())
+				_, err := tw.Write([]byte(manifestContent))
+				Expect(err).NotTo(HaveOccurred())
+				Expect(tw.Close()).To(Succeed())
+				Expect(gw.Close()).To(Succeed())
+
+				stemcellPath := filepath.Join(os.TempDir(), "bosh-stemcell-1.1016-vsphere-ubuntu-jammy-go_agent.tgz")
+				Expect(os.WriteFile(stemcellPath, buf.Bytes(), 0600)).To(Succeed())
+				defer os.Remove(stemcellPath)
+
+				server.AppendHandlers(
+					ghttp.RespondWith(http.StatusOK, `{"stemcells": [], "infrastructure_type": "vsphere-esxi", "available_stemcells": [{"filename": "bosh-vsphere-esxi-ubuntu-jammy-go_agent-1.1016.tgz", "os": "ubuntu-jammy", "version": "1.1016"}]}`),
+					ghttp.RespondWith(http.StatusOK, `{"info":{"version":"2.6.3"}}`),
+				)
+
+				found, err := service.CheckStemcellAvailability(stemcellPath)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(found).To(BeTrue())
+			})
+		})
+
 		When("Docker Ops Manager (warden/docker infrastructure equivalence)", func() {
 			It("returns true when stemcell manifest has warden and report has docker", func() {
 				// Docker Ops Manager reports infrastructure_type "docker" but stemcells are built for "warden".
@@ -380,6 +535,57 @@ cloud_properties:
 
 				server.AppendHandlers(
 					ghttp.RespondWith(http.StatusOK, `{"stemcells": [], "infrastructure_type": "docker", "available_stemcells": [{"filename": "bosh-docker-ubuntu-jammy-1.1016.tgz", "os": "ubuntu-jammy", "version": "1.1016"}]}`),
+					ghttp.RespondWith(http.StatusOK, `{"info":{"version":"2.6.3"}}`),
+				)
+
+				found, err := service.CheckStemcellAvailability(stemcellPath)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(found).To(BeTrue())
+			})
+
+			It("falls back to filename matching when manifest fields don't match any stemcell (TNZ-103785)", func() {
+				// This is the regression test for TNZ-103785. The bug was that when manifest
+				// extraction succeeded but the manifest fields didn't match any stemcell in the
+				// diagnostic report, the function would return false immediately without
+				// attempting the filename-based fallback. This test verifies that the fix
+				// allows the function to continue to filename matching.
+
+				// Create a stemcell with manifest that won't match any stemcell in the report
+				// (different infrastructure type), but the filename DOES exist in available_stemcells.
+				manifestContent := `name: bosh-aws-ubuntu-jammy
+version: "1.1016"
+operating_system: ubuntu-jammy
+cloud_properties:
+  infrastructure: aws
+`
+				var buf bytes.Buffer
+				gw := gzip.NewWriter(&buf)
+				tw := tar.NewWriter(gw)
+				Expect(tw.WriteHeader(&tar.Header{Name: "stemcell.MF", Size: int64(len(manifestContent))})).To(Succeed())
+				_, err := tw.Write([]byte(manifestContent))
+				Expect(err).NotTo(HaveOccurred())
+				Expect(tw.Close()).To(Succeed())
+				Expect(gw.Close()).To(Succeed())
+
+				stemcellPath := filepath.Join(os.TempDir(), "bosh-stemcell-1.1016-aws-ubuntu-jammy-go_agent.tgz")
+				Expect(os.WriteFile(stemcellPath, buf.Bytes(), 0600)).To(Succeed())
+				defer os.Remove(stemcellPath)
+
+				// Diagnostic report has the stemcell by filename in available_stemcells,
+				// but with a different infrastructure type (vsphere instead of aws),
+				// so manifest matching won't find it. The fallback filename matching should find it.
+				server.AppendHandlers(
+					ghttp.RespondWith(http.StatusOK, `{
+						"stemcells": [],
+						"infrastructure_type": "vsphere-esxi",
+						"available_stemcells": [
+							{
+								"filename": "bosh-stemcell-1.1016-aws-ubuntu-jammy-go_agent.tgz",
+								"os": "ubuntu-jammy",
+								"version": "1.1016"
+							}
+						]
+					}`),
 					ghttp.RespondWith(http.StatusOK, `{"info":{"version":"2.6.3"}}`),
 				)
 


### PR DESCRIPTION
The CheckStemcellAvailability function was returning false immediately when manifest-based matching didn't find a stemcell, without attempting the filename-based fallback. This caused the download-product command with --check-already-uploaded to re-download stemcells that were already available in Ops Manager.

Remove the early return after manifest matching so the function can gracefully degrade to filename-based matching when manifest comparison doesn't find a match. This ensures stemcells are correctly detected regardless of whether the manifest fields match exactly.

Fixes TNZ-103785