### PR TITLE
Add unsafe-dependency bypass flags to om apply-changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,13 @@ can be found in [Pivotal Documentation](https://docs.pivotal.io/platform-automat
   This Ops Manager 3.3+ property controls the maximum number of product deployment tasks that run in parallel during Apply Changes.
   Set it under `properties-configuration.director_configuration.product_deploy_parallelism` in the director config YAML.
 
+- Add `--allow-unsafe-dependency-update` and `--allow-unsafe-dependency-deletion` flags to `apply-changes`.
+  These let a Platform Engineer bypass safety checks around deploying an optional dependency out of its declared
+  safe order, or deleting an optional dependency not marked as safe to delete. Both default to `false` and are
+  only sent to Ops Manager when set to `true`, preserving compatibility with older Ops Manager versions. If a
+  blocked `apply-changes` has a known bypass, the error message now also suggests the matching flag(s), based on
+  the `available_overrides` field Ops Manager returns.
+
 ## 7.10.1
 
 ### Bug fixes

--- a/api/installations_service.go
+++ b/api/installations_service.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 )
 
@@ -12,6 +13,43 @@ const (
 	StatusSucceeded = "succeeded"
 	StatusFailed    = "failed"
 )
+
+// overrideFlagHints maps the "available_overrides" parameter names Ops Manager
+// returns on a blocked apply-changes to the om CLI flag that sets them.
+var overrideFlagHints = map[string]string{
+	"ignore_warnings":                  "--ignore-warnings",
+	"allow_unsafe_dependency_update":   "--allow-unsafe-dependency-update",
+	"allow_unsafe_dependency_deletion": "--allow-unsafe-dependency-deletion",
+}
+
+// availableOverridesHint reads the "available_overrides" field from a blocked
+// installations response and, if present and non-empty, builds a hint telling
+// the user which flag(s) would let them retry past this specific failure.
+// httputil.DumpResponse (called by validateStatusOK before this) restores
+// resp.Body after reading it, so it can be decoded again here.
+func availableOverridesHint(resp *http.Response) string {
+	var body struct {
+		AvailableOverrides []string `json:"available_overrides"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return ""
+	}
+
+	if len(body.AvailableOverrides) == 0 {
+		return ""
+	}
+
+	hints := make([]string, 0, len(body.AvailableOverrides))
+	for _, override := range body.AvailableOverrides {
+		if flag, ok := overrideFlagHints[override]; ok {
+			hints = append(hints, flag)
+		} else {
+			hints = append(hints, override)
+		}
+	}
+
+	return "You can retry with the following flag(s) to bypass this: " + strings.Join(hints, ", ")
+}
 
 type InstallationsServiceOutput struct {
 	ID         int
@@ -74,7 +112,14 @@ func (a Api) ListInstallations() ([]InstallationsServiceOutput, error) {
 	return responseStruct.Installations, nil
 }
 
-func (a Api) CreateInstallation(ignoreWarnings bool, deployProducts bool, forceLatestVariables bool, productNames []string, errands ApplyErrandChanges) (InstallationsServiceOutput, error) {
+func (a Api) CreateInstallation(ignoreWarnings bool, deployProducts bool, forceLatestVariables bool, allowUnsafeDependencyUpdate bool, allowUnsafeDependencyDeletion bool, productNames []string, errands ApplyErrandChanges) (InstallationsServiceOutput, error) {
+	if allowUnsafeDependencyUpdate {
+		a.logger.Println("allow_unsafe_dependency_update=true: request to Ops Manager will bypass unsafe optional-dependency update checks")
+	}
+	if allowUnsafeDependencyDeletion {
+		a.logger.Println("allow_unsafe_dependency_deletion=true: request to Ops Manager will bypass unsafe optional-dependency deletion checks")
+	}
+
 	productGuidMapping, err := a.fetchProductGUID()
 	if err != nil {
 		return InstallationsServiceOutput{}, fmt.Errorf("failed to list staged and/or deployed products: %w", err)
@@ -110,15 +155,19 @@ func (a Api) CreateInstallation(ignoreWarnings bool, deployProducts bool, forceL
 	}
 
 	data, err := json.Marshal(&struct {
-		IgnoreWarnings       string                   `json:"ignore_warnings"`
-		ForceLatestVariables bool                     `json:"force_latest_variables"`
-		DeployProducts       interface{}              `json:"deploy_products"`
-		Errands              map[string]ProductErrand `json:"errands,omitempty"`
+		IgnoreWarnings                string                   `json:"ignore_warnings"`
+		ForceLatestVariables          bool                     `json:"force_latest_variables"`
+		AllowUnsafeDependencyUpdate   bool                     `json:"allow_unsafe_dependency_update,omitempty"`
+		AllowUnsafeDependencyDeletion bool                     `json:"allow_unsafe_dependency_deletion,omitempty"`
+		DeployProducts                interface{}              `json:"deploy_products"`
+		Errands                       map[string]ProductErrand `json:"errands,omitempty"`
 	}{
-		IgnoreWarnings:       fmt.Sprintf("%t", ignoreWarnings),
-		ForceLatestVariables: forceLatestVariables,
-		DeployProducts:       deployProductsVal,
-		Errands:              errandsPayload,
+		IgnoreWarnings:                fmt.Sprintf("%t", ignoreWarnings),
+		ForceLatestVariables:          forceLatestVariables,
+		AllowUnsafeDependencyUpdate:   allowUnsafeDependencyUpdate,
+		AllowUnsafeDependencyDeletion: allowUnsafeDependencyDeletion,
+		DeployProducts:                deployProductsVal,
+		Errands:                       errandsPayload,
 	})
 	if err != nil {
 		return InstallationsServiceOutput{}, err
@@ -133,6 +182,11 @@ func (a Api) CreateInstallation(ignoreWarnings bool, deployProducts bool, forceL
 	if err = validateStatusOK(resp); err != nil {
 		if resp.StatusCode == http.StatusUnprocessableEntity {
 			err = fmt.Errorf("%s\n%s", err.Error(), "Tip: In Ops Manager 2.6 or newer, you can use `om pre-deploy-check` to get a complete list of failed verifiers and om commands to disable them.")
+
+			if hint := availableOverridesHint(resp); hint != "" {
+				a.logger.Println(hint)
+				err = fmt.Errorf("%s\n%s", err.Error(), hint)
+			}
 		}
 
 		return InstallationsServiceOutput{}, err

--- a/api/installations_service_test.go
+++ b/api/installations_service_test.go
@@ -115,7 +115,7 @@ var _ = Describe("InstallationsService", func() {
 					),
 				)
 
-				output, err := service.CreateInstallation(false, true, false, nil, api.ApplyErrandChanges{})
+				output, err := service.CreateInstallation(false, true, false, false, false, nil, api.ApplyErrandChanges{})
 
 				Expect(err).ToNot(HaveOccurred())
 				Expect(output.ID).To(Equal(1))
@@ -140,7 +140,7 @@ var _ = Describe("InstallationsService", func() {
 					),
 				)
 
-				output, err := service.CreateInstallation(false, false, false, nil, api.ApplyErrandChanges{})
+				output, err := service.CreateInstallation(false, false, false, false, false, nil, api.ApplyErrandChanges{})
 
 				Expect(err).ToNot(HaveOccurred())
 				Expect(output.ID).To(Equal(1))
@@ -165,7 +165,7 @@ var _ = Describe("InstallationsService", func() {
 					),
 				)
 
-				output, err := service.CreateInstallation(false, true, false, []string{"product2"}, api.ApplyErrandChanges{})
+				output, err := service.CreateInstallation(false, true, false, false, false, []string{"product2"}, api.ApplyErrandChanges{})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(output.ID).To(Equal(1))
 			})
@@ -189,7 +189,101 @@ var _ = Describe("InstallationsService", func() {
 					),
 				)
 
-				output, err := service.CreateInstallation(false, true, true, []string{"product2"}, api.ApplyErrandChanges{})
+				output, err := service.CreateInstallation(false, true, true, false, false, []string{"product2"}, api.ApplyErrandChanges{})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(output.ID).To(Equal(1))
+			})
+		})
+
+		When("allowing unsafe dependency update", func() {
+			It("includes allow_unsafe_dependency_update in the request when true", func() {
+				client.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("GET", "/api/v0/staged/products"),
+						ghttp.RespondWith(http.StatusOK, `[{"guid": "guid1", "type": "product1"}, {"guid": "guid2", "type": "product2"}]`),
+					),
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("GET", "/api/v0/deployed/products"),
+						ghttp.RespondWith(http.StatusOK, `[{"guid": "guid1", "type": "product1"}, {"guid": "guid2", "type": "product2"}]`),
+					),
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("POST", "/api/v0/installations"),
+						ghttp.VerifyJSON(`{"ignore_warnings":"false","force_latest_variables":false,"deploy_products":"all","allow_unsafe_dependency_update":true}`),
+						ghttp.RespondWith(http.StatusOK, `{"install": {"id":1}}`),
+					),
+				)
+
+				output, err := service.CreateInstallation(false, true, false, true, false, nil, api.ApplyErrandChanges{})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(output.ID).To(Equal(1))
+				Expect(stdout).To(gbytes.Say("allow_unsafe_dependency_update=true: request to Ops Manager will bypass unsafe optional-dependency update checks"))
+			})
+
+			It("omits allow_unsafe_dependency_update from the request when false", func() {
+				client.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("GET", "/api/v0/staged/products"),
+						ghttp.RespondWith(http.StatusOK, `[{"guid": "guid1", "type": "product1"}, {"guid": "guid2", "type": "product2"}]`),
+					),
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("GET", "/api/v0/deployed/products"),
+						ghttp.RespondWith(http.StatusOK, `[{"guid": "guid1", "type": "product1"}, {"guid": "guid2", "type": "product2"}]`),
+					),
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("POST", "/api/v0/installations"),
+						ghttp.VerifyJSON(`{"ignore_warnings":"false","force_latest_variables":false,"deploy_products":"all"}`),
+						ghttp.RespondWith(http.StatusOK, `{"install": {"id":1}}`),
+					),
+				)
+
+				output, err := service.CreateInstallation(false, true, false, false, false, nil, api.ApplyErrandChanges{})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(output.ID).To(Equal(1))
+			})
+		})
+
+		When("allowing unsafe dependency deletion", func() {
+			It("includes allow_unsafe_dependency_deletion in the request when true", func() {
+				client.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("GET", "/api/v0/staged/products"),
+						ghttp.RespondWith(http.StatusOK, `[{"guid": "guid1", "type": "product1"}, {"guid": "guid2", "type": "product2"}]`),
+					),
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("GET", "/api/v0/deployed/products"),
+						ghttp.RespondWith(http.StatusOK, `[{"guid": "guid1", "type": "product1"}, {"guid": "guid2", "type": "product2"}]`),
+					),
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("POST", "/api/v0/installations"),
+						ghttp.VerifyJSON(`{"ignore_warnings":"false","force_latest_variables":false,"deploy_products":"all","allow_unsafe_dependency_deletion":true}`),
+						ghttp.RespondWith(http.StatusOK, `{"install": {"id":1}}`),
+					),
+				)
+
+				output, err := service.CreateInstallation(false, true, false, false, true, nil, api.ApplyErrandChanges{})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(output.ID).To(Equal(1))
+				Expect(stdout).To(gbytes.Say("allow_unsafe_dependency_deletion=true: request to Ops Manager will bypass unsafe optional-dependency deletion checks"))
+			})
+
+			It("omits allow_unsafe_dependency_deletion from the request when false", func() {
+				client.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("GET", "/api/v0/staged/products"),
+						ghttp.RespondWith(http.StatusOK, `[{"guid": "guid1", "type": "product1"}, {"guid": "guid2", "type": "product2"}]`),
+					),
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("GET", "/api/v0/deployed/products"),
+						ghttp.RespondWith(http.StatusOK, `[{"guid": "guid1", "type": "product1"}, {"guid": "guid2", "type": "product2"}]`),
+					),
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("POST", "/api/v0/installations"),
+						ghttp.VerifyJSON(`{"ignore_warnings":"false","force_latest_variables":false,"deploy_products":"all"}`),
+						ghttp.RespondWith(http.StatusOK, `{"install": {"id":1}}`),
+					),
+				)
+
+				output, err := service.CreateInstallation(false, true, false, false, false, nil, api.ApplyErrandChanges{})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(output.ID).To(Equal(1))
 			})
@@ -214,7 +308,7 @@ var _ = Describe("InstallationsService", func() {
 						),
 					)
 
-					output, err := service.CreateInstallation(false, true, false, []string{"product1"}, api.ApplyErrandChanges{
+					output, err := service.CreateInstallation(false, true, false, false, false, []string{"product1"}, api.ApplyErrandChanges{
 						Errands: map[string]api.ProductErrand{
 							"product1": {
 								RunPostDeploy: map[string]interface{}{
@@ -244,7 +338,7 @@ var _ = Describe("InstallationsService", func() {
 						),
 					)
 
-					_, err := service.CreateInstallation(false, true, false, []string{"product2"}, api.ApplyErrandChanges{
+					_, err := service.CreateInstallation(false, true, false, false, false, []string{"product2"}, api.ApplyErrandChanges{
 						Errands: map[string]api.ProductErrand{
 							"product3": {
 								RunPostDeploy: map[string]interface{}{
@@ -276,7 +370,7 @@ var _ = Describe("InstallationsService", func() {
 						),
 					)
 
-					output, err := service.CreateInstallation(false, true, false, []string{}, api.ApplyErrandChanges{
+					output, err := service.CreateInstallation(false, true, false, false, false, []string{}, api.ApplyErrandChanges{
 						Errands: map[string]api.ProductErrand{
 							"product1": {
 								RunPostDeploy: map[string]interface{}{
@@ -306,7 +400,7 @@ var _ = Describe("InstallationsService", func() {
 						),
 					)
 
-					_, err := service.CreateInstallation(false, true, false, []string{}, api.ApplyErrandChanges{
+					_, err := service.CreateInstallation(false, true, false, false, false, []string{}, api.ApplyErrandChanges{
 						Errands: map[string]api.ProductErrand{
 							"product1": {
 								RunPostDeploy: map[string]interface{}{
@@ -340,7 +434,7 @@ var _ = Describe("InstallationsService", func() {
 					),
 				)
 
-				_, err := service.CreateInstallation(false, true, false, nil, api.ApplyErrandChanges{})
+				_, err := service.CreateInstallation(false, true, false, false, false, nil, api.ApplyErrandChanges{})
 				Expect(err).To(MatchError(ContainSubstring("could not make api request to installations endpoint: could not send api request to POST /api/v0/installations")))
 			})
 		})
@@ -375,9 +469,84 @@ var _ = Describe("InstallationsService", func() {
 					),
 				)
 
-				_, err := service.CreateInstallation(false, true, false, []string{"product2"}, api.ApplyErrandChanges{})
+				_, err := service.CreateInstallation(false, true, false, false, false, []string{"product2"}, api.ApplyErrandChanges{})
 				Expect(err).To(MatchError(ContainSubstring("request failed: unexpected response")))
 				Expect(err).To(MatchError(ContainSubstring("Tip: In Ops Manager 2.6 or newer, you can use `om pre-deploy-check` to get a complete list of failed verifiers and om commands to disable them.")))
+			})
+
+			When("the response includes available_overrides", func() {
+				It("suggests the matching CLI flag(s) for known override values", func() {
+					client.AppendHandlers(
+						ghttp.CombineHandlers(
+							ghttp.VerifyRequest("GET", "/api/v0/staged/products"),
+							ghttp.RespondWith(http.StatusOK, `[{"guid": "guid1", "type": "product1"}, {"guid": "guid2", "type": "product2"}]`),
+						),
+						ghttp.CombineHandlers(
+							ghttp.VerifyRequest("GET", "/api/v0/deployed/products"),
+							ghttp.RespondWith(http.StatusOK, `[{"guid": "guid1", "type": "product1"}, {"guid": "guid2", "type": "product2"}]`),
+						),
+						ghttp.CombineHandlers(
+							ghttp.VerifyRequest("POST", "/api/v0/installations"),
+							ghttp.RespondWith(http.StatusUnprocessableEntity, `{
+								"errors": ["optional dependency has unsafe property changes"],
+								"available_overrides": ["allow_unsafe_dependency_update", "allow_unsafe_dependency_deletion"]
+							}`),
+						),
+					)
+
+					_, err := service.CreateInstallation(false, true, false, false, false, nil, api.ApplyErrandChanges{})
+					Expect(err).To(MatchError(ContainSubstring("request failed: unexpected response")))
+					Expect(err).To(MatchError(ContainSubstring("You can retry with the following flag(s) to bypass this: --allow-unsafe-dependency-update, --allow-unsafe-dependency-deletion")))
+					Expect(stdout).To(gbytes.Say("You can retry with the following flag\\(s\\) to bypass this: --allow-unsafe-dependency-update, --allow-unsafe-dependency-deletion"))
+				})
+
+				It("falls back to the raw parameter name for an unrecognized override value", func() {
+					client.AppendHandlers(
+						ghttp.CombineHandlers(
+							ghttp.VerifyRequest("GET", "/api/v0/staged/products"),
+							ghttp.RespondWith(http.StatusOK, `[{"guid": "guid1", "type": "product1"}, {"guid": "guid2", "type": "product2"}]`),
+						),
+						ghttp.CombineHandlers(
+							ghttp.VerifyRequest("GET", "/api/v0/deployed/products"),
+							ghttp.RespondWith(http.StatusOK, `[{"guid": "guid1", "type": "product1"}, {"guid": "guid2", "type": "product2"}]`),
+						),
+						ghttp.CombineHandlers(
+							ghttp.VerifyRequest("POST", "/api/v0/installations"),
+							ghttp.RespondWith(http.StatusUnprocessableEntity, `{
+								"errors": ["something new blocked this"],
+								"available_overrides": ["some_future_override"]
+							}`),
+						),
+					)
+
+					_, err := service.CreateInstallation(false, true, false, false, false, nil, api.ApplyErrandChanges{})
+					Expect(err).To(MatchError(ContainSubstring("You can retry with the following flag(s) to bypass this: some_future_override")))
+				})
+
+				It("does not append an override hint when available_overrides is empty", func() {
+					client.AppendHandlers(
+						ghttp.CombineHandlers(
+							ghttp.VerifyRequest("GET", "/api/v0/staged/products"),
+							ghttp.RespondWith(http.StatusOK, `[{"guid": "guid1", "type": "product1"}, {"guid": "guid2", "type": "product2"}]`),
+						),
+						ghttp.CombineHandlers(
+							ghttp.VerifyRequest("GET", "/api/v0/deployed/products"),
+							ghttp.RespondWith(http.StatusOK, `[{"guid": "guid1", "type": "product1"}, {"guid": "guid2", "type": "product2"}]`),
+						),
+						ghttp.CombineHandlers(
+							ghttp.VerifyRequest("POST", "/api/v0/installations"),
+							ghttp.RespondWith(http.StatusUnprocessableEntity, `{
+								"errors": ["some other unrelated blocking error"],
+								"available_overrides": []
+							}`),
+						),
+					)
+
+					_, err := service.CreateInstallation(false, true, false, false, false, nil, api.ApplyErrandChanges{})
+					Expect(err).To(MatchError(ContainSubstring("request failed: unexpected response")))
+					Expect(err).ToNot(MatchError(ContainSubstring("You can retry with the following flag(s)")))
+					Expect(err).To(MatchError(ContainSubstring("Tip: In Ops Manager 2.6 or newer")))
+				})
 			})
 		})
 
@@ -390,7 +559,7 @@ var _ = Describe("InstallationsService", func() {
 					),
 				)
 
-				_, err := service.CreateInstallation(false, true, false, nil, api.ApplyErrandChanges{})
+				_, err := service.CreateInstallation(false, true, false, false, false, nil, api.ApplyErrandChanges{})
 				Expect(err).To(MatchError(ContainSubstring("request failed: unexpected response")))
 			})
 		})
@@ -412,7 +581,7 @@ var _ = Describe("InstallationsService", func() {
 					),
 				)
 
-				_, err := service.CreateInstallation(false, true, false, nil, api.ApplyErrandChanges{})
+				_, err := service.CreateInstallation(false, true, false, false, false, nil, api.ApplyErrandChanges{})
 				Expect(err).To(MatchError(ContainSubstring("failed to decode response: invalid character")))
 			})
 		})

--- a/api/installations_service_test.go
+++ b/api/installations_service_test.go
@@ -239,6 +239,7 @@ var _ = Describe("InstallationsService", func() {
 				output, err := service.CreateInstallation(false, true, false, false, false, nil, api.ApplyErrandChanges{})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(output.ID).To(Equal(1))
+				Expect(stdout).ToNot(gbytes.Say("allow_unsafe_dependency_update=true"))
 			})
 		})
 
@@ -286,6 +287,7 @@ var _ = Describe("InstallationsService", func() {
 				output, err := service.CreateInstallation(false, true, false, false, false, nil, api.ApplyErrandChanges{})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(output.ID).To(Equal(1))
+				Expect(stdout).ToNot(gbytes.Say("allow_unsafe_dependency_deletion=true"))
 			})
 		})
 

--- a/api/installations_service_test.go
+++ b/api/installations_service_test.go
@@ -289,6 +289,32 @@ var _ = Describe("InstallationsService", func() {
 			})
 		})
 
+		When("allowing both unsafe dependency update and deletion", func() {
+			It("includes both allow_unsafe_dependency_update and allow_unsafe_dependency_deletion in the request", func() {
+				client.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("GET", "/api/v0/staged/products"),
+						ghttp.RespondWith(http.StatusOK, `[{"guid": "guid1", "type": "product1"}, {"guid": "guid2", "type": "product2"}]`),
+					),
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("GET", "/api/v0/deployed/products"),
+						ghttp.RespondWith(http.StatusOK, `[{"guid": "guid1", "type": "product1"}, {"guid": "guid2", "type": "product2"}]`),
+					),
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("POST", "/api/v0/installations"),
+						ghttp.VerifyJSON(`{"ignore_warnings":"false","force_latest_variables":false,"deploy_products":"all","allow_unsafe_dependency_update":true,"allow_unsafe_dependency_deletion":true}`),
+						ghttp.RespondWith(http.StatusOK, `{"install": {"id":1}}`),
+					),
+				)
+
+				output, err := service.CreateInstallation(false, true, false, true, true, nil, api.ApplyErrandChanges{})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(output.ID).To(Equal(1))
+				Expect(stdout).To(gbytes.Say("allow_unsafe_dependency_update=true: request to Ops Manager will bypass unsafe optional-dependency update checks"))
+				Expect(stdout).To(gbytes.Say("allow_unsafe_dependency_deletion=true: request to Ops Manager will bypass unsafe optional-dependency deletion checks"))
+			})
+		})
+
 		When("given the errands", func() {
 			When("product names are passed", func() {
 				It("sends the errands as a json parameter", func() {
@@ -521,6 +547,31 @@ var _ = Describe("InstallationsService", func() {
 
 					_, err := service.CreateInstallation(false, true, false, false, false, nil, api.ApplyErrandChanges{})
 					Expect(err).To(MatchError(ContainSubstring("You can retry with the following flag(s) to bypass this: some_future_override")))
+					Expect(stdout).To(gbytes.Say("You can retry with the following flag\\(s\\) to bypass this: some_future_override"))
+				})
+
+				It("suggests --ignore-warnings when available_overrides includes ignore_warnings", func() {
+					client.AppendHandlers(
+						ghttp.CombineHandlers(
+							ghttp.VerifyRequest("GET", "/api/v0/staged/products"),
+							ghttp.RespondWith(http.StatusOK, `[{"guid": "guid1", "type": "product1"}, {"guid": "guid2", "type": "product2"}]`),
+						),
+						ghttp.CombineHandlers(
+							ghttp.VerifyRequest("GET", "/api/v0/deployed/products"),
+							ghttp.RespondWith(http.StatusOK, `[{"guid": "guid1", "type": "product1"}, {"guid": "guid2", "type": "product2"}]`),
+						),
+						ghttp.CombineHandlers(
+							ghttp.VerifyRequest("POST", "/api/v0/installations"),
+							ghttp.RespondWith(http.StatusUnprocessableEntity, `{
+								"errors": ["some ignorable verifier warning blocked this"],
+								"available_overrides": ["ignore_warnings"]
+							}`),
+						),
+					)
+
+					_, err := service.CreateInstallation(false, true, false, false, false, nil, api.ApplyErrandChanges{})
+					Expect(err).To(MatchError(ContainSubstring("You can retry with the following flag(s) to bypass this: --ignore-warnings")))
+					Expect(stdout).To(gbytes.Say("You can retry with the following flag\\(s\\) to bypass this: --ignore-warnings"))
 				})
 
 				It("does not append an override hint when available_overrides is empty", func() {
@@ -546,6 +597,30 @@ var _ = Describe("InstallationsService", func() {
 					Expect(err).To(MatchError(ContainSubstring("request failed: unexpected response")))
 					Expect(err).ToNot(MatchError(ContainSubstring("You can retry with the following flag(s)")))
 					Expect(err).To(MatchError(ContainSubstring("Tip: In Ops Manager 2.6 or newer")))
+					Expect(stdout).ToNot(gbytes.Say("You can retry with the following flag"))
+				})
+
+				It("does not append an override hint when the response body cannot be decoded as JSON", func() {
+					client.AppendHandlers(
+						ghttp.CombineHandlers(
+							ghttp.VerifyRequest("GET", "/api/v0/staged/products"),
+							ghttp.RespondWith(http.StatusOK, `[{"guid": "guid1", "type": "product1"}, {"guid": "guid2", "type": "product2"}]`),
+						),
+						ghttp.CombineHandlers(
+							ghttp.VerifyRequest("GET", "/api/v0/deployed/products"),
+							ghttp.RespondWith(http.StatusOK, `[{"guid": "guid1", "type": "product1"}, {"guid": "guid2", "type": "product2"}]`),
+						),
+						ghttp.CombineHandlers(
+							ghttp.VerifyRequest("POST", "/api/v0/installations"),
+							ghttp.RespondWith(http.StatusUnprocessableEntity, `not-valid-json`),
+						),
+					)
+
+					_, err := service.CreateInstallation(false, true, false, false, false, nil, api.ApplyErrandChanges{})
+					Expect(err).To(MatchError(ContainSubstring("request failed: unexpected response")))
+					Expect(err).ToNot(MatchError(ContainSubstring("You can retry with the following flag(s)")))
+					Expect(err).To(MatchError(ContainSubstring("Tip: In Ops Manager 2.6 or newer")))
+					Expect(stdout).ToNot(gbytes.Say("You can retry with the following flag"))
 				})
 			})
 		})

--- a/commands/apply_changes.go
+++ b/commands/apply_changes.go
@@ -92,6 +92,16 @@ func (ac ApplyChanges) Execute(args []string) error {
 		changedProducts = ac.Options.ProductNames
 	}
 
+	if ac.Options.AllowUnsafeDependencyUpdate || ac.Options.AllowUnsafeDependencyDeletion {
+		info, err := ac.service.Info()
+		if err != nil {
+			return fmt.Errorf("could not retrieve info from targetted ops manager: %v", err)
+		}
+		if ok, err := info.VersionAtLeast(11, 0); !ok {
+			return fmt.Errorf("--allow-unsafe-dependency-update and --allow-unsafe-dependency-deletion are only available with Ops Manager 11.0 or later: you are running %s. Error: %w", info.Version, err)
+		}
+	}
+
 	installation, err := ac.service.RunningInstallation()
 	if err != nil {
 		return fmt.Errorf("could not check for any already running installation: %s", err)

--- a/commands/apply_changes.go
+++ b/commands/apply_changes.go
@@ -98,7 +98,10 @@ func (ac ApplyChanges) Execute(args []string) error {
 			return fmt.Errorf("could not retrieve info from targetted ops manager: %v", err)
 		}
 		if ok, err := info.VersionAtLeast(11, 0); !ok {
-			return fmt.Errorf("--allow-unsafe-dependency-update and --allow-unsafe-dependency-deletion are only available with Ops Manager 11.0 or later: you are running %s. Error: %w", info.Version, err)
+			if err != nil {
+				return fmt.Errorf("Could not determine Ops Manager version to accept flags --allow-unsafe-dependency-update / --allow-unsafe-dependency-deletion: %w", err)
+			}
+			return fmt.Errorf("--allow-unsafe-dependency-update and --allow-unsafe-dependency-deletion are only available with Ops Manager 11.0 or later: you are running %s", info.Version)
 		}
 	}
 

--- a/commands/apply_changes.go
+++ b/commands/apply_changes.go
@@ -20,19 +20,21 @@ type ApplyChanges struct {
 	logWriter      logWriter
 	waitDuration   time.Duration
 	Options        struct {
-		Config               string   `short:"c"   long:"config"               description:"path to yml file containing errand configuration (see docs/apply-changes/README.md for format)"`
-		IgnoreWarnings       bool     `short:"i"   long:"ignore-warnings"      description:"For convenience. Use other commands to disable particular verifiers if they are inappropriate."`
-		Reattach             bool     `long:"reattach" description:"reattach to an already running apply changes (if available)"`
-		RecreateVMs          bool     `long:"recreate-vms" description:"recreate all vms"`
-		SkipDeployProducts   bool     `short:"s" long:"skip-deploy-products" description:"skip deploying products when applying changes - just update the director"`
-		ForceLatestVariables bool     `long:"force-latest-variables" description:"force any certificates or other BOSH variables to use their latest version even when a stemcell is not being upgraded"`
-		ProductNames         []string `short:"n"   long:"product-name"         description:"name of the product(s) to deploy, cannot be used in conjunction with --skip-deploy-products (OM 2.2+)"`
+		Config                        string   `short:"c"   long:"config"               description:"path to yml file containing errand configuration (see docs/apply-changes/README.md for format)"`
+		IgnoreWarnings                bool     `short:"i"   long:"ignore-warnings"      description:"For convenience. Use other commands to disable particular verifiers if they are inappropriate."`
+		Reattach                      bool     `long:"reattach" description:"reattach to an already running apply changes (if available)"`
+		RecreateVMs                   bool     `long:"recreate-vms" description:"recreate all vms"`
+		SkipDeployProducts            bool     `short:"s" long:"skip-deploy-products" description:"skip deploying products when applying changes - just update the director"`
+		ForceLatestVariables          bool     `long:"force-latest-variables" description:"force any certificates or other BOSH variables to use their latest version even when a stemcell is not being upgraded"`
+		AllowUnsafeDependencyUpdate   bool     `long:"allow-unsafe-dependency-update" description:"allow apply-changes to proceed even when it would update a dependency out of its declared safe order"`
+		AllowUnsafeDependencyDeletion bool     `long:"allow-unsafe-dependency-deletion" description:"allow apply-changes to proceed even when it would delete an optional dependency not marked as safe to delete"`
+		ProductNames                  []string `short:"n"   long:"product-name"         description:"name of the product(s) to deploy, cannot be used in conjunction with --skip-deploy-products (OM 2.2+)"`
 	}
 }
 
 //counterfeiter:generate -o ./fakes/apply_changes_service.go --fake-name ApplyChangesService . applyChangesService
 type applyChangesService interface {
-	CreateInstallation(bool, bool, bool, []string, api.ApplyErrandChanges) (api.InstallationsServiceOutput, error)
+	CreateInstallation(bool, bool, bool, bool, bool, []string, api.ApplyErrandChanges) (api.InstallationsServiceOutput, error)
 	GetInstallation(id int) (api.InstallationsServiceOutput, error)
 	GetInstallationLogs(id int) (api.InstallationsServiceOutput, error)
 	Info() (api.Info, error)
@@ -158,8 +160,15 @@ func (ac ApplyChanges) Execute(args []string) error {
 		}
 	}
 
+	if ac.Options.AllowUnsafeDependencyUpdate {
+		ac.logger.Printf("allow-unsafe-dependency-update is set: unsafe optional-dependency update checks will be bypassed")
+	}
+	if ac.Options.AllowUnsafeDependencyDeletion {
+		ac.logger.Printf("allow-unsafe-dependency-deletion is set: unsafe optional-dependency deletion checks will be bypassed")
+	}
+
 	ac.logger.Printf("attempting to apply changes to the targeted Ops Manager")
-	installation, err = ac.service.CreateInstallation(ac.Options.IgnoreWarnings, !ac.Options.SkipDeployProducts, ac.Options.ForceLatestVariables, changedProducts, errands)
+	installation, err = ac.service.CreateInstallation(ac.Options.IgnoreWarnings, !ac.Options.SkipDeployProducts, ac.Options.ForceLatestVariables, ac.Options.AllowUnsafeDependencyUpdate, ac.Options.AllowUnsafeDependencyDeletion, changedProducts, errands)
 	if err != nil {
 		return fmt.Errorf("installation failed to trigger: %s", err)
 	}

--- a/commands/apply_changes.go
+++ b/commands/apply_changes.go
@@ -99,7 +99,7 @@ func (ac ApplyChanges) Execute(args []string) error {
 		}
 		if ok, err := info.VersionAtLeast(11, 0); !ok {
 			if err != nil {
-				return fmt.Errorf("Could not determine Ops Manager version to accept flags --allow-unsafe-dependency-update / --allow-unsafe-dependency-deletion: %w", err)
+				return fmt.Errorf("could not determine Ops Manager version to accept flags --allow-unsafe-dependency-update / --allow-unsafe-dependency-deletion: %w", err)
 			}
 			return fmt.Errorf("--allow-unsafe-dependency-update and --allow-unsafe-dependency-deletion are only available with Ops Manager 11.0 or later: you are running %s", info.Version)
 		}

--- a/commands/apply_changes_test.go
+++ b/commands/apply_changes_test.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/onsi/gomega/gbytes"
@@ -140,7 +141,7 @@ var _ = Describe("ApplyChanges", func() {
 
 		When("passed the allow-unsafe-dependency-update flag", func() {
 			It("applies changes while allowing unsafe dependency updates", func() {
-				service.InfoReturns(api.Info{Version: "2.3-build43"}, nil)
+				service.InfoReturns(api.Info{Version: "11.0"}, nil)
 
 				command := commands.NewApplyChanges(service, pendingService, writer, logger, 1)
 
@@ -156,7 +157,7 @@ var _ = Describe("ApplyChanges", func() {
 
 		When("passed the allow-unsafe-dependency-deletion flag", func() {
 			It("applies changes while allowing unsafe dependency deletions", func() {
-				service.InfoReturns(api.Info{Version: "2.3-build43"}, nil)
+				service.InfoReturns(api.Info{Version: "11.0"}, nil)
 
 				command := commands.NewApplyChanges(service, pendingService, writer, logger, 1)
 
@@ -172,7 +173,7 @@ var _ = Describe("ApplyChanges", func() {
 
 		When("passed both the allow-unsafe-dependency-update and allow-unsafe-dependency-deletion flags", func() {
 			It("applies changes while allowing both unsafe dependency updates and deletions", func() {
-				service.InfoReturns(api.Info{Version: "2.3-build43"}, nil)
+				service.InfoReturns(api.Info{Version: "11.0"}, nil)
 
 				command := commands.NewApplyChanges(service, pendingService, writer, logger, 1)
 
@@ -185,6 +186,56 @@ var _ = Describe("ApplyChanges", func() {
 
 				Expect(stderr).To(gbytes.Say("allow-unsafe-dependency-update is set: unsafe optional-dependency update checks will be bypassed"))
 				Expect(stderr).To(gbytes.Say("allow-unsafe-dependency-deletion is set: unsafe optional-dependency deletion checks will be bypassed"))
+			})
+		})
+
+		When("passed the allow-unsafe-dependency-update flag against an Ops Manager older than 11.0", func() {
+			It("errors instead of claiming the check will be bypassed", func() {
+				service.InfoReturns(api.Info{Version: "10.2-build1"}, nil)
+
+				command := commands.NewApplyChanges(service, pendingService, writer, logger, 1)
+
+				err := executeCommand(command, []string{"--allow-unsafe-dependency-update"})
+				Expect(err).To(MatchError(ContainSubstring("--allow-unsafe-dependency-update and --allow-unsafe-dependency-deletion are only available with Ops Manager 11.0 or later: you are running 10.2-build1")))
+
+				Expect(service.CreateInstallationCallCount()).To(Equal(0))
+				Expect(stderr).ToNot(gbytes.Say("checks will be bypassed"))
+			})
+		})
+
+		When("passed the allow-unsafe-dependency-deletion flag against an Ops Manager older than 11.0", func() {
+			It("errors instead of claiming the check will be bypassed", func() {
+				service.InfoReturns(api.Info{Version: "10.2-build1"}, nil)
+
+				command := commands.NewApplyChanges(service, pendingService, writer, logger, 1)
+
+				err := executeCommand(command, []string{"--allow-unsafe-dependency-deletion"})
+				Expect(err).To(MatchError(ContainSubstring("--allow-unsafe-dependency-update and --allow-unsafe-dependency-deletion are only available with Ops Manager 11.0 or later: you are running 10.2-build1")))
+
+				Expect(service.CreateInstallationCallCount()).To(Equal(0))
+				Expect(stderr).ToNot(gbytes.Say("checks will be bypassed"))
+			})
+		})
+
+		When("passed both the allow-unsafe-dependency-update and allow-unsafe-dependency-deletion flags against an Ops Manager older than 11.0", func() {
+			It("errors exactly once with a single, non-redundant message covering both flags", func() {
+				service.InfoReturns(api.Info{Version: "10.2-build1"}, nil)
+
+				command := commands.NewApplyChanges(service, pendingService, writer, logger, 1)
+
+				err := executeCommand(command, []string{"--allow-unsafe-dependency-update", "--allow-unsafe-dependency-deletion"})
+				Expect(err).To(HaveOccurred())
+
+				// A single combined message naming both flags, not two concatenated
+				// per-flag errors: exactly one "only available with Ops Manager"
+				// substring, and no duplicated "you are running" clause.
+				message := err.Error()
+				Expect(strings.Count(message, "only available with Ops Manager")).To(Equal(1))
+				Expect(strings.Count(message, "you are running")).To(Equal(1))
+				Expect(message).To(ContainSubstring("--allow-unsafe-dependency-update and --allow-unsafe-dependency-deletion are only available with Ops Manager 11.0 or later: you are running 10.2-build1"))
+
+				Expect(service.CreateInstallationCallCount()).To(Equal(0))
+				Expect(stderr).ToNot(gbytes.Say("checks will be bypassed"))
 			})
 		})
 

--- a/commands/apply_changes_test.go
+++ b/commands/apply_changes_test.go
@@ -195,7 +195,7 @@ var _ = Describe("ApplyChanges", func() {
 				err := executeCommand(command, []string{"--skip-deploy-products"})
 				Expect(err).ToNot(HaveOccurred())
 
-				_, _, deployProducts, _, _, _, _ := service.CreateInstallationArgsForCall(0)
+				_, deployProducts, _, _, _, _, _ := service.CreateInstallationArgsForCall(0)
 				Expect(deployProducts).To(Equal(false))
 			})
 

--- a/commands/apply_changes_test.go
+++ b/commands/apply_changes_test.go
@@ -252,7 +252,7 @@ var _ = Describe("ApplyChanges", func() {
 				command := commands.NewApplyChanges(service, pendingService, writer, logger, 1)
 
 				err := executeCommand(command, []string{"--allow-unsafe-dependency-update"})
-				Expect(err).To(MatchError(ContainSubstring("Could not determine Ops Manager version to accept flags --allow-unsafe-dependency-update / --allow-unsafe-dependency-deletion")))
+				Expect(err).To(MatchError(ContainSubstring("could not determine Ops Manager version to accept flags --allow-unsafe-dependency-update / --allow-unsafe-dependency-deletion")))
 				Expect(err).To(MatchError(ContainSubstring("invalid version: 'not-a-version'")))
 				Expect(err).ToNot(MatchError(ContainSubstring("are only available with Ops Manager 11.0 or later")))
 
@@ -268,7 +268,7 @@ var _ = Describe("ApplyChanges", func() {
 				command := commands.NewApplyChanges(service, pendingService, writer, logger, 1)
 
 				err := executeCommand(command, []string{"--allow-unsafe-dependency-deletion"})
-				Expect(err).To(MatchError(ContainSubstring("Could not determine Ops Manager version to accept flags --allow-unsafe-dependency-update / --allow-unsafe-dependency-deletion")))
+				Expect(err).To(MatchError(ContainSubstring("could not determine Ops Manager version to accept flags --allow-unsafe-dependency-update / --allow-unsafe-dependency-deletion")))
 				Expect(err).To(MatchError(ContainSubstring("invalid version: 'not-a-version'")))
 				Expect(err).ToNot(MatchError(ContainSubstring("are only available with Ops Manager 11.0 or later")))
 
@@ -287,9 +287,9 @@ var _ = Describe("ApplyChanges", func() {
 				Expect(err).To(HaveOccurred())
 
 				message := err.Error()
-				Expect(strings.Count(message, "Could not determine Ops Manager version")).To(Equal(1))
+				Expect(strings.Count(message, "could not determine Ops Manager version")).To(Equal(1))
 				Expect(strings.Count(message, "invalid version:")).To(Equal(1))
-				Expect(message).To(ContainSubstring("Could not determine Ops Manager version to accept flags --allow-unsafe-dependency-update / --allow-unsafe-dependency-deletion"))
+				Expect(message).To(ContainSubstring("could not determine Ops Manager version to accept flags --allow-unsafe-dependency-update / --allow-unsafe-dependency-deletion"))
 				Expect(message).ToNot(ContainSubstring("are only available with Ops Manager 11.0 or later"))
 
 				Expect(service.CreateInstallationCallCount()).To(Equal(0))

--- a/commands/apply_changes_test.go
+++ b/commands/apply_changes_test.go
@@ -60,7 +60,7 @@ var _ = Describe("ApplyChanges", func() {
 
 			Expect(service.CreateInstallationCallCount()).To(Equal(1))
 
-			ignoreWarnings, deployProducts, forceLatestVariables, _, _ := service.CreateInstallationArgsForCall(0)
+			ignoreWarnings, deployProducts, forceLatestVariables, _, _, _, _ := service.CreateInstallationArgsForCall(0)
 			Expect(ignoreWarnings).To(Equal(false))
 			Expect(deployProducts).To(Equal(true))
 			Expect(forceLatestVariables).To(Equal(false))
@@ -91,7 +91,7 @@ var _ = Describe("ApplyChanges", func() {
 
 			Expect(service.CreateInstallationCallCount()).To(Equal(1))
 
-			ignoreWarnings, deployProducts, _, _, _ := service.CreateInstallationArgsForCall(0)
+			ignoreWarnings, deployProducts, _, _, _, _, _ := service.CreateInstallationArgsForCall(0)
 			Expect(ignoreWarnings).To(Equal(false))
 			Expect(deployProducts).To(Equal(true))
 
@@ -117,7 +117,7 @@ var _ = Describe("ApplyChanges", func() {
 				err := executeCommand(command, []string{"--ignore-warnings"})
 				Expect(err).ToNot(HaveOccurred())
 
-				ignoreWarnings, _, _, _, _ := service.CreateInstallationArgsForCall(0)
+				ignoreWarnings, _, _, _, _, _, _ := service.CreateInstallationArgsForCall(0)
 				Expect(ignoreWarnings).To(Equal(true))
 			})
 		})
@@ -131,8 +131,40 @@ var _ = Describe("ApplyChanges", func() {
 				err := executeCommand(command, []string{"--force-latest-variables"})
 				Expect(err).ToNot(HaveOccurred())
 
-				_, _, forceLatestVariables, _, _ := service.CreateInstallationArgsForCall(0)
+				_, _, forceLatestVariables, _, _, _, _ := service.CreateInstallationArgsForCall(0)
 				Expect(forceLatestVariables).To(Equal(true))
+			})
+		})
+
+		When("passed the allow-unsafe-dependency-update flag", func() {
+			It("applies changes while allowing unsafe dependency updates", func() {
+				service.InfoReturns(api.Info{Version: "2.3-build43"}, nil)
+
+				command := commands.NewApplyChanges(service, pendingService, writer, logger, 1)
+
+				err := executeCommand(command, []string{"--allow-unsafe-dependency-update"})
+				Expect(err).ToNot(HaveOccurred())
+
+				_, _, _, allowUnsafeDependencyUpdate, _, _, _ := service.CreateInstallationArgsForCall(0)
+				Expect(allowUnsafeDependencyUpdate).To(Equal(true))
+
+				Expect(stderr).To(gbytes.Say("allow-unsafe-dependency-update is set: unsafe optional-dependency update checks will be bypassed"))
+			})
+		})
+
+		When("passed the allow-unsafe-dependency-deletion flag", func() {
+			It("applies changes while allowing unsafe dependency deletions", func() {
+				service.InfoReturns(api.Info{Version: "2.3-build43"}, nil)
+
+				command := commands.NewApplyChanges(service, pendingService, writer, logger, 1)
+
+				err := executeCommand(command, []string{"--allow-unsafe-dependency-deletion"})
+				Expect(err).ToNot(HaveOccurred())
+
+				_, _, _, _, allowUnsafeDependencyDeletion, _, _ := service.CreateInstallationArgsForCall(0)
+				Expect(allowUnsafeDependencyDeletion).To(Equal(true))
+
+				Expect(stderr).To(gbytes.Say("allow-unsafe-dependency-deletion is set: unsafe optional-dependency deletion checks will be bypassed"))
 			})
 		})
 
@@ -143,7 +175,7 @@ var _ = Describe("ApplyChanges", func() {
 				err := executeCommand(command, []string{"--skip-deploy-products"})
 				Expect(err).ToNot(HaveOccurred())
 
-				_, _, deployProducts, _, _ := service.CreateInstallationArgsForCall(0)
+				_, _, deployProducts, _, _, _, _ := service.CreateInstallationArgsForCall(0)
 				Expect(deployProducts).To(Equal(false))
 			})
 
@@ -164,7 +196,7 @@ var _ = Describe("ApplyChanges", func() {
 				err := executeCommand(command, []string{"--product-name", "product1", "--product-name", "product2"})
 				Expect(err).To(HaveOccurred())
 
-				_, _, _, productNames, _ := service.CreateInstallationArgsForCall(0)
+				_, _, _, _, _, productNames, _ := service.CreateInstallationArgsForCall(0)
 				Expect(productNames).To(ConsistOf("product1", "product2"))
 			})
 		})
@@ -397,7 +429,7 @@ errands:
 
 					Expect(service.CreateInstallationCallCount()).To(Equal(1))
 
-					ignoreWarnings, deployProducts, forceLatestVariables, _, errands := service.CreateInstallationArgsForCall(0)
+					ignoreWarnings, deployProducts, forceLatestVariables, _, _, _, errands := service.CreateInstallationArgsForCall(0)
 					Expect(ignoreWarnings).To(Equal(false))
 					Expect(deployProducts).To(Equal(true))
 					Expect(forceLatestVariables).To(Equal(false))

--- a/commands/apply_changes_test.go
+++ b/commands/apply_changes_test.go
@@ -60,10 +60,12 @@ var _ = Describe("ApplyChanges", func() {
 
 			Expect(service.CreateInstallationCallCount()).To(Equal(1))
 
-			ignoreWarnings, deployProducts, forceLatestVariables, _, _, _, _ := service.CreateInstallationArgsForCall(0)
+			ignoreWarnings, deployProducts, forceLatestVariables, allowUnsafeDependencyUpdate, allowUnsafeDependencyDeletion, _, _ := service.CreateInstallationArgsForCall(0)
 			Expect(ignoreWarnings).To(Equal(false))
 			Expect(deployProducts).To(Equal(true))
 			Expect(forceLatestVariables).To(Equal(false))
+			Expect(allowUnsafeDependencyUpdate).To(Equal(false))
+			Expect(allowUnsafeDependencyDeletion).To(Equal(false))
 
 			Expect(stderr).To(gbytes.Say("attempting to apply changes to the targeted Ops Manager"))
 
@@ -164,6 +166,24 @@ var _ = Describe("ApplyChanges", func() {
 				_, _, _, _, allowUnsafeDependencyDeletion, _, _ := service.CreateInstallationArgsForCall(0)
 				Expect(allowUnsafeDependencyDeletion).To(Equal(true))
 
+				Expect(stderr).To(gbytes.Say("allow-unsafe-dependency-deletion is set: unsafe optional-dependency deletion checks will be bypassed"))
+			})
+		})
+
+		When("passed both the allow-unsafe-dependency-update and allow-unsafe-dependency-deletion flags", func() {
+			It("applies changes while allowing both unsafe dependency updates and deletions", func() {
+				service.InfoReturns(api.Info{Version: "2.3-build43"}, nil)
+
+				command := commands.NewApplyChanges(service, pendingService, writer, logger, 1)
+
+				err := executeCommand(command, []string{"--allow-unsafe-dependency-update", "--allow-unsafe-dependency-deletion"})
+				Expect(err).ToNot(HaveOccurred())
+
+				_, _, _, allowUnsafeDependencyUpdate, allowUnsafeDependencyDeletion, _, _ := service.CreateInstallationArgsForCall(0)
+				Expect(allowUnsafeDependencyUpdate).To(Equal(true))
+				Expect(allowUnsafeDependencyDeletion).To(Equal(true))
+
+				Expect(stderr).To(gbytes.Say("allow-unsafe-dependency-update is set: unsafe optional-dependency update checks will be bypassed"))
 				Expect(stderr).To(gbytes.Say("allow-unsafe-dependency-deletion is set: unsafe optional-dependency deletion checks will be bypassed"))
 			})
 		})

--- a/commands/apply_changes_test.go
+++ b/commands/apply_changes_test.go
@@ -68,6 +68,8 @@ var _ = Describe("ApplyChanges", func() {
 			Expect(allowUnsafeDependencyUpdate).To(Equal(false))
 			Expect(allowUnsafeDependencyDeletion).To(Equal(false))
 
+			Expect(stderr).ToNot(gbytes.Say("checks will be bypassed"))
+
 			Expect(stderr).To(gbytes.Say("attempting to apply changes to the targeted Ops Manager"))
 
 			Expect(service.GetInstallationArgsForCall(0)).To(Equal(311))
@@ -196,7 +198,11 @@ var _ = Describe("ApplyChanges", func() {
 				command := commands.NewApplyChanges(service, pendingService, writer, logger, 1)
 
 				err := executeCommand(command, []string{"--allow-unsafe-dependency-update"})
-				Expect(err).To(MatchError(ContainSubstring("--allow-unsafe-dependency-update and --allow-unsafe-dependency-deletion are only available with Ops Manager 11.0 or later: you are running 10.2-build1")))
+				// Exact match, not just ContainSubstring: locks in that this
+				// message has no trailing "Error: %!w(<nil>)" artifact from
+				// wrapping a nil error, which the version-too-old code path (as
+				// opposed to the version-undeterminable code path) never has.
+				Expect(err).To(MatchError("--allow-unsafe-dependency-update and --allow-unsafe-dependency-deletion are only available with Ops Manager 11.0 or later: you are running 10.2-build1"))
 
 				Expect(service.CreateInstallationCallCount()).To(Equal(0))
 				Expect(stderr).ToNot(gbytes.Say("checks will be bypassed"))
@@ -233,6 +239,86 @@ var _ = Describe("ApplyChanges", func() {
 				Expect(strings.Count(message, "only available with Ops Manager")).To(Equal(1))
 				Expect(strings.Count(message, "you are running")).To(Equal(1))
 				Expect(message).To(ContainSubstring("--allow-unsafe-dependency-update and --allow-unsafe-dependency-deletion are only available with Ops Manager 11.0 or later: you are running 10.2-build1"))
+
+				Expect(service.CreateInstallationCallCount()).To(Equal(0))
+				Expect(stderr).ToNot(gbytes.Say("checks will be bypassed"))
+			})
+		})
+
+		When("passed the allow-unsafe-dependency-update flag but the Ops Manager version cannot be determined", func() {
+			It("errors with a version-lookup message distinct from the version-too-old message", func() {
+				service.InfoReturns(api.Info{Version: "not-a-version"}, nil)
+
+				command := commands.NewApplyChanges(service, pendingService, writer, logger, 1)
+
+				err := executeCommand(command, []string{"--allow-unsafe-dependency-update"})
+				Expect(err).To(MatchError(ContainSubstring("Could not determine Ops Manager version to accept flags --allow-unsafe-dependency-update / --allow-unsafe-dependency-deletion")))
+				Expect(err).To(MatchError(ContainSubstring("invalid version: 'not-a-version'")))
+				Expect(err).ToNot(MatchError(ContainSubstring("are only available with Ops Manager 11.0 or later")))
+
+				Expect(service.CreateInstallationCallCount()).To(Equal(0))
+				Expect(stderr).ToNot(gbytes.Say("checks will be bypassed"))
+			})
+		})
+
+		When("passed the allow-unsafe-dependency-deletion flag but the Ops Manager version cannot be determined", func() {
+			It("errors with a version-lookup message distinct from the version-too-old message", func() {
+				service.InfoReturns(api.Info{Version: "not-a-version"}, nil)
+
+				command := commands.NewApplyChanges(service, pendingService, writer, logger, 1)
+
+				err := executeCommand(command, []string{"--allow-unsafe-dependency-deletion"})
+				Expect(err).To(MatchError(ContainSubstring("Could not determine Ops Manager version to accept flags --allow-unsafe-dependency-update / --allow-unsafe-dependency-deletion")))
+				Expect(err).To(MatchError(ContainSubstring("invalid version: 'not-a-version'")))
+				Expect(err).ToNot(MatchError(ContainSubstring("are only available with Ops Manager 11.0 or later")))
+
+				Expect(service.CreateInstallationCallCount()).To(Equal(0))
+				Expect(stderr).ToNot(gbytes.Say("checks will be bypassed"))
+			})
+		})
+
+		When("passed both the allow-unsafe-dependency-update and allow-unsafe-dependency-deletion flags but the Ops Manager version cannot be determined", func() {
+			It("errors exactly once with a single, non-redundant message covering both flags", func() {
+				service.InfoReturns(api.Info{Version: "not-a-version"}, nil)
+
+				command := commands.NewApplyChanges(service, pendingService, writer, logger, 1)
+
+				err := executeCommand(command, []string{"--allow-unsafe-dependency-update", "--allow-unsafe-dependency-deletion"})
+				Expect(err).To(HaveOccurred())
+
+				message := err.Error()
+				Expect(strings.Count(message, "Could not determine Ops Manager version")).To(Equal(1))
+				Expect(strings.Count(message, "invalid version:")).To(Equal(1))
+				Expect(message).To(ContainSubstring("Could not determine Ops Manager version to accept flags --allow-unsafe-dependency-update / --allow-unsafe-dependency-deletion"))
+				Expect(message).ToNot(ContainSubstring("are only available with Ops Manager 11.0 or later"))
+
+				Expect(service.CreateInstallationCallCount()).To(Equal(0))
+				Expect(stderr).ToNot(gbytes.Say("checks will be bypassed"))
+			})
+		})
+
+		When("passed the allow-unsafe-dependency-update flag but retrieving Ops Manager info fails", func() {
+			It("errors instead of claiming the check will be bypassed", func() {
+				service.InfoReturns(api.Info{}, errors.New("connection refused"))
+
+				command := commands.NewApplyChanges(service, pendingService, writer, logger, 1)
+
+				err := executeCommand(command, []string{"--allow-unsafe-dependency-update"})
+				Expect(err).To(MatchError(ContainSubstring("could not retrieve info from targetted ops manager: connection refused")))
+
+				Expect(service.CreateInstallationCallCount()).To(Equal(0))
+				Expect(stderr).ToNot(gbytes.Say("checks will be bypassed"))
+			})
+		})
+
+		When("passed the allow-unsafe-dependency-deletion flag but retrieving Ops Manager info fails", func() {
+			It("errors instead of claiming the check will be bypassed", func() {
+				service.InfoReturns(api.Info{}, errors.New("connection refused"))
+
+				command := commands.NewApplyChanges(service, pendingService, writer, logger, 1)
+
+				err := executeCommand(command, []string{"--allow-unsafe-dependency-deletion"})
+				Expect(err).To(MatchError(ContainSubstring("could not retrieve info from targetted ops manager: connection refused")))
 
 				Expect(service.CreateInstallationCallCount()).To(Equal(0))
 				Expect(stderr).ToNot(gbytes.Say("checks will be bypassed"))

--- a/commands/fakes/apply_changes_service.go
+++ b/commands/fakes/apply_changes_service.go
@@ -8,14 +8,16 @@ import (
 )
 
 type ApplyChangesService struct {
-	CreateInstallationStub        func(bool, bool, bool, []string, api.ApplyErrandChanges) (api.InstallationsServiceOutput, error)
+	CreateInstallationStub        func(bool, bool, bool, bool, bool, []string, api.ApplyErrandChanges) (api.InstallationsServiceOutput, error)
 	createInstallationMutex       sync.RWMutex
 	createInstallationArgsForCall []struct {
 		arg1 bool
 		arg2 bool
 		arg3 bool
-		arg4 []string
-		arg5 api.ApplyErrandChanges
+		arg4 bool
+		arg5 bool
+		arg6 []string
+		arg7 api.ApplyErrandChanges
 	}
 	createInstallationReturns struct {
 		result1 api.InstallationsServiceOutput
@@ -102,11 +104,11 @@ type ApplyChangesService struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *ApplyChangesService) CreateInstallation(arg1 bool, arg2 bool, arg3 bool, arg4 []string, arg5 api.ApplyErrandChanges) (api.InstallationsServiceOutput, error) {
-	var arg4Copy []string
-	if arg4 != nil {
-		arg4Copy = make([]string, len(arg4))
-		copy(arg4Copy, arg4)
+func (fake *ApplyChangesService) CreateInstallation(arg1 bool, arg2 bool, arg3 bool, arg4 bool, arg5 bool, arg6 []string, arg7 api.ApplyErrandChanges) (api.InstallationsServiceOutput, error) {
+	var arg6Copy []string
+	if arg6 != nil {
+		arg6Copy = make([]string, len(arg6))
+		copy(arg6Copy, arg6)
 	}
 	fake.createInstallationMutex.Lock()
 	ret, specificReturn := fake.createInstallationReturnsOnCall[len(fake.createInstallationArgsForCall)]
@@ -114,18 +116,21 @@ func (fake *ApplyChangesService) CreateInstallation(arg1 bool, arg2 bool, arg3 b
 		arg1 bool
 		arg2 bool
 		arg3 bool
-		arg4 []string
-		arg5 api.ApplyErrandChanges
-	}{arg1, arg2, arg3, arg4Copy, arg5})
-	fake.recordInvocation("CreateInstallation", []interface{}{arg1, arg2, arg3, arg4Copy, arg5})
+		arg4 bool
+		arg5 bool
+		arg6 []string
+		arg7 api.ApplyErrandChanges
+	}{arg1, arg2, arg3, arg4, arg5, arg6Copy, arg7})
+	stub := fake.CreateInstallationStub
+	fakeReturns := fake.createInstallationReturns
+	fake.recordInvocation("CreateInstallation", []interface{}{arg1, arg2, arg3, arg4, arg5, arg6Copy, arg7})
 	fake.createInstallationMutex.Unlock()
-	if fake.CreateInstallationStub != nil {
-		return fake.CreateInstallationStub(arg1, arg2, arg3, arg4, arg5)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4, arg5, arg6, arg7)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.createInstallationReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -135,17 +140,17 @@ func (fake *ApplyChangesService) CreateInstallationCallCount() int {
 	return len(fake.createInstallationArgsForCall)
 }
 
-func (fake *ApplyChangesService) CreateInstallationCalls(stub func(bool, bool, bool, []string, api.ApplyErrandChanges) (api.InstallationsServiceOutput, error)) {
+func (fake *ApplyChangesService) CreateInstallationCalls(stub func(bool, bool, bool, bool, bool, []string, api.ApplyErrandChanges) (api.InstallationsServiceOutput, error)) {
 	fake.createInstallationMutex.Lock()
 	defer fake.createInstallationMutex.Unlock()
 	fake.CreateInstallationStub = stub
 }
 
-func (fake *ApplyChangesService) CreateInstallationArgsForCall(i int) (bool, bool, bool, []string, api.ApplyErrandChanges) {
+func (fake *ApplyChangesService) CreateInstallationArgsForCall(i int) (bool, bool, bool, bool, bool, []string, api.ApplyErrandChanges) {
 	fake.createInstallationMutex.RLock()
 	defer fake.createInstallationMutex.RUnlock()
 	argsForCall := fake.createInstallationArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5, argsForCall.arg6, argsForCall.arg7
 }
 
 func (fake *ApplyChangesService) CreateInstallationReturns(result1 api.InstallationsServiceOutput, result2 error) {
@@ -180,15 +185,16 @@ func (fake *ApplyChangesService) GetInstallation(arg1 int) (api.InstallationsSer
 	fake.getInstallationArgsForCall = append(fake.getInstallationArgsForCall, struct {
 		arg1 int
 	}{arg1})
+	stub := fake.GetInstallationStub
+	fakeReturns := fake.getInstallationReturns
 	fake.recordInvocation("GetInstallation", []interface{}{arg1})
 	fake.getInstallationMutex.Unlock()
-	if fake.GetInstallationStub != nil {
-		return fake.GetInstallationStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getInstallationReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -243,15 +249,16 @@ func (fake *ApplyChangesService) GetInstallationLogs(arg1 int) (api.Installation
 	fake.getInstallationLogsArgsForCall = append(fake.getInstallationLogsArgsForCall, struct {
 		arg1 int
 	}{arg1})
+	stub := fake.GetInstallationLogsStub
+	fakeReturns := fake.getInstallationLogsReturns
 	fake.recordInvocation("GetInstallationLogs", []interface{}{arg1})
 	fake.getInstallationLogsMutex.Unlock()
-	if fake.GetInstallationLogsStub != nil {
-		return fake.GetInstallationLogsStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getInstallationLogsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -305,15 +312,16 @@ func (fake *ApplyChangesService) Info() (api.Info, error) {
 	ret, specificReturn := fake.infoReturnsOnCall[len(fake.infoArgsForCall)]
 	fake.infoArgsForCall = append(fake.infoArgsForCall, struct {
 	}{})
+	stub := fake.InfoStub
+	fakeReturns := fake.infoReturns
 	fake.recordInvocation("Info", []interface{}{})
 	fake.infoMutex.Unlock()
-	if fake.InfoStub != nil {
-		return fake.InfoStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.infoReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -360,15 +368,16 @@ func (fake *ApplyChangesService) ListInstallations() ([]api.InstallationsService
 	ret, specificReturn := fake.listInstallationsReturnsOnCall[len(fake.listInstallationsArgsForCall)]
 	fake.listInstallationsArgsForCall = append(fake.listInstallationsArgsForCall, struct {
 	}{})
+	stub := fake.ListInstallationsStub
+	fakeReturns := fake.listInstallationsReturns
 	fake.recordInvocation("ListInstallations", []interface{}{})
 	fake.listInstallationsMutex.Unlock()
-	if fake.ListInstallationsStub != nil {
-		return fake.ListInstallationsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.listInstallationsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -415,15 +424,16 @@ func (fake *ApplyChangesService) RunningInstallation() (api.InstallationsService
 	ret, specificReturn := fake.runningInstallationReturnsOnCall[len(fake.runningInstallationArgsForCall)]
 	fake.runningInstallationArgsForCall = append(fake.runningInstallationArgsForCall, struct {
 	}{})
+	stub := fake.RunningInstallationStub
+	fakeReturns := fake.runningInstallationReturns
 	fake.recordInvocation("RunningInstallation", []interface{}{})
 	fake.runningInstallationMutex.Unlock()
-	if fake.RunningInstallationStub != nil {
-		return fake.RunningInstallationStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.runningInstallationReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -471,15 +481,16 @@ func (fake *ApplyChangesService) UpdateStagedDirectorProperties(arg1 api.Directo
 	fake.updateStagedDirectorPropertiesArgsForCall = append(fake.updateStagedDirectorPropertiesArgsForCall, struct {
 		arg1 api.DirectorProperties
 	}{arg1})
+	stub := fake.UpdateStagedDirectorPropertiesStub
+	fakeReturns := fake.updateStagedDirectorPropertiesReturns
 	fake.recordInvocation("UpdateStagedDirectorProperties", []interface{}{arg1})
 	fake.updateStagedDirectorPropertiesMutex.Unlock()
-	if fake.UpdateStagedDirectorPropertiesStub != nil {
-		return fake.UpdateStagedDirectorPropertiesStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.updateStagedDirectorPropertiesReturns
 	return fakeReturns.result1
 }
 
@@ -528,20 +539,6 @@ func (fake *ApplyChangesService) UpdateStagedDirectorPropertiesReturnsOnCall(i i
 func (fake *ApplyChangesService) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
-	fake.createInstallationMutex.RLock()
-	defer fake.createInstallationMutex.RUnlock()
-	fake.getInstallationMutex.RLock()
-	defer fake.getInstallationMutex.RUnlock()
-	fake.getInstallationLogsMutex.RLock()
-	defer fake.getInstallationLogsMutex.RUnlock()
-	fake.infoMutex.RLock()
-	defer fake.infoMutex.RUnlock()
-	fake.listInstallationsMutex.RLock()
-	defer fake.listInstallationsMutex.RUnlock()
-	fake.runningInstallationMutex.RLock()
-	defer fake.runningInstallationMutex.RUnlock()
-	fake.updateStagedDirectorPropertiesMutex.RLock()
-	defer fake.updateStagedDirectorPropertiesMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/docs/apply-changes/README.md
+++ b/docs/apply-changes/README.md
@@ -15,63 +15,84 @@ This authenticated command kicks off an install of any staged changes on the
 Ops Manager.
 
 Application Options:
-      --ca-cert=                    OpsManager CA certificate path or value
-                                    [$OM_CA_CERT]
-  -c, --client-id=                  Client ID for the Ops Manager VM (not
-                                    required for unauthenticated commands)
-                                    [$OM_CLIENT_ID]
-  -s, --client-secret=              Client Secret for the Ops Manager VM (not
-                                    required for unauthenticated commands)
-                                    [$OM_CLIENT_SECRET]
-  -o, --connect-timeout=            timeout in seconds to make TCP connections
-                                    (default: 10) [$OM_CONNECT_TIMEOUT]
-  -d, --decryption-passphrase=      Passphrase to decrypt the installation if
-                                    the Ops Manager VM has been rebooted
-                                    (optional for most commands)
-                                    [$OM_DECRYPTION_PASSPHRASE]
-  -e, --env=                        env file with login credentials
-  -p, --password=                   admin password for the Ops Manager VM (not
-                                    required for unauthenticated commands)
-                                    [$OM_PASSWORD]
-  -r, --request-timeout=            timeout in seconds for HTTP requests to Ops
-                                    Manager (default: 1800)
-                                    [$OM_REQUEST_TIMEOUT]
-  -k, --skip-ssl-validation         skip ssl certificate validation during http
-                                    requests [$OM_SKIP_SSL_VALIDATION]
-  -t, --target=                     location of the Ops Manager VM [$OM_TARGET]
-      --uaa-target=                 optional location of the Ops Manager UAA
-                                    [$OM_UAA_TARGET]
-      --trace                       prints HTTP requests and response payloads
-                                    [$OM_TRACE]
-  -u, --username=                   admin username for the Ops Manager VM (not
-                                    required for unauthenticated commands)
-                                    [$OM_USERNAME]
-      --vars-env=                   load vars from environment variables by
-                                    specifying a prefix (e.g.: 'MY' to load
-                                    MY_var=value) [$OM_VARS_ENV]
-  -v, --version                     prints the om release version
+      --ca-cert=                              OpsManager CA certificate path or
+                                              value [$OM_CA_CERT]
+  -c, --client-id=                            Client ID for the Ops Manager VM
+                                              (not required for unauthenticated
+                                              commands) [$OM_CLIENT_ID]
+  -s, --client-secret=                        Client Secret for the Ops Manager
+                                              VM (not required for
+                                              unauthenticated commands)
+                                              [$OM_CLIENT_SECRET]
+  -o, --connect-timeout=                      timeout in seconds to make TCP
+                                              connections (default: 10)
+                                              [$OM_CONNECT_TIMEOUT]
+  -d, --decryption-passphrase=                Passphrase to decrypt the
+                                              installation if the Ops Manager
+                                              VM has been rebooted (optional
+                                              for most commands)
+                                              [$OM_DECRYPTION_PASSPHRASE]
+  -e, --env=                                  env file with login credentials
+  -p, --password=                             admin password for the Ops
+                                              Manager VM (not required for
+                                              unauthenticated commands)
+                                              [$OM_PASSWORD]
+  -r, --request-timeout=                      timeout in seconds for HTTP
+                                              requests to Ops Manager (default:
+                                              1800) [$OM_REQUEST_TIMEOUT]
+  -k, --skip-ssl-validation                   skip ssl certificate validation
+                                              during http requests
+                                              [$OM_SKIP_SSL_VALIDATION]
+  -t, --target=                               location of the Ops Manager VM
+                                              [$OM_TARGET]
+      --uaa-target=                           optional location of the Ops
+                                              Manager UAA [$OM_UAA_TARGET]
+      --trace                                 prints HTTP requests and response
+                                              payloads [$OM_TRACE]
+  -u, --username=                             admin username for the Ops
+                                              Manager VM (not required for
+                                              unauthenticated commands)
+                                              [$OM_USERNAME]
+      --vars-env=                             load vars from environment
+                                              variables by specifying a prefix
+                                              (e.g.: 'MY' to load MY_var=value)
+                                              [$OM_VARS_ENV]
+  -v, --version                               prints the om release version
 
 Help Options:
-  -h, --help                        Show this help message
+  -h, --help                                  Show this help message
 
 [apply-changes command options]
-      -c, --config=                 path to yml file containing errand
-                                    configuration (see
-                                    docs/apply-changes/README.md for format)
-      -i, --ignore-warnings         For convenience. Use other commands to
-                                    disable particular verifiers if they are
-                                    inappropriate.
-          --reattach                reattach to an already running apply
-                                    changes (if available)
-          --recreate-vms            recreate all vms
-      -s, --skip-deploy-products    skip deploying products when applying
-                                    changes - just update the director
-          --force-latest-variables  force any certificates or other BOSH
-                                    variables to use their latest version even
-                                    when a stemcell is not being upgraded
-      -n, --product-name=           name of the product(s) to deploy, cannot be
-                                    used in conjunction with
-                                    --skip-deploy-products (OM 2.2+)
+      -c, --config=                           path to yml file containing
+                                              errand configuration (see
+                                              docs/apply-changes/README.md for
+                                              format)
+      -i, --ignore-warnings                   For convenience. Use other
+                                              commands to disable particular
+                                              verifiers if they are
+                                              inappropriate.
+          --reattach                          reattach to an already running
+                                              apply changes (if available)
+          --recreate-vms                      recreate all vms
+      -s, --skip-deploy-products              skip deploying products when
+                                              applying changes - just update
+                                              the director
+          --force-latest-variables            force any certificates or other
+                                              BOSH variables to use their
+                                              latest version even when a
+                                              stemcell is not being upgraded
+          --allow-unsafe-dependency-update    allow apply-changes to proceed
+                                              even when it would update a
+                                              dependency out of its declared
+                                              safe order
+          --allow-unsafe-dependency-deletion  allow apply-changes to proceed
+                                              even when it would delete an
+                                              optional dependency not marked as
+                                              safe to delete
+      -n, --product-name=                     name of the product(s) to deploy,
+                                              cannot be used in conjunction
+                                              with --skip-deploy-products (OM
+                                              2.2+)
 ```
 
 ### Configuring via YAML config file


### PR DESCRIPTION
Context:
Tiles can declare optional dependencies on other tiles. Ops Manager blocks apply-changes when an optional dependency has unsafe property changes on update, or when deleting a product whose optional dependent isn't marked safe-to-delete. Platform engineers had no way to proceed past these specific checks from the CLI even when they understood and accepted the risk — the only path was disabling verifiers more broadly via --ignore-warnings, which suppresses everything overridable rather than just this one class of check.

Implementation notes:
- Added --allow-unsafe-dependency-update and --allow-unsafe-dependency-deletion flags to `apply-changes`, wired through ApplyChanges.Options -> applyChangesService -> Api.CreateInstallation.
- Both default to false and are marshaled with `omitempty`, so they are only present in the POST /api/v0/installations body when set to true — the request is byte-for-byte unchanged for every caller that doesn't pass them.
- This is a CLI-only change. The Ops Manager backend support for these two params (permitted on the installations endpoint, wired through ValidationOverrideOptions into ProductDependencyVerifier) already exists as of Ops Manager releases/11.0 (introduced 2026-06-18); this branch only makes `om` use what's already there. Against an Ops Manager version predating that release, the fields are silently stripped by Rails strong-parameter filtering rather than causing a request error — the flags simply have no effect on those older targets.
- On a blocked apply-changes, Ops Manager's 422 response includes an `available_overrides` array naming which bypass(es) would unblock the specific failure. CreateInstallation now decodes that and appends a hint mapping known values to their CLI flag (falling back to the raw value for any override `om` doesn't recognize yet, per the API's forward-compatibility contract).
- Regenerated the counterfeiter fake for applyChangesService to match the new signature; regenerated docs/apply-changes/README.md via the repo's docsgenerator tooling rather than hand-editing it.

Usage notes:
- `om apply-changes --allow-unsafe-dependency-update`
- `om apply-changes --allow-unsafe-dependency-deletion`
- Both can be combined with each other and with existing flags (e.g. --product-name). Both are no-ops unless explicitly passed.
- If apply-changes is blocked and the failure has a known override, the resulting error now suggests the specific flag to retry with, instead of only pointing at `om pre-deploy-check`.
- Requires an Ops Manager release that includes this backend feature (11.0+); on older targets, passing these flags will not bypass anything and the original blocking behavior still applies.