### PR TITLE
Pass OpenStack password via OS_PASSWORD env var instead of CLI arg

### DIFF
--- a/vmlifecycle/vmmanagers/fakes/openstackRunner.go
+++ b/vmlifecycle/vmmanagers/fakes/openstackRunner.go
@@ -7,17 +7,18 @@ import (
 )
 
 type OpenstackRunner struct {
-	ExecuteStub        func([]interface{}) (*bytes.Buffer, *bytes.Buffer, error)
-	executeMutex       sync.RWMutex
-	executeArgsForCall []struct {
-		arg1 []interface{}
+	ExecuteWithEnvVarsStub        func([]string, []interface{}) (*bytes.Buffer, *bytes.Buffer, error)
+	executeWithEnvVarsMutex       sync.RWMutex
+	executeWithEnvVarsArgsForCall []struct {
+		arg1 []string
+		arg2 []interface{}
 	}
-	executeReturns struct {
+	executeWithEnvVarsReturns struct {
 		result1 *bytes.Buffer
 		result2 *bytes.Buffer
 		result3 error
 	}
-	executeReturnsOnCall map[int]struct {
+	executeWithEnvVarsReturnsOnCall map[int]struct {
 		result1 *bytes.Buffer
 		result2 *bytes.Buffer
 		result3 error
@@ -26,71 +27,77 @@ type OpenstackRunner struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *OpenstackRunner) Execute(arg1 []interface{}) (*bytes.Buffer, *bytes.Buffer, error) {
-	var arg1Copy []interface{}
+func (fake *OpenstackRunner) ExecuteWithEnvVars(arg1 []string, arg2 []interface{}) (*bytes.Buffer, *bytes.Buffer, error) {
+	var arg1Copy []string
 	if arg1 != nil {
-		arg1Copy = make([]interface{}, len(arg1))
+		arg1Copy = make([]string, len(arg1))
 		copy(arg1Copy, arg1)
 	}
-	fake.executeMutex.Lock()
-	ret, specificReturn := fake.executeReturnsOnCall[len(fake.executeArgsForCall)]
-	fake.executeArgsForCall = append(fake.executeArgsForCall, struct {
-		arg1 []interface{}
-	}{arg1Copy})
-	fake.recordInvocation("Execute", []interface{}{arg1Copy})
-	fake.executeMutex.Unlock()
-	if fake.ExecuteStub != nil {
-		return fake.ExecuteStub(arg1)
+	var arg2Copy []interface{}
+	if arg2 != nil {
+		arg2Copy = make([]interface{}, len(arg2))
+		copy(arg2Copy, arg2)
+	}
+	fake.executeWithEnvVarsMutex.Lock()
+	ret, specificReturn := fake.executeWithEnvVarsReturnsOnCall[len(fake.executeWithEnvVarsArgsForCall)]
+	fake.executeWithEnvVarsArgsForCall = append(fake.executeWithEnvVarsArgsForCall, struct {
+		arg1 []string
+		arg2 []interface{}
+	}{arg1Copy, arg2Copy})
+	fake.recordInvocation("ExecuteWithEnvVars", []interface{}{arg1Copy, arg2Copy})
+	fake.executeWithEnvVarsMutex.Unlock()
+	if fake.ExecuteWithEnvVarsStub != nil {
+		return fake.ExecuteWithEnvVarsStub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.executeReturns
+	fakeReturns := fake.executeWithEnvVarsReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
-func (fake *OpenstackRunner) ExecuteCallCount() int {
-	fake.executeMutex.RLock()
-	defer fake.executeMutex.RUnlock()
-	return len(fake.executeArgsForCall)
+func (fake *OpenstackRunner) ExecuteWithEnvVarsCallCount() int {
+	fake.executeWithEnvVarsMutex.RLock()
+	defer fake.executeWithEnvVarsMutex.RUnlock()
+	return len(fake.executeWithEnvVarsArgsForCall)
 }
 
-func (fake *OpenstackRunner) ExecuteCalls(stub func([]interface{}) (*bytes.Buffer, *bytes.Buffer, error)) {
-	fake.executeMutex.Lock()
-	defer fake.executeMutex.Unlock()
-	fake.ExecuteStub = stub
+func (fake *OpenstackRunner) ExecuteWithEnvVarsCalls(stub func([]string, []interface{}) (*bytes.Buffer, *bytes.Buffer, error)) {
+	fake.executeWithEnvVarsMutex.Lock()
+	defer fake.executeWithEnvVarsMutex.Unlock()
+	fake.ExecuteWithEnvVarsStub = stub
 }
 
-func (fake *OpenstackRunner) ExecuteArgsForCall(i int) []interface{} {
-	fake.executeMutex.RLock()
-	defer fake.executeMutex.RUnlock()
-	argsForCall := fake.executeArgsForCall[i]
-	return argsForCall.arg1
+func (fake *OpenstackRunner) ExecuteWithEnvVarsArgsForCall(i int) ([]string, []interface{}) {
+	fake.executeWithEnvVarsMutex.RLock()
+	defer fake.executeWithEnvVarsMutex.RUnlock()
+	argsForCall := fake.executeWithEnvVarsArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
 }
 
-func (fake *OpenstackRunner) ExecuteReturns(result1 *bytes.Buffer, result2 *bytes.Buffer, result3 error) {
-	fake.executeMutex.Lock()
-	defer fake.executeMutex.Unlock()
-	fake.ExecuteStub = nil
-	fake.executeReturns = struct {
+func (fake *OpenstackRunner) ExecuteWithEnvVarsReturns(result1 *bytes.Buffer, result2 *bytes.Buffer, result3 error) {
+	fake.executeWithEnvVarsMutex.Lock()
+	defer fake.executeWithEnvVarsMutex.Unlock()
+	fake.ExecuteWithEnvVarsStub = nil
+	fake.executeWithEnvVarsReturns = struct {
 		result1 *bytes.Buffer
 		result2 *bytes.Buffer
 		result3 error
 	}{result1, result2, result3}
 }
 
-func (fake *OpenstackRunner) ExecuteReturnsOnCall(i int, result1 *bytes.Buffer, result2 *bytes.Buffer, result3 error) {
-	fake.executeMutex.Lock()
-	defer fake.executeMutex.Unlock()
-	fake.ExecuteStub = nil
-	if fake.executeReturnsOnCall == nil {
-		fake.executeReturnsOnCall = make(map[int]struct {
+func (fake *OpenstackRunner) ExecuteWithEnvVarsReturnsOnCall(i int, result1 *bytes.Buffer, result2 *bytes.Buffer, result3 error) {
+	fake.executeWithEnvVarsMutex.Lock()
+	defer fake.executeWithEnvVarsMutex.Unlock()
+	fake.ExecuteWithEnvVarsStub = nil
+	if fake.executeWithEnvVarsReturnsOnCall == nil {
+		fake.executeWithEnvVarsReturnsOnCall = make(map[int]struct {
 			result1 *bytes.Buffer
 			result2 *bytes.Buffer
 			result3 error
 		})
 	}
-	fake.executeReturnsOnCall[i] = struct {
+	fake.executeWithEnvVarsReturnsOnCall[i] = struct {
 		result1 *bytes.Buffer
 		result2 *bytes.Buffer
 		result3 error
@@ -100,8 +107,8 @@ func (fake *OpenstackRunner) ExecuteReturnsOnCall(i int, result1 *bytes.Buffer, 
 func (fake *OpenstackRunner) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
-	fake.executeMutex.RLock()
-	defer fake.executeMutex.RUnlock()
+	fake.executeWithEnvVarsMutex.RLock()
+	defer fake.executeWithEnvVarsMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/vmlifecycle/vmmanagers/openstack.go
+++ b/vmlifecycle/vmmanagers/openstack.go
@@ -38,7 +38,7 @@ type OpenstackConfig struct {
 
 //go:generate counterfeiter -o ./fakes/openstackRunner.go --fake-name OpenstackRunner . openstackRunner
 type openstackRunner interface {
-	Execute(args []interface{}) (*bytes.Buffer, *bytes.Buffer, error)
+	ExecuteWithEnvVars(env []string, args []interface{}) (*bytes.Buffer, *bytes.Buffer, error)
 }
 
 type OpenstackVMManager struct {
@@ -155,7 +155,7 @@ func (o *OpenstackVMManager) listExistingImages(imageName string) (string, error
 		`--format`, `value`,
 		`--column`, `ID`)
 
-	stdout, _, err := o.runner.Execute(args)
+	stdout, _, err := o.runner.ExecuteWithEnvVars(o.addEnvVars(), args)
 	return cleanupString(stdout.String()), checkFormatedError("openstack error failed to list existing images. Could not create: %s", err)
 }
 
@@ -172,7 +172,7 @@ func (o *OpenstackVMManager) createImage(imageName string) (imageURI string, err
 		`--format`, `value`, `--column`, `id`,
 		`--file`, o.Image, imageName)
 
-	stdout, _, err := o.runner.Execute(args)
+	stdout, _, err := o.runner.ExecuteWithEnvVars(o.addEnvVars(), args)
 
 	return cleanupString(stdout.String()), err
 }
@@ -202,7 +202,7 @@ func (o *OpenstackVMManager) createVM(imageID string) (serverID string, state St
 
 	args = append(args, o.Config.VMName)
 
-	stdout, _, err := o.runner.Execute(args)
+	stdout, _, err := o.runner.ExecuteWithEnvVars(o.addEnvVars(), args)
 	if err != nil {
 		return "", StateInfo{}, err
 	}
@@ -211,7 +211,7 @@ func (o *OpenstackVMManager) createVM(imageID string) (serverID string, state St
 
 func (o *OpenstackVMManager) deleteVM() error {
 	args := append(o.getAuthArguments(), `server`, `delete`, o.State.ID, `--wait`)
-	_, _, err := o.runner.Execute(args)
+	_, _, err := o.runner.ExecuteWithEnvVars(o.addEnvVars(), args)
 	if err != nil {
 		return fmt.Errorf("openstack error deleting VM: %s", err)
 	}
@@ -223,7 +223,7 @@ func (o *OpenstackVMManager) attachIP(serverID string) error {
 	log.Println("Attaching Public IP to VM...")
 	args := append(o.getAuthArguments(), `server`, `add`, `floating`, `ip`,
 		serverID, o.Config.PublicIP)
-	_, _, err := o.runner.Execute(args)
+	_, _, err := o.runner.ExecuteWithEnvVars(o.addEnvVars(), args)
 	if err != nil {
 		return fmt.Errorf("openstack error attaching the IP address to VM: %s", err)
 	}
@@ -251,7 +251,7 @@ func (o *OpenstackVMManager) vmExists() (bool, error) {
 		`--column`, `status`,
 		`--format`, `value`)
 
-	stdout, _, err := o.runner.Execute(args)
+	stdout, _, err := o.runner.ExecuteWithEnvVars(o.addEnvVars(), args)
 	status := cleanupString(stdout.String())
 
 	return status == "ACTIVE", checkFormatedError("VM ID in statefile does not exist. Please check your statefile and try again: %s", err)
@@ -261,7 +261,7 @@ func (o *OpenstackVMManager) getVMImage() (string, error) {
 	args := append(o.getAuthArguments(), `server`, `show`, o.State.ID,
 		`--column`, `image`,
 		`--format`, `value`)
-	stdout, _, err := o.runner.Execute(args)
+	stdout, _, err := o.runner.ExecuteWithEnvVars(o.addEnvVars(), args)
 	if err != nil {
 		return "", fmt.Errorf(
 			"%s\n       Could not find VM with ID %q.\n       To fix, ensure the VM ID in the statefile matches a VM that exists.\n       If the VM has already been deleted, delete the contents of the statefile.",
@@ -276,15 +276,23 @@ func (o *OpenstackVMManager) getVMImage() (string, error) {
 
 func (o *OpenstackVMManager) deleteImage(imageID string) error {
 	args := append(o.getAuthArguments(), `image`, `delete`, imageID)
-	_, _, err := o.runner.Execute(args)
+	_, _, err := o.runner.ExecuteWithEnvVars(o.addEnvVars(), args)
 
 	return checkFormatedError("openstack error failed to remove existing image. Could not create: %s", err)
+}
+
+// addEnvVars passes the OpenStack password via the OS_PASSWORD env var
+// instead of a CLI flag, since process argv (unlike the environment) is
+// readable by any local user via /proc/<pid>/cmdline or ps.
+func (o *OpenstackVMManager) addEnvVars() []string {
+	return []string{
+		fmt.Sprintf("OS_PASSWORD=%s", o.Config.Password),
+	}
 }
 
 func (o *OpenstackVMManager) getAuthArguments() []interface{} {
 	args := []interface{}{
 		`--os-username`, runner.Redact(o.Config.Username),
-		`--os-password`, runner.Redact(o.Config.Password),
 		`--os-auth-url`, o.Config.AuthUrl,
 		`--os-project-name`, o.Config.Project,
 	}

--- a/vmlifecycle/vmmanagers/openstack_test.go
+++ b/vmlifecycle/vmmanagers/openstack_test.go
@@ -68,16 +68,16 @@ opsman-configuration:
 					command, runner := createCommand(configStrTemplate)
 					command.Config.PrivateIP = ""
 
-					runner.ExecuteReturnsOnCall(0, bytes.NewBufferString("\r\n"), nil, nil)
-					runner.ExecuteReturnsOnCall(1, bytes.NewBufferString("custom-image-id\r\n"), nil, nil)
-					runner.ExecuteReturnsOnCall(2, bytes.NewBufferString("custom-server-id\r\n"), bytes.NewBufferString("TestStatus: pending creation"), nil)
+					runner.ExecuteWithEnvVarsReturnsOnCall(0, bytes.NewBufferString("\r\n"), nil, nil)
+					runner.ExecuteWithEnvVarsReturnsOnCall(1, bytes.NewBufferString("custom-image-id\r\n"), nil, nil)
+					runner.ExecuteWithEnvVarsReturnsOnCall(2, bytes.NewBufferString("custom-server-id\r\n"), bytes.NewBufferString("TestStatus: pending creation"), nil)
 
 					_, _, err := command.CreateVM()
 					Expect(err).ToNot(HaveOccurred())
-					invokes := runner.Invocations()["Execute"]
+					invokes := runner.Invocations()["ExecuteWithEnvVars"]
 					Expect(invokes).ToNot(HaveLen(0))
-					for _, args := range invokes {
-						Expect(args[0]).ToNot(ContainElement(ContainSubstring("fixed-ip")))
+					for _, invoke := range invokes {
+						Expect(invoke[1]).ToNot(ContainElement(ContainSubstring("fixed-ip")))
 					}
 				})
 			})
@@ -87,16 +87,16 @@ opsman-configuration:
 					command, runner := createCommand(configStrTemplate)
 					command.Config.PublicIP = ""
 
-					runner.ExecuteReturnsOnCall(0, bytes.NewBufferString("\r\n"), nil, nil)
-					runner.ExecuteReturnsOnCall(1, bytes.NewBufferString("custom-image-id\r\n"), nil, nil)
-					runner.ExecuteReturnsOnCall(2, bytes.NewBufferString("custom-server-id\r\n"), bytes.NewBufferString("TestStatus: pending creation"), nil)
+					runner.ExecuteWithEnvVarsReturnsOnCall(0, bytes.NewBufferString("\r\n"), nil, nil)
+					runner.ExecuteWithEnvVarsReturnsOnCall(1, bytes.NewBufferString("custom-image-id\r\n"), nil, nil)
+					runner.ExecuteWithEnvVarsReturnsOnCall(2, bytes.NewBufferString("custom-server-id\r\n"), bytes.NewBufferString("TestStatus: pending creation"), nil)
 
 					_, _, err := command.CreateVM()
 					Expect(err).ToNot(HaveOccurred())
-					invokes := runner.Invocations()["Execute"]
+					invokes := runner.Invocations()["ExecuteWithEnvVars"]
 					Expect(invokes).ToNot(HaveLen(0))
-					for _, args := range invokes {
-						Expect(args[0]).ToNot(ContainElement(ContainSubstring("floating")))
+					for _, invoke := range invokes {
+						Expect(invoke[1]).ToNot(ContainElement(ContainSubstring("floating")))
 					}
 				})
 			})
@@ -108,18 +108,17 @@ opsman-configuration:
 						IAAS: "openstack",
 						ID:   "vm-name",
 					}
-					runner.ExecuteReturnsOnCall(0, bytes.NewBufferString("ACTIVE\r\n"), nil, nil)
+					runner.ExecuteWithEnvVarsReturnsOnCall(0, bytes.NewBufferString("ACTIVE\r\n"), nil, nil)
 
 					status, state, err := command.CreateVM()
 					Expect(err).ToNot(HaveOccurred())
 					Expect(status).To(Equal(vmmanagers.Exist))
 
-					Expect(runner.ExecuteCallCount()).To(BeEquivalentTo(1))
+					Expect(runner.ExecuteWithEnvVarsCallCount()).To(BeEquivalentTo(1))
 
-					actualArgs := runner.ExecuteArgsForCall(0)
+					actualEnv, actualArgs := runner.ExecuteWithEnvVarsArgsForCall(0)
 					Expect(actualArgs).To(matchers.OrderedConsistOf([]interface{}{
 						"--os-username", gstruct.Ignore(),
-						"--os-password", gstruct.Ignore(),
 						"--os-auth-url", "https://example.com:5000/v2.0",
 						"--os-project-name", "marker",
 						"--insecure",
@@ -130,6 +129,8 @@ opsman-configuration:
 						"--column", "status",
 						"--format", "value",
 					}))
+					Expect(actualEnv).To(ContainElement("OS_PASSWORD=password"))
+					Expect(actualArgs).ToNot(ContainElement("--os-password"))
 
 					Expect(state.IAAS).To(Equal("openstack"))
 					Expect(state.ID).To(Equal("vm-name"))
@@ -140,14 +141,14 @@ opsman-configuration:
 						It("returns an error", func() {
 							command, runner := createCommand(configStrTemplate)
 							command.State.ID = "vm-name"
-							runner.ExecuteReturnsOnCall(0, nil, bytes.NewBufferString(""), errors.New("some error"))
+							runner.ExecuteWithEnvVarsReturnsOnCall(0, nil, bytes.NewBufferString(""), errors.New("some error"))
 
 							status, _, err := command.CreateVM()
 							Expect(err).To(HaveOccurred())
 							Expect(err.Error()).To(MatchRegexp("VM ID in statefile does not exist. Please check your statefile and try again"))
 							Expect(status).To(Equal(vmmanagers.Unknown))
 
-							Expect(runner.ExecuteCallCount()).To(BeEquivalentTo(1))
+							Expect(runner.ExecuteWithEnvVarsCallCount()).To(BeEquivalentTo(1))
 						})
 					})
 				})
@@ -157,14 +158,13 @@ opsman-configuration:
 				It("calls openstack with correct cli arguments", func() {
 					command, runner := createCommand(configStrTemplate)
 
-					runner.ExecuteReturnsOnCall(0, bytes.NewBufferString("\r\n"), nil, nil)
-					runner.ExecuteReturnsOnCall(1, bytes.NewBufferString("custom-image-id\r\n"), nil, nil)
-					runner.ExecuteReturnsOnCall(2, bytes.NewBufferString("custom-server-id\r\n"), bytes.NewBufferString("TestStatus: pending creation"), nil)
+					runner.ExecuteWithEnvVarsReturnsOnCall(0, bytes.NewBufferString("\r\n"), nil, nil)
+					runner.ExecuteWithEnvVarsReturnsOnCall(1, bytes.NewBufferString("custom-image-id\r\n"), nil, nil)
+					runner.ExecuteWithEnvVarsReturnsOnCall(2, bytes.NewBufferString("custom-server-id\r\n"), bytes.NewBufferString("TestStatus: pending creation"), nil)
 
 					commands := [][]interface{}{
 						{ //1
 							"--os-username", gstruct.Ignore(),
-							"--os-password", gstruct.Ignore(),
 							"--os-auth-url", "https://example.com:5000/v2.0",
 							"--os-project-name", "marker",
 							"--insecure",
@@ -178,7 +178,6 @@ opsman-configuration:
 						},
 						{ //2
 							"--os-username", gstruct.Ignore(),
-							"--os-password", gstruct.Ignore(),
 							"--os-auth-url", "https://example.com:5000/v2.0",
 							"--os-project-name", "marker",
 							"--insecure",
@@ -191,7 +190,6 @@ opsman-configuration:
 						},
 						{ //3
 							"--os-username", gstruct.Ignore(),
-							"--os-password", gstruct.Ignore(),
 							"--os-auth-url", "https://example.com:5000/v2.0",
 							"--os-project-name", "marker",
 							"--insecure",
@@ -210,7 +208,6 @@ opsman-configuration:
 						},
 						{ //4
 							"--os-username", gstruct.Ignore(),
-							"--os-password", gstruct.Ignore(),
 							"--os-auth-url", "https://example.com:5000/v2.0",
 							"--os-project-name", "marker",
 							"--insecure",
@@ -227,8 +224,10 @@ opsman-configuration:
 					Expect(stateInfo).To(Equal(vmmanagers.StateInfo{IAAS: "openstack", ID: "custom-server-id"}))
 
 					for i, expectedArgs := range commands {
-						actualArgs := runner.ExecuteArgsForCall(i)
+						actualEnv, actualArgs := runner.ExecuteWithEnvVarsArgsForCall(i)
 						Expect(actualArgs).To(matchers.OrderedConsistOf(expectedArgs))
+						Expect(actualEnv).To(ContainElement("OS_PASSWORD=password"))
+						Expect(actualArgs).ToNot(ContainElement("--os-password"))
 					}
 				})
 
@@ -252,9 +251,9 @@ opsman-configuration:
 						DescribeTable("prints errors from openstack", func(callNumber int, expectedStatus vmmanagers.Status) {
 							command, runner := createCommand(configStrTemplate)
 
-							runner.ExecuteReturns(bytes.NewBufferString("null\r\n"), nil, nil)
+							runner.ExecuteWithEnvVarsReturns(bytes.NewBufferString("null\r\n"), nil, nil)
 
-							runner.ExecuteReturnsOnCall(callNumber, nil, nil, errors.New("some error occurred"))
+							runner.ExecuteWithEnvVarsReturnsOnCall(callNumber, nil, nil, errors.New("some error occurred"))
 							status, _, err := command.CreateVM()
 							Expect(status).To(Equal(expectedStatus))
 							Expect(err).To(HaveOccurred())
@@ -284,17 +283,17 @@ opsman-configuration:
 				It("deletes the image", func() {
 					command, runner := createCommand(configStrTemplate)
 
-					runner.ExecuteReturnsOnCall(0, bytes.NewBufferString("image-id\r\n"), nil, nil)
-					runner.ExecuteReturnsOnCall(2, bytes.NewBufferString("custom-image-id\r\n"), nil, nil)
-					runner.ExecuteReturnsOnCall(3, bytes.NewBufferString("custom-server-id\r\n"), bytes.NewBufferString("TestStatus: pending creation"), nil)
+					runner.ExecuteWithEnvVarsReturnsOnCall(0, bytes.NewBufferString("image-id\r\n"), nil, nil)
+					runner.ExecuteWithEnvVarsReturnsOnCall(2, bytes.NewBufferString("custom-image-id\r\n"), nil, nil)
+					runner.ExecuteWithEnvVarsReturnsOnCall(3, bytes.NewBufferString("custom-server-id\r\n"), bytes.NewBufferString("TestStatus: pending creation"), nil)
 
 					status, _, err := command.CreateVM()
 					Expect(err).ToNot(HaveOccurred())
 					Expect(status).To(Equal(vmmanagers.Success))
 
-					Expect(runner.ExecuteArgsForCall(1)).To(matchers.OrderedConsistOf(
+					actualEnv, actualArgs := runner.ExecuteWithEnvVarsArgsForCall(1)
+					Expect(actualArgs).To(matchers.OrderedConsistOf(
 						"--os-username", gstruct.Ignore(),
-						"--os-password", gstruct.Ignore(),
 						"--os-auth-url", "https://example.com:5000/v2.0",
 						"--os-project-name", "marker",
 						"--insecure",
@@ -303,14 +302,15 @@ opsman-configuration:
 						"--os-identity-api-version", "3",
 						"image", "delete", "awesome-vm-image",
 					))
+					Expect(actualEnv).To(ContainElement("OS_PASSWORD=password"))
 				})
 
 				It("displays an error the delete fails", func() {
 					command, runner := createCommand(configStrTemplate)
 
-					runner.ExecuteReturnsOnCall(0, bytes.NewBufferString("DOWN\r\n"), nil, nil)
-					runner.ExecuteReturnsOnCall(1, bytes.NewBufferString("image-id\r\n"), nil, nil)
-					runner.ExecuteReturnsOnCall(2, nil, nil, errors.New("error occurred"))
+					runner.ExecuteWithEnvVarsReturnsOnCall(0, bytes.NewBufferString("DOWN\r\n"), nil, nil)
+					runner.ExecuteWithEnvVarsReturnsOnCall(1, bytes.NewBufferString("image-id\r\n"), nil, nil)
+					runner.ExecuteWithEnvVarsReturnsOnCall(2, nil, nil, errors.New("error occurred"))
 
 					status, _, err := command.CreateVM()
 					Expect(err).To(HaveOccurred())
@@ -370,13 +370,13 @@ opsman-configuration:
 
 			command, runner := createCommand(configStr)
 
-			runner.ExecuteReturnsOnCall(0, bytes.NewBufferString("custom-image-id\r\n"), nil, nil)
-			runner.ExecuteReturnsOnCall(1, bytes.NewBufferString("custom-server-id\r\n"), bytes.NewBufferString("TestStatus: pending creation"), nil)
+			runner.ExecuteWithEnvVarsReturnsOnCall(0, bytes.NewBufferString("custom-image-id\r\n"), nil, nil)
+			runner.ExecuteWithEnvVarsReturnsOnCall(1, bytes.NewBufferString("custom-server-id\r\n"), bytes.NewBufferString("TestStatus: pending creation"), nil)
 
 			_, _, err := command.CreateVM()
 			Expect(err).ToNot(HaveOccurred())
 
-			args := runner.ExecuteArgsForCall(3)
+			_, args := runner.ExecuteWithEnvVarsArgsForCall(3)
 			Expect(args).To(ContainElement("ops-manager-vm"))
 			Expect(args).To(ContainElement("m1.xlarge"))
 			Expect(args).To(ContainElement("3"))
@@ -399,15 +399,14 @@ opsman-configuration:
 					command, runner := createCommand(configStrTemplate)
 					command.State.ID = "some-random-id"
 
-					runner.ExecuteReturnsOnCall(0, bytes.NewBufferString(`{"image":"testing-opsman-image (7bf1ac30-290f-42ae-bc5e-b240ef051fbf)"}`), nil, nil)
+					runner.ExecuteWithEnvVarsReturnsOnCall(0, bytes.NewBufferString(`{"image":"testing-opsman-image (7bf1ac30-290f-42ae-bc5e-b240ef051fbf)"}`), nil, nil)
 
 					err := command.DeleteVM()
 					Expect(err).ToNot(HaveOccurred())
 
-					Expect(runner.ExecuteArgsForCall(0)).To(matchers.OrderedConsistOf(
+					env0, args0 := runner.ExecuteWithEnvVarsArgsForCall(0)
+					Expect(args0).To(matchers.OrderedConsistOf(
 						"--os-username",
-						gstruct.Ignore(),
-						"--os-password",
 						gstruct.Ignore(),
 						"--os-auth-url",
 						"https://example.com:5000/v2.0",
@@ -421,11 +420,11 @@ opsman-configuration:
 						"--format",
 						"value",
 					))
+					Expect(env0).To(ContainElement("OS_PASSWORD=password"))
 
-					Expect(runner.ExecuteArgsForCall(1)).To(matchers.OrderedConsistOf(
+					env1, args1 := runner.ExecuteWithEnvVarsArgsForCall(1)
+					Expect(args1).To(matchers.OrderedConsistOf(
 						"--os-username",
-						gstruct.Ignore(),
-						"--os-password",
 						gstruct.Ignore(),
 						"--os-auth-url",
 						"https://example.com:5000/v2.0",
@@ -436,11 +435,11 @@ opsman-configuration:
 						"some-random-id",
 						"--wait",
 					))
+					Expect(env1).To(ContainElement("OS_PASSWORD=password"))
 
-					Expect(runner.ExecuteArgsForCall(2)).To(matchers.OrderedConsistOf(
+					env2, args2 := runner.ExecuteWithEnvVarsArgsForCall(2)
+					Expect(args2).To(matchers.OrderedConsistOf(
 						"--os-username",
-						gstruct.Ignore(),
-						"--os-password",
 						gstruct.Ignore(),
 						"--os-auth-url",
 						"https://example.com:5000/v2.0",
@@ -450,6 +449,7 @@ opsman-configuration:
 						"delete",
 						"7bf1ac30-290f-42ae-bc5e-b240ef051fbf",
 					))
+					Expect(env2).To(ContainElement("OS_PASSWORD=password"))
 				})
 
 				Describe("failure cases", func() {
@@ -457,7 +457,7 @@ opsman-configuration:
 						It("prints errors from openstack", func() {
 							command, runner := createCommand(configStrTemplate)
 
-							runner.ExecuteReturns(nil, nil, errors.New("some error occurred"))
+							runner.ExecuteWithEnvVarsReturns(nil, nil, errors.New("some error occurred"))
 							err := command.DeleteVM()
 							Expect(err).To(HaveOccurred())
 							Expect(err.Error()).To(ContainSubstring("openstack error "))
@@ -468,7 +468,7 @@ opsman-configuration:
 						It("returns an error", func() {
 							command, runner := createCommand(configStrTemplate)
 							command.State.ID = "invalid-id"
-							runner.ExecuteReturns(nil, nil, errors.New("vm does not exist"))
+							runner.ExecuteWithEnvVarsReturns(nil, nil, errors.New("vm does not exist"))
 
 							command.State = vmmanagers.StateInfo{
 								IAAS: "openstack",
@@ -507,7 +507,7 @@ opsman-configuration:
 			It("prints error", func() {
 				command, runner := createCommand(configStrTemplate)
 
-				runner.ExecuteReturns(nil, nil, errors.New("some error occurred"))
+				runner.ExecuteWithEnvVarsReturns(nil, nil, errors.New("some error occurred"))
 
 				command.State = state
 				err := command.DeleteVM()


### PR DESCRIPTION
## Summary
- `getAuthArguments()` in `vmlifecycle/vmmanagers/openstack.go` placed `--os-password <cleartext>` into the `openstack` CLI's argv on every subprocess invocation. `runner.Redact()` only suppresses the value from the log line written to stderr — the real value still lands in the child process's argv, which is readable by any local user via `ps -ef` or `/proc/<pid>/cmdline` while a vmlifecycle command is in flight (image uploads/`server create --wait` can run for minutes).
- The OpenStack CLI supports `OS_PASSWORD` as an environment variable specifically to avoid this. This PR passes it that way via `runner.ExecuteWithEnvVars`, matching the pattern already used by the `aws`/`azure`/`vsphere` vmmanagers in this same package (`addEnvVars()` + `ExecuteWithEnvVars`).
- `--os-username` remains a CLI arg (unchanged) since only the password was flagged as sensitive.

## Test plan
- [x] Updated `openstack_test.go`: removed `--os-password` from all expected argv assertions, and added assertions that `OS_PASSWORD=<password>` is present in the env passed to `ExecuteWithEnvVars` at every call site (`CreateVM`, `DeleteVM`, image list/create/delete, server create/delete/show, attach IP).
- [x] Regenerated `fakes/openstackRunner.go` (`openstackRunner` interface changed from `Execute` to `ExecuteWithEnvVars`, matching the counterfeiter-generated shape of the existing `AwsRunner` fake).
- [x] `go build ./...` — clean
- [x] `go vet ./vmlifecycle/vmmanagers/...` — clean
- [x] `gofmt -l` on all changed files — clean
- [x] `go test ./vmlifecycle/vmmanagers/...` — 221 passed / 8 failed, identical to the pre-change baseline (the 8 failures are pre-existing, caused by a missing sibling `../../../docs-platform-automation` checkout, unrelated to this change)
- [x] Focused run on `--ginkgo.focus="Openstack"` — 30/31 passed, only the same pre-existing sibling-repo failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)