### PR TITLE
Bump Go toolchain to 1.26.5 to fix CVE-2026-39822

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/pivotal-cf/om
 
-go 1.26.4
+go 1.26.5
 
 require (
 	cloud.google.com/go/storage v1.64.0


### PR DESCRIPTION
Go's os.Root Open/OpenFile/etc. improperly followed symlinks to locations outside the Root when the final path component was a symlink and the path ended in "/". Fixed upstream in Go 1.26.5.

TASCVE-121466 / GO-2026-4970